### PR TITLE
refactor(ui): harmonize header backdrops and improve navigation

### DIFF
--- a/Presentation/App.xaml
+++ b/Presentation/App.xaml
@@ -14,6 +14,7 @@
             <x:String x:Key="ArtistFallbackPictureUri">ms-appx:///Assets/artistFallback.png</x:String>
             
             <x:Double x:Key="headerBackgroundOpacity">0.9</x:Double>
+            <x:Double x:Key="headerBackdropOpacity">0.1</x:Double>
             <x:Double x:Key="largeHeaderHeight">280</x:Double>
             <x:Double x:Key="normalHeaderHeight">180</x:Double>
             <x:Double x:Key="smallHeaderHeight">100</x:Double>

--- a/Presentation/Pages/AlbumPage.xaml
+++ b/Presentation/Pages/AlbumPage.xaml
@@ -25,7 +25,7 @@
         <Image x:Name="backdrop"
                Grid.RowSpan="2"
                Source="{x:Bind ViewModel.Backdrop,Mode=OneWay}"
-               Opacity="0.20"
+               Opacity="{StaticResource headerBackdropOpacity}"
                Style="{StaticResource headerBackdrop}"
                Stretch="UniformToFill"
                IsHitTestVisible="False" />
@@ -185,8 +185,7 @@
 
         <!-- Tracks grid -->
         <Grid x:Name="tracks"
-              CornerRadius="12,12,0,0"
-              Padding="24"
+              CornerRadius="12,12,0,0"              
               Background="{ThemeResource CardBackgroundFillColorDefault}"
               Grid.Row="1"
               Margin="4,0,4,4"

--- a/Presentation/Pages/ArtistPage.xaml
+++ b/Presentation/Pages/ArtistPage.xaml
@@ -26,7 +26,7 @@
         <Image x:Name="backdrop"
                Grid.RowSpan="2"
                Source="{x:Bind ViewModel.Backdrop,Mode=OneWay}"
-               Opacity="0.20"
+               Opacity="{StaticResource headerBackdropOpacity}"
                Style="{StaticResource headerBackdrop}"
                Stretch="UniformToFill"
                IsHitTestVisible="False" />
@@ -171,8 +171,7 @@
         <!-- Content -->
         <Border Grid.Row="1"
                 CornerRadius="12,12,0,0"
-                Background="{ThemeResource CardBackgroundFillColorDefault}"
-                Padding="24"
+                Background="{ThemeResource CardBackgroundFillColorDefault}"                
                 Margin="4,0,4,4">
             <Pivot>
                 <PivotItem x:Uid="artistViewTabAlbums">

--- a/Presentation/Pages/ListeningPage.xaml
+++ b/Presentation/Pages/ListeningPage.xaml
@@ -20,6 +20,19 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
+        <Grid.Background>
+            <SolidColorBrush Color="{ThemeResource CardBackgroundFillColorDefault}"
+                             Opacity="{StaticResource headerBackgroundOpacity}" />
+        </Grid.Background>
+
+        <Image x:Name="backdrop"
+               Grid.RowSpan="4"
+               Source="{x:Bind ViewModel.Artist.Backdrop,Mode=OneWay}"
+               Opacity="0.20"
+               Style="{StaticResource headerBackdrop}"
+               Stretch="UniformToFill"
+               IsHitTestVisible="False" />
+
         <!-- Title -->
         <StackPanel Orientation="Horizontal"
                     Margin="4,6,0,6">
@@ -56,26 +69,13 @@
               X2="100"></Line>
 
         <!-- Header -->
-        <Grid Grid.Row="1">
-
-            <Grid.Background>
-                <SolidColorBrush Color="{ThemeResource CardBackgroundFillColorDefault}"
-                                 Opacity="{StaticResource headerBackgroundOpacity}" />
-            </Grid.Background>
+        <Grid Grid.Row="1" Padding="2">
 
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="100"
                                   x:Name="pictureColumn"></ColumnDefinition>
                 <ColumnDefinition Width="*"></ColumnDefinition>
             </Grid.ColumnDefinitions>
-
-            <Image x:Name="backdrop"
-                   Source="{x:Bind ViewModel.Artist.Backdrop, Mode=OneWay}"
-                   Stretch="UniformToFill"
-                   VerticalAlignment="Center"
-                   HorizontalAlignment="Center"
-                   Opacity="0.1"
-                   Grid.ColumnSpan="2" />
 
             <Grid Margin="6"
                   Padding="0"
@@ -100,15 +100,23 @@
 
             <RelativePanel Grid.Column="1"
                            Margin="6,0,0,0">
-                <Button x:Name="headerTitle"
-                        Content="{x:Bind ViewModel.Artist.Artist.Name, Mode=OneWay}"
-                        Style="{StaticResource ButtonHighContrastStyle}"
-                        FontSize="20"
-                        Command="{x:Bind ViewModel.Artist.ArtistOpenCommand}" />
+                
+                <HyperlinkButton x:Name="trackTitle"
+                                 Content="{x:Bind ViewModel.CurrentTrack.Title}"
+                                 Command="{x:Bind ViewModel.CurrentTrack.TrackOpenCommand}"
+                                 FontSize="24" Padding="0" Margin="0"
+                                 Style="{StaticResource headerGenreHyperlink}" />
+
+                <HyperlinkButton x:Name="artistName"
+                                 RelativePanel.Below="trackTitle"
+                                 Content="{x:Bind ViewModel.CurrentTrack.ArtistName}"
+                                 Command="{x:Bind ViewModel.CurrentTrack.ArtistOpenCommand}"
+                                 FontSize="16"
+                                 Style="{StaticResource headerGenreHyperlink}" />
 
                 <Button x:Name="buttonCountry"
-                        RelativePanel.RightOf="headerTitle"
-                        RelativePanel.AlignVerticalCenterWith="headerTitle"
+                        RelativePanel.RightOf="artistName"
+                        RelativePanel.AlignVerticalCenterWith="artistName"
                         Margin="4,0,0,0"
                         Style="{StaticResource ButtonTextBlockStyle}"
                         Visibility="{x:Bind ViewModel.Artist.Artist.CountryCode, Converter={StaticResource StringToVisibilityConverter}}"
@@ -119,51 +127,12 @@
                            Height="10"></Image>
                 </Button>
 
-                <Button x:Name="headerGenre"
-                        RelativePanel.Below="headerTitle"
-                        Content="{x:Bind ViewModel.Artist.Artist.GenreName, Mode=OneWay}"
-                        Style="{StaticResource ButtonHighContrastStyle}"
-                        Command="{Binding Artist.GenreOpenCommand}"
-                        Margin="0,0,10,0" />
-
-                <HyperlinkButton x:Uid="artistOfficialSite"
-                                 x:Name="officialSite"
-                                 RelativePanel.RightOf="headerGenre"
-                                 RelativePanel.Below="headerTitle"
-                                 Visibility="{x:Bind ViewModel.Artist.Artist.OfficialSiteUrl, Converter={StaticResource StringToVisibilityConverter}}"
-                                 NavigateUri="{x:Bind ViewModel.Artist.Artist.OfficialSiteUrl, Converter={StaticResource StringToUriConverter}}"
-                                 Style="{StaticResource HyperLinkHighContrastStyle}"
-                                 Margin="0,0,10,0" />
-
-                <HyperlinkButton x:Uid="artistWikipedia"
-                                 x:Name="wikipedia"
-                                 RelativePanel.RightOf="officialSite"
-                                 RelativePanel.Below="headerTitle"
-                                 Visibility="{x:Bind ViewModel.Artist.Artist.WikipediaUrl, Converter={StaticResource StringToVisibilityConverter}}"
-                                 NavigateUri="{x:Bind ViewModel.Artist.Artist.WikipediaUrl, Converter={StaticResource StringToUriConverter}}"
-                                 Style="{StaticResource HyperLinkHighContrastStyle}" />
-
-                <ScrollViewer RelativePanel.Below="headerGenre"
-                              Margin="0,5,0,0"
-                              RelativePanel.AlignLeftWithPanel="True"
-                              RelativePanel.AlignRightWithPanel="True"
-                              VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Auto"
-                              x:Name="panelBiography"
-                              Visibility="Collapsed"
-                              Height="120">
-                    <TextBlock Padding="0"
-                               ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                               ScrollViewer.VerticalScrollBarVisibility="Visible"
-                               Text="{x:Bind ViewModel.Artist.Artist.Biography, Mode=OneWay}"
-                               FontSize="11"
-                               TextWrapping="WrapWholeWords"
-                               Style="{StaticResource BodyTextBlockStyle}"
-                               VerticalAlignment="Top"
-                               HorizontalAlignment="Stretch"
-                               Width="{Binding ElementName=panelBiography, Path=ViewportWidth}"
-                               TextTrimming="Clip" />
-                </ScrollViewer>
+                <HyperlinkButton x:Name="albumName"
+                                 RelativePanel.Below="artistName"
+                                 Content="{x:Bind ViewModel.CurrentTrack.AlbumName}"
+                                 Command="{x:Bind ViewModel.CurrentTrack.AlbumOpenCommand}"
+                                 FontSize="16"
+                                 Style="{StaticResource headerGenreHyperlink}" />
             </RelativePanel>
         </Grid>
 
@@ -174,15 +143,31 @@
                         Style="{StaticResource headerCommandBar}">
                 <AppBarButton x:Uid="shuffleButton"
                               Style="{StaticResource AppBarButtonCompactStyle}"
-                              Icon="Shuffle"
-                              Label="Mélanger"
+                              Icon="Shuffle"                              
                               Command="{x:Bind ViewModel.ShufflePlaylistCommand}" />
+
+                <AppBarSeparator />
+
+                <AppBarButton x:Uid="artistViewWebSite"
+                              Style="{StaticResource headerGenericButton}"
+                              Icon="World"
+                              Command="{x:Bind ViewModel.Artist.OpenOfficielSiteCommand}"
+                              Visibility="{x:Bind ViewModel.Artist.Artist.OfficialSiteUrl, Converter={StaticResource StringToVisibilityConverter}}" />
+
+                <AppBarButton x:Uid="artistViewLastFm"
+                              Style="{StaticResource headerGenericButton}"
+                              Icon="MusicInfo"
+                              Command="{x:Bind ViewModel.Artist.OpenLastFmPageCommand, Mode=OneWay}"
+                              Visibility="{x:Bind ViewModel.Artist.LastFmPageAvailable, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
             </CommandBar>
         </RelativePanel>
 
         <!-- Tracks -->
-
         <Grid x:Name="tracks"
+              CornerRadius="12,12,0,0"
+              Padding="24"
+              Background="{ThemeResource CardBackgroundFillColorDefault}"              
+              Margin="4,0,4,4"
               Grid.Row="3">
 
             <Grid.RowDefinitions>

--- a/Presentation/Pages/ListeningPage.xaml.cs
+++ b/Presentation/Pages/ListeningPage.xaml.cs
@@ -1,5 +1,4 @@
 using Microsoft.UI.Xaml.Controls;
-using Rok.Commons;
 using Rok.Logic.ViewModels.Listening;
 
 
@@ -30,7 +29,6 @@ public sealed partial class ListeningPage : Page, IDisposable
             tb.Text = (args.ItemIndex + 1).ToString() + ".";
         }
     }
-
 
     public void Dispose()
     {

--- a/Presentation/Pages/TrackPage.xaml
+++ b/Presentation/Pages/TrackPage.xaml
@@ -24,11 +24,12 @@
         <Image x:Name="backdrop"
                Grid.RowSpan="2"
                Source="{x:Bind ViewModel.Backdrop,Mode=OneWay}"
-               Opacity="0.20"
+               Opacity="{StaticResource headerBackdropOpacity}"
                Style="{StaticResource headerBackdrop}"
                Stretch="UniformToFill"
                IsHitTestVisible="False" />
 
+        <!-- Header -->
         <StackPanel Grid.Row="0" Orientation="Vertical" Padding="6" Spacing="4">
             <TextBlock Text="{x:Bind ViewModel.Track.Title}"
                        FontSize="32"
@@ -52,6 +53,7 @@
             </StackPanel>
         </StackPanel>
 
+        <!-- Content -->
         <Border Grid.Row="2"
                 Background="{ThemeResource CardBackgroundFillColorDefault}"
                 Padding="24"


### PR DESCRIPTION
Refactored UI headers on Album, Artist, Listening, and Track pages for visual consistency. Introduced a reusable headerBackdropOpacity resource for centralized backdrop opacity. Replaced hardcoded opacity values with the new resource. ListeningPage header reworked: main info as HyperlinkButtons for direct navigation. Added quick access buttons for artist website and Last.fm in ListeningPage. Removed redundant biography and external links from ListeningPage header. Improved XAML structure: better alignment, padding, and style consistency. Harmonized TrackPage content section and backdrop opacity. Removed unused Rok.Commons import from ListeningPage.xaml.cs. Overall, these changes modernize and simplify the user experience.