### PR TITLE
feat(tracks): add grouping by score for tracks view

### DIFF
--- a/Presentation/Logic/ViewModels/GroupingConstants.cs
+++ b/Presentation/Logic/ViewModels/GroupingConstants.cs
@@ -18,4 +18,6 @@ public static class GroupingConstants
 
     public const string Title = "TITLE";
     public const string Genre = "GENRENAME";
+
+    public const string Score = "SCORE";
 }

--- a/Presentation/Logic/ViewModels/Tracks/TracksGroupCategory.cs
+++ b/Presentation/Logic/ViewModels/Tracks/TracksGroupCategory.cs
@@ -14,6 +14,7 @@ public class TracksGroupCategory(ResourceLoader resourceLoader) : GroupCategoryS
             GroupingConstants.Artist => ResourceLoader.GetString("tracksViewGroupByArtist"),
             GroupingConstants.Album => ResourceLoader.GetString("tracksViewGroupByAlbum"),
             GroupingConstants.Genre => ResourceLoader.GetString("tracksViewGroupByGenre"),
+            GroupingConstants.Score => ResourceLoader.GetString("tracksViewGroupByScore"),
             _ => groupBy,
         };
     }
@@ -26,6 +27,7 @@ public class TracksGroupCategory(ResourceLoader resourceLoader) : GroupCategoryS
         RegisterStrategy(GroupingConstants.Artist, GroupByArtist);
         RegisterStrategy(GroupingConstants.Album, GroupByAlbum);
         RegisterStrategy(GroupingConstants.Genre, GroupByGenre);
+        RegisterStrategy(GroupingConstants.Score, GroupByScore);
         RegisterStrategy(GroupingConstants.CreatDate, tracks => GroupByCreatDate(tracks, t => t.Track.CreatDate));
         RegisterStrategy(GroupingConstants.LastListen, tracks => SortByLastListen(tracks, t => t.Track.LastListen));
         RegisterStrategy(GroupingConstants.ListenCount, tracks => SortByListenCount(tracks, t => t.Track.ListenCount));
@@ -47,7 +49,6 @@ public class TracksGroupCategory(ResourceLoader resourceLoader) : GroupCategoryS
 
         return BuildGroupedCollection(selectedItems, orderByDescending: false);
     }
-
 
     private IEnumerable<TracksGroupCategoryViewModel> GroupByArtist(List<TrackViewModel> tracks)
     {
@@ -80,5 +81,22 @@ public class TracksGroupCategory(ResourceLoader resourceLoader) : GroupCategoryS
             });
 
         return BuildGroupedCollection(selectedItems, orderByDescending: false);
+    }
+
+    private IEnumerable<TracksGroupCategoryViewModel> GroupByScore(List<TrackViewModel> tracks)
+    {
+        IEnumerable<TracksGroupCategoryViewModel> selectedItems = tracks
+            .GroupBy(x => x.Track.Score.ToString())
+            .Select(x => new TracksGroupCategoryViewModel
+            {
+                Title = x.Key,
+                Items = x.OrderByDescending(c => c.Track.Score)
+                         .ThenBy(c => c.Track.ArtistName)
+                         .ThenBy(c => c.AlbumName)
+                         .ThenBy(c => c.TrackNumber)
+                         .ToList()
+            });
+
+        return BuildGroupedCollection(selectedItems, orderByDescending: true);
     }
 }

--- a/Presentation/Pages/TracksGroupByMenuBuilder.cs
+++ b/Presentation/Pages/TracksGroupByMenuBuilder.cs
@@ -18,6 +18,7 @@ internal class TracksGroupByMenuBuilder
         "GENRENAME",
         "LASTLISTEN",
         "LISTENCOUNT",
+        "SCORE"
     ];
 
 

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1059,4 +1059,10 @@
   <data name="albumViewPlaylist.Label" xml:space="preserve">
     <value>Playlists</value>
   </data>
+  <data name="groupByscore" xml:space="preserve">
+    <value>score</value>
+  </data>
+  <data name="tracksViewGroupByScore" xml:space="preserve">
+    <value>score</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1059,4 +1059,10 @@
   <data name="albumViewPlaylist.Label" xml:space="preserve">
     <value>Playlists</value>
   </data>
+  <data name="groupByscore" xml:space="preserve">
+    <value>score</value>
+  </data>
+  <data name="tracksViewGroupByScore" xml:space="preserve">
+    <value>score</value>
+  </data>
 </root>


### PR DESCRIPTION
Added a new "Score" grouping option for tracks.
Introduced GroupingConstants.Score constant.
Updated TracksGroupCategory to support grouping by score, including display label and grouping strategy.
Implemented GroupByScore method to group and sort tracks by score (descending), artist, album, and track number. Added "SCORE" to the group by menu options.
Updated resource files (en/fr) with translations for "score" to ensure correct UI display.
This enhances user ability to organize tracks by their rating.