### PR TITLE
feat(ui): improve score animation & clarify data bindings

### DIFF
--- a/Presentation/Commons/RatingControlDarkControl.xaml
+++ b/Presentation/Commons/RatingControlDarkControl.xaml
@@ -15,6 +15,7 @@
     </UserControl.Resources>
 
     <RatingControl x:Name="InnerRating"
+                       Opacity="{x:Bind Opacity, Mode=OneWay}"
                        MaxRating="{x:Bind MaxRating, Mode=OneWay}"
                        IsClearEnabled="{x:Bind IsClearEnabled, Mode=OneWay}"
                        InitialSetValue="{x:Bind InitialValue, Mode=OneWay}"

--- a/Presentation/Pages/ListeningPage.xaml
+++ b/Presentation/Pages/ListeningPage.xaml
@@ -102,14 +102,14 @@
                            Margin="6,0,0,0">
 
                 <HyperlinkButton x:Name="currentTrackTitle"
-                                 Content="{x:Bind ViewModel.CurrentTrack.Title}"
+                                 Content="{x:Bind ViewModel.CurrentTrack.Title, Mode=OneWay}"
                                  Command="{x:Bind ViewModel.CurrentTrack.TrackOpenCommand}"
                                  FontSize="24" Padding="0" Margin="0"
                                  Style="{StaticResource headerGenreHyperlink}" />
 
                 <HyperlinkButton x:Name="artistName"
                                  RelativePanel.Below="currentTrackTitle"
-                                 Content="{x:Bind ViewModel.CurrentTrack.ArtistName}"
+                                 Content="{x:Bind ViewModel.CurrentTrack.ArtistName, Mode=OneWay}"
                                  Command="{x:Bind ViewModel.CurrentTrack.ArtistOpenCommand}"
                                  FontSize="16"
                                  Style="{StaticResource headerGenreHyperlink}" />
@@ -119,17 +119,17 @@
                         RelativePanel.AlignVerticalCenterWith="artistName"
                         Margin="4,0,0,0"
                         Style="{StaticResource ButtonTextBlockStyle}"
-                        Visibility="{x:Bind ViewModel.Artist.Artist.CountryCode, Converter={StaticResource StringToVisibilityConverter}}"
+                        Visibility="{x:Bind ViewModel.Artist.Artist.CountryCode, Mode=OneWay, Converter={StaticResource StringToVisibilityConverter}}"
                         BorderBrush="Transparent"
                         Background="Transparent"
-                        ToolTipService.ToolTip="{x:Bind ViewModel.Artist.Artist.CountryName}">
-                    <Image Source="{x:Bind ViewModel.Artist.Artist.CountryCode, Converter={StaticResource CountryCodeToImageSourceConverter}}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.Artist.Artist.CountryName, Mode=OneWay}">
+                    <Image Source="{x:Bind ViewModel.Artist.Artist.CountryCode, Mode=OneWay, Converter={StaticResource CountryCodeToImageSourceConverter}}"
                            Height="10"></Image>
                 </Button>
 
                 <HyperlinkButton x:Name="albumName"
                                  RelativePanel.Below="artistName"
-                                 Content="{x:Bind ViewModel.CurrentTrack.AlbumName}"
+                                 Content="{x:Bind ViewModel.CurrentTrack.AlbumName, Mode=OneWay}"
                                  Command="{x:Bind ViewModel.CurrentTrack.AlbumOpenCommand}"
                                  FontSize="16"
                                  Style="{StaticResource headerGenreHyperlink}" />

--- a/Presentation/Pages/PlayerView.xaml
+++ b/Presentation/Pages/PlayerView.xaml
@@ -43,7 +43,16 @@
                 <VisualStateGroup x:Name="visualChangeGroup">
                     <VisualState x:Name="changeTrackTitleAnimation">
                         <Storyboard>
-                            <DoubleAnimation Storyboard.TargetName="trackTitleLine"
+                            <DoubleAnimation Storyboard.TargetName="trackTitle"
+                                             From="0"
+                                             To="1"
+                                             Storyboard.TargetProperty="Opacity"
+                                             Duration="0:0:2" />
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="changeTrackScoreAnimation">
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetName="trackScore"
                                              From="0"
                                              To="1"
                                              Storyboard.TargetProperty="Opacity"
@@ -119,6 +128,9 @@
                 <StackPanel x:Name="trackTitleLine" Grid.Column="1" Grid.Row="0" Orientation="Horizontal" Margin="6,0,0,0">
                     <HyperlinkButton Grid.Column="0"
                                      x:Name="trackTitle"
+                                     HorizontalAlignment="Left"
+                                     HorizontalContentAlignment="Left"
+                                     MinWidth="100"
                                      MaxWidth="200"
                                      Style="{StaticResource MiniLinkStyle}"
                                      Command="{x:Bind ViewModel.CurrentTrack.TrackOpenCommand, Mode=OneWay}"
@@ -126,7 +138,7 @@
                                      ContentTemplate="{StaticResource EllipsisTemplate}"
                                      ToolTipService.ToolTip="{x:Bind ViewModel.CurrentTrack.Title, Mode=OneWay}"/>
 
-                    <commons:RatingControlDarkControl x:Name="score"
+                    <commons:RatingControlDarkControl x:Name="trackScore"
                                    Margin="30,0,0,0" 
                                    HorizontalAlignment="Right"                                                       
                                    InitialValue="{x:Bind ViewModel.CurrentTrack.Score, Mode=OneWay}" 

--- a/Presentation/Pages/PlayerView.xaml.cs
+++ b/Presentation/Pages/PlayerView.xaml.cs
@@ -93,5 +93,8 @@ public sealed partial class PlayerView : UserControl
 
         if (previousTrack.AlbumId != newTrack.AlbumId)
             this.changeTrackAlbumAnimation?.Storyboard.Begin();
+
+        if (previousTrack.Score != newTrack.Score)
+            this.changeTrackScoreAnimation?.Storyboard.Begin();
     }
 }

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -817,7 +817,7 @@
     <value>{sans titre}</value>
   </data>
   <data name="ListeningViewTitle.Text" xml:space="preserve">
-    <value>En cours de</value>
+    <value>En cours d'écoute</value>
   </data>
   <data name="ListeningViewTitleCount.Text" xml:space="preserve">
     <value>chansons, </value>


### PR DESCRIPTION
Clarified OneWay bindings in ListeningPage for better UI performance. Added score change animation (opacity) in PlayerView for RatingControl. Renamed RatingControl from 'score' to 'trackScore' for clarity. Triggered score animation in code-behind when track score changes. Improved French translation for "ListeningViewTitle.Text". Enhanced maintainability and user experience through these UI updates.