### PR TITLE
Change hyperlink pointer over color to accent color

### DIFF
--- a/Presentation/Styles/NovaStyles.xaml
+++ b/Presentation/Styles/NovaStyles.xaml
@@ -216,7 +216,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
                                                                        Storyboard.TargetName="TextElement">
                                             <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="{ThemeResource HyperlinkButtonForegroundPointerOver}" />
+                                                                    Value="{ThemeResource SystemAccentColorLight2}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>


### PR DESCRIPTION
The Foreground resource for the "TextElement" in the "PointerOver" visual state has been updated. Instead of using the HyperlinkButtonForegroundPointerOver theme resource, it now uses SystemAccentColorLight2. This change ensures better consistency with the application's accent color scheme and improves visual feedback when hovering over hyperlinks. No other visual states or resources were modified in this update.