### PR TITLE
feat(fullscreen): improve track change & backdrop handling

### DIFF
--- a/Presentation/MainWindow.xaml.cs
+++ b/Presentation/MainWindow.xaml.cs
@@ -66,7 +66,7 @@ namespace Rok
             SplashScreen.Start();
 
             Messenger.Subscribe<FullScreenMessage>((message) => FullScreenHandle(message));
-            Messenger.Subscribe<MediaChangedMessage>((message) => MediaChanged());
+            Messenger.Subscribe<MediaChangedMessage>((message) => MediaChanged(message));
             Messenger.Subscribe<LibraryRefreshMessage>((message) => LibraryRefreshHandle(message));
             Messenger.Subscribe<SearchNoResultMessage>(async (message) => await SearchNoResultHandleAsync());
             Messenger.Subscribe<CompactModeMessage>((message) => ToggleCompactMode());
@@ -191,11 +191,11 @@ namespace Rok
         }
 
 
-        private void MediaChanged()
+        private void MediaChanged(MediaChangedMessage message)
         {
             _dispatcherQueue.TryEnqueue(async () =>
             {
-                await fullscreen.TrackChangedAsync();
+                await fullscreen.TrackChangedAsync(message.NewTrack, message.PreviousTrack);
             });
         }
 


### PR DESCRIPTION
Refactor FullScreenControl to better handle track changes and backdrop loading. TrackChangedAsync now takes new and previous tracks as parameters, enabling precise detection of artist changes. Introduce CancellationTokenSource to cancel ongoing async operations when tracks change rapidly, preventing race conditions and UI glitches. Backdrop list access is now thread-safe via locking. Backdrop loading and display methods accept a CancellationToken and handle cancellation gracefully. In MainWindow.xaml.cs, MediaChanged now passes track info to TrackChangedAsync, ensuring UI stays in sync with the player state.
These changes improve reliability and responsiveness of the fullscreen view.