### PR TITLE
refactor(ui): unify header and card styles on main pages

### DIFF
--- a/Presentation/Package.appxmanifest
+++ b/Presentation/Package.appxmanifest
@@ -9,7 +9,7 @@
 	<Identity
 	  Name="dev-Rokapp.Rokmusicplayer"
 	  Publisher="CN=C9A55691-54ED-46EA-9D4F-F3CD41C04242"
-	  Version="1.0.87.0" />
+	  Version="1.1.1.0" />
 
 	<Properties>
 		<DisplayName>Rok musicplayer (dev)</DisplayName>

--- a/Presentation/Pages/AlbumPage.xaml
+++ b/Presentation/Pages/AlbumPage.xaml
@@ -17,22 +17,27 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Grid>
-            <Grid.Background>
-                <SolidColorBrush Color="{ThemeResource CardBackgroundFillColorDefault}"
-                                 Opacity="{StaticResource headerBackgroundOpacity}" />
-            </Grid.Background>
+        <Grid.Background>
+            <SolidColorBrush Color="{ThemeResource CardBackgroundFillColorDefault}"
+                             Opacity="{StaticResource headerBackgroundOpacity}" />
+        </Grid.Background>
+
+        <Image x:Name="backdrop"
+               Grid.RowSpan="2"
+               Source="{x:Bind ViewModel.Backdrop,Mode=OneWay}"
+               Opacity="0.20"
+               Style="{StaticResource headerBackdrop}"
+               Stretch="UniformToFill"
+               IsHitTestVisible="False" />
+
+        <!-- Header -->
+        <Grid Padding="2">
 
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="pictureColumn"
                                   Width="{ThemeResource headerPictureColumnWidth}" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-
-            <Image x:Name="backdrop"
-                   Source="{x:Bind ViewModel.Backdrop,Mode=OneWay}"
-                   Style="{StaticResource headerBackdrop}"
-                   Grid.ColumnSpan="2" />
 
             <Grid Style="{StaticResource headerPictureGrid}">
                 <common:PictureControl x:Name="artistPicture"
@@ -178,9 +183,13 @@
             </RelativePanel>
         </Grid>
 
+        <!-- Tracks grid -->
         <Grid x:Name="tracks"
+              CornerRadius="12,12,0,0"
+              Padding="24"
+              Background="{ThemeResource CardBackgroundFillColorDefault}"
               Grid.Row="1"
-              Margin="4,0,0,0"
+              Margin="4,0,4,4"
               ScrollViewer.VerticalScrollBarVisibility="Auto">
 
             <Grid.RowDefinitions>

--- a/Presentation/Pages/ArtistPage.xaml
+++ b/Presentation/Pages/ArtistPage.xaml
@@ -13,24 +13,32 @@
 
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition x:Name="headerRow" Height="{ThemeResource headerRowHeight}" />
+            <RowDefinition x:Name="headerRow" 
+                           Height="{ThemeResource headerRowHeight}" />
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Grid>
-            <Grid.Background>
-                <SolidColorBrush Color="{ThemeResource CardBackgroundFillColorDefault}" Opacity="{StaticResource headerBackgroundOpacity}" />
-            </Grid.Background>
+        <Grid.Background>
+            <SolidColorBrush Color="{ThemeResource CardBackgroundFillColorDefault}"
+                             Opacity="{StaticResource headerBackgroundOpacity}" />
+        </Grid.Background>
+
+        <Image x:Name="backdrop"
+               Grid.RowSpan="2"
+               Source="{x:Bind ViewModel.Backdrop,Mode=OneWay}"
+               Opacity="0.20"
+               Style="{StaticResource headerBackdrop}"
+               Stretch="UniformToFill"
+               IsHitTestVisible="False" />
+
+        <!-- Header -->
+        <Grid Padding="2">
 
             <Grid.ColumnDefinitions>
-                <ColumnDefinition x:Name="pictureColumn" Width="{ThemeResource headerPictureColumnWidth}"/>
+                <ColumnDefinition x:Name="pictureColumn" 
+                                  Width="{ThemeResource headerPictureColumnWidth}"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-
-            <Image x:Name="backdrop" 
-                   Source="{x:Bind ViewModel.Backdrop,Mode=OneWay}" 
-                   Style="{StaticResource headerBackdrop}"                    
-                   Grid.ColumnSpan="2"/>
 
             <Grid Style="{StaticResource headerPictureGrid}">
                 <common:PictureControl x:Name="artistPicture" 
@@ -160,8 +168,14 @@
 
         </Grid>
 
-        <Pivot Grid.Row="1">
-            <PivotItem x:Uid="artistViewTabAlbums">
+        <!-- Content -->
+        <Border Grid.Row="1"
+                CornerRadius="12,12,0,0"
+                Background="{ThemeResource CardBackgroundFillColorDefault}"
+                Padding="24"
+                Margin="4,0,4,4">
+            <Pivot>
+                <PivotItem x:Uid="artistViewTabAlbums">
                 <common:GridViewExtended x:Name="grid" 
                                          ItemsSource="{x:Bind ViewModel.Albums}" 
                                          ContainerContentChanging="grid_ContainerContentChanging"  
@@ -318,5 +332,6 @@
                 </Grid>
             </PivotItem>
         </Pivot>
+        </Border>
     </Grid>
 </Page>

--- a/Presentation/Pages/TrackPage.xaml
+++ b/Presentation/Pages/TrackPage.xaml
@@ -16,10 +16,9 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-
         <Grid.Background>
             <SolidColorBrush Color="{ThemeResource CardBackgroundFillColorDefault}"
-                             Opacity="0.7" />
+                             Opacity="{StaticResource headerBackgroundOpacity}" />
         </Grid.Background>
 
         <Image x:Name="backdrop"


### PR DESCRIPTION
Refactored Album, Artist, and Track pages for visual consistency:
- Updated header backgrounds and opacity using shared resources.
- Moved backdrop images to background with unified opacity and style.
- Added rounded corners and padding to main content containers.
- Wrapped Pivot and tracks grid in Border for card effect.
- Cleaned up unnecessary Grids and improved XAML structure.
- Bumped app version to 1.1.1.0 in manifest. These changes modernize the UI and improve maintainability.