### PR TITLE
Refactor: invoke CurrentTrackChanged on UI thread safely

### DIFF
--- a/Presentation/Logic/ViewModels/Listening/Services/ListeningPlaylistManager.cs
+++ b/Presentation/Logic/ViewModels/Listening/Services/ListeningPlaylistManager.cs
@@ -60,7 +60,11 @@ public partial class ListeningPlaylistManager : ObservableObject
         });
 
         await LoadArtistIfNeededAsync(track);
-        CurrentTrackChanged?.Invoke(this, EventArgs.Empty);
+
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            CurrentTrackChanged?.Invoke(this, EventArgs.Empty);
+        });
     }
 
     private async Task LoadArtistIfNeededAsync(TrackDto track)


### PR DESCRIPTION
The CurrentTrackChanged event is now triggered via _dispatcherQueue.TryEnqueue to ensure it runs on the UI thread. This change prevents potential threading issues when updating UI components in response to track changes. It improves application stability and maintains thread safety for UI-bound event handlers.