### PR TITLE
refactor: improve menu cleanup & page disposal for memory safety

### DIFF
--- a/Presentation/Commons/MenuFlyoutExtensions.cs
+++ b/Presentation/Commons/MenuFlyoutExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml.Controls;
 using Rok.Application.Features.Playlists.PlaylistMenu;
+using System.Runtime.CompilerServices;
 
 namespace Rok.Commons;
 
@@ -17,7 +18,35 @@ public static class MenuFlyoutExtensions
             "TrackId",
             typeof(long),
             typeof(MenuFlyoutExtensions),
-            new PropertyMetadata(0));
+            new PropertyMetadata(0L));
+
+    // store per-menuitem click handler so we can detach before removal
+    private static readonly DependencyProperty MenuItemClickHandlerProperty =
+        DependencyProperty.RegisterAttached(
+            "MenuItemClickHandler",
+            typeof(RoutedEventHandler),
+            typeof(MenuFlyoutExtensions),
+            new PropertyMetadata(null));
+
+    // attached property to store playlist id on MenuFlyoutItem (avoid closures)
+    private static readonly DependencyProperty MenuItemPlaylistIdProperty =
+        DependencyProperty.RegisterAttached(
+            "MenuItemPlaylistId",
+            typeof(long),
+            typeof(MenuFlyoutExtensions),
+            new PropertyMetadata(0L));
+
+    // attached property to store weak reference to service on MenuFlyoutItem
+    private static readonly DependencyProperty MenuItemServiceWeakRefProperty =
+        DependencyProperty.RegisterAttached(
+            "MenuItemServiceWeakRef",
+            typeof(object),
+            typeof(MenuFlyoutExtensions),
+            new PropertyMetadata(null));
+
+    // map service -> list of menu weakrefs, use ConditionalWeakTable to avoid keeping services alive
+    private static readonly ConditionalWeakTable<IPlaylistMenuService, List<WeakReference<MenuFlyout>>> s_serviceMenus = new();
+    private static readonly object s_lock = new();
 
     public static void SetPlaylistMenuService(DependencyObject obj, IPlaylistMenuService value)
         => obj.SetValue(PlaylistMenuServiceProperty, value);
@@ -31,23 +60,139 @@ public static class MenuFlyoutExtensions
     public static long GetTrackId(DependencyObject obj)
         => (long)obj.GetValue(TrackIdProperty);
 
+    private static void SetMenuItemClickHandler(DependencyObject obj, RoutedEventHandler? handler)
+        => obj.SetValue(MenuItemClickHandlerProperty, handler);
+
+    private static RoutedEventHandler? GetMenuItemClickHandler(DependencyObject obj)
+        => (RoutedEventHandler?)obj.GetValue(MenuItemClickHandlerProperty);
+
+    private static void SetMenuItemPlaylistId(DependencyObject obj, long id)
+        => obj.SetValue(MenuItemPlaylistIdProperty, id);
+
+    private static long GetMenuItemPlaylistId(DependencyObject obj)
+        => (long)obj.GetValue(MenuItemPlaylistIdProperty);
+
+    private static void SetMenuItemServiceWeakRef(DependencyObject obj, object? wr)
+        => obj.SetValue(MenuItemServiceWeakRefProperty, wr);
+
+    private static object? GetMenuItemServiceWeakRef(DependencyObject obj)
+        => obj.GetValue(MenuItemServiceWeakRefProperty);
+
     private static async void OnPlaylistMenuServiceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is MenuFlyout menuFlyout && e.NewValue is IPlaylistMenuService service)
+        if (d is not MenuFlyout menuFlyout)
+            return;
+
+        if (e.OldValue is IPlaylistMenuService oldService)
         {
-            await UpdatePlaylistMenuItems(menuFlyout, service);
-            service.PlaylistsChanged += async (_, _) =>
+            RemoveMenuFlyoutForService(oldService, menuFlyout);
+            CleanupExistingSubmenuClickHandlers(menuFlyout);
+        }
+
+        if (e.NewValue is IPlaylistMenuService newService)
+        {
+            AddMenuFlyoutForService(newService, menuFlyout);
+            await UpdatePlaylistMenuItems(menuFlyout, newService).ConfigureAwait(false);
+        }
+    }
+
+    private static void AddMenuFlyoutForService(IPlaylistMenuService service, MenuFlyout menuFlyout)
+    {
+        lock (s_lock)
+        {
+            if (!s_serviceMenus.TryGetValue(service, out List<WeakReference<MenuFlyout>>? list))
             {
-                if (menuFlyout.DispatcherQueue.HasThreadAccess)
+                list = new List<WeakReference<MenuFlyout>>();
+                s_serviceMenus.Add(service, list);
+                // subscribe static handler once
+                service.PlaylistsChanged += Service_PlaylistsChanged;
+            }
+
+            // add weak ref if not present
+            if (!list.Any(wr => wr.TryGetTarget(out MenuFlyout? mf) && ReferenceEquals(mf, menuFlyout)))
+            {
+                list.Add(new WeakReference<MenuFlyout>(menuFlyout));
+            }
+        }
+    }
+
+    private static void RemoveMenuFlyoutForService(IPlaylistMenuService service, MenuFlyout menuFlyout)
+    {
+        lock (s_lock)
+        {
+            if (s_serviceMenus.TryGetValue(service, out List<WeakReference<MenuFlyout>>? list))
+            {
+                list.RemoveAll(wr => !wr.TryGetTarget(out MenuFlyout? mf) || ReferenceEquals(mf, menuFlyout));
+
+                if (list.Count == 0)
                 {
-                    await UpdatePlaylistMenuItems(menuFlyout, service);
+                    // remove key and unsubscribe
+                    s_serviceMenus.Remove(service);
+                    try
+                    {
+                        service.PlaylistsChanged -= Service_PlaylistsChanged;
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+            }
+        }
+    }
+
+    private static void Service_PlaylistsChanged(object? sender, EventArgs e)
+    {
+        if (sender is not IPlaylistMenuService service)
+            return;
+
+        List<WeakReference<MenuFlyout>>? list = null;
+        lock (s_lock)
+        {
+            if (!s_serviceMenus.TryGetValue(service, out list))
+                return;
+            // create snapshot
+            list = list.ToList();
+        }
+
+        foreach (WeakReference<MenuFlyout> wr in list)
+        {
+            if (wr.TryGetTarget(out MenuFlyout? mf))
+            {
+                if (mf.DispatcherQueue.HasThreadAccess)
+                {
+                    _ = UpdatePlaylistMenuItems(mf, service);
                 }
                 else
                 {
-                    menuFlyout.DispatcherQueue.TryEnqueue(async () =>
-                        await UpdatePlaylistMenuItems(menuFlyout, service));
+                    mf.DispatcherQueue.TryEnqueue(() => _ = UpdatePlaylistMenuItems(mf, service));
                 }
-            };
+            }
+        }
+    }
+
+    private static void CleanupExistingSubmenuClickHandlers(MenuFlyout menuFlyout)
+    {
+        MenuFlyoutSubItem? existingAddToItem = menuFlyout.Items.OfType<MenuFlyoutSubItem>()
+             .FirstOrDefault(item => item.Tag?.ToString() == "AddToPlaylistSubMenu");
+
+        if (existingAddToItem != null)
+        {
+            foreach (MenuFlyoutItem? mi in existingAddToItem.Items.OfType<MenuFlyoutItem>().ToList())
+            {
+                RoutedEventHandler? handler = GetMenuItemClickHandler(mi);
+                if (handler != null)
+                {
+                    try { mi.Click -= handler; } catch { }
+                    SetMenuItemClickHandler(mi, null);
+                }
+
+                try { SetMenuItemServiceWeakRef(mi, null); } catch { }
+                try { SetMenuItemPlaylistId(mi, 0); } catch { }
+            }
+
+            try { existingAddToItem.Items.Clear(); } catch { }
+            try { if (menuFlyout.Items.Contains(existingAddToItem)) menuFlyout.Items.Remove(existingAddToItem); } catch { }
         }
     }
 
@@ -55,11 +200,7 @@ public static class MenuFlyoutExtensions
     {
         ResourceLoader resourceLoader = ResourceLoader.GetForViewIndependentUse();
 
-        MenuFlyoutSubItem? existingAddToItem = menuFlyout.Items.OfType<MenuFlyoutSubItem>()
-             .FirstOrDefault(item => item.Tag?.ToString() == "AddToPlaylistSubMenu");
-
-        if (existingAddToItem != null)
-            menuFlyout.Items.Remove(existingAddToItem);
+        CleanupExistingSubmenuClickHandlers(menuFlyout);
 
         IEnumerable<PlaylistMenuItem> playlists = await service.GetPlaylistMenuItemsAsync();
 
@@ -69,9 +210,11 @@ public static class MenuFlyoutExtensions
         MenuFlyoutSubItem addToSubMenu = new()
         {
             Text = resourceLoader.GetString("MenuFlyout_AddTo_Text") ?? "Add to",
-            Icon = new FontIcon { Glyph = "\uE710" }, // Icon "Add"
+            Icon = new FontIcon { Glyph = "\uE710" },
             Tag = "AddToPlaylistSubMenu"
         };
+
+        long trackId = GetTrackId(menuFlyout);
 
         if (playlists.Any())
         {
@@ -84,11 +227,13 @@ public static class MenuFlyoutExtensions
                     Tag = "PlaylistItem"
                 };
 
-                menuItem.Click += async (sender, _) =>
-                {
-                    long trackId = GetTrackId(menuFlyout);
-                    await service.AddTrackToPlaylistAsync(playlist.Id, trackId);
-                };
+                SetMenuItemPlaylistId(menuItem, playlist.Id);
+                SetMenuItemServiceWeakRef(menuItem, new WeakReference<IPlaylistMenuService>(service));
+
+                // attach static handler
+                RoutedEventHandler handler = MenuItemStaticClickHandler;
+                menuItem.Click += handler;
+                SetMenuItemClickHandler(menuItem, handler);
 
                 addToSubMenu.Items.Add(menuItem);
             }
@@ -100,27 +245,72 @@ public static class MenuFlyoutExtensions
         MenuFlyoutItem newPlaylistItem = new()
         {
             Text = resourceLoader.GetString("MenuFlyout_NewPlaylist_Text") ?? "New playlist...",
-            Icon = new FontIcon { Glyph = "\uE710" }, // Icon "Add"
+            Icon = new FontIcon { Glyph = "\uE710" },
             Tag = "NewPlaylistItem"
         };
 
-        newPlaylistItem.Click += async (sender, _) =>
-        {
-            if (App.MainWindow?.Content?.XamlRoot != null)
-            {
-                string? playlistName = await ShowCreatePlaylistDialogAsync(App.MainWindow.Content.XamlRoot);
-                if (!string.IsNullOrWhiteSpace(playlistName))
-                {
-                    long trackId = GetTrackId(menuFlyout);
-                    await service.CreateNewPlaylistWithTrackAsync(playlistName, trackId);
-                }
-            }
-        };
+        SetMenuItemPlaylistId(newPlaylistItem, -1);
+        SetMenuItemServiceWeakRef(newPlaylistItem, new WeakReference<IPlaylistMenuService>(service));
+        newPlaylistItem.SetValue(MenuItemPlaylistIdProperty, trackId);
+
+        RoutedEventHandler newHandler = NewPlaylistStaticClickHandler;
+        newPlaylistItem.Click += newHandler;
+        SetMenuItemClickHandler(newPlaylistItem, newHandler);
 
         addToSubMenu.Items.Add(newPlaylistItem);
         menuFlyout.Items.Add(addToSubMenu);
     }
 
+    private static async void MenuItemStaticClickHandler(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuFlyoutItem mi)
+            return;
+
+        object? wr = GetMenuItemServiceWeakRef(mi);
+        long playlistId = GetMenuItemPlaylistId(mi);
+        long trackId = GetMenuItemPlaylistId(mi);
+
+        if (wr is WeakReference<IPlaylistMenuService> weak && weak.TryGetTarget(out IPlaylistMenuService? service))
+        {
+            try
+            {
+                if (playlistId > 0)
+                    await service.AddTrackToPlaylistAsync(playlistId, trackId);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
+    private static async void NewPlaylistStaticClickHandler(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuFlyoutItem mi)
+            return;
+
+        object? wr = GetMenuItemServiceWeakRef(mi);
+        long trackId = GetMenuItemPlaylistId(mi);
+
+        if (wr is WeakReference<IPlaylistMenuService> weak && weak.TryGetTarget(out IPlaylistMenuService? service))
+        {
+            try
+            {
+                if (App.MainWindow?.Content?.XamlRoot != null)
+                {
+                    string? playlistName = await ShowCreatePlaylistDialogAsync(App.MainWindow.Content.XamlRoot);
+                    if (!string.IsNullOrWhiteSpace(playlistName))
+                    {
+                        await service.CreateNewPlaylistWithTrackAsync(playlistName, trackId);
+                    }
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
 
     private static async Task<string?> ShowCreatePlaylistDialogAsync(XamlRoot xamlRoot)
     {

--- a/Presentation/Pages/AlbumsPage.xaml.cs
+++ b/Presentation/Pages/AlbumsPage.xaml.cs
@@ -5,21 +5,26 @@ using Microsoft.UI.Xaml.Navigation;
 using Rok.Commons;
 using Rok.Logic.ViewModels.Albums;
 using System.ComponentModel;
+using System.Threading;
 
 namespace Rok.Pages;
 
 public sealed partial class AlbumsPage : Page, IDisposable
 {
+    private readonly ILogger<AlbumsPage> _logger;
+
     public AlbumsViewModel ViewModel { get; set; }
 
     private readonly AlbumsFilterMenuBuilder _filterMenuBuilder = new();
     private readonly AlbumsGroupByMenuBuilder _groupByMenuBuilder = new();
 
+    private bool _disposed;
+
     public AlbumsPage()
     {
         this.InitializeComponent();
 
-
+        _logger = App.ServiceProvider.GetRequiredService<ILogger<AlbumsPage>>();
         ViewModel = App.ServiceProvider.GetRequiredService<AlbumsViewModel>();
         DataContext = ViewModel;
 
@@ -39,6 +44,10 @@ public sealed partial class AlbumsPage : Page, IDisposable
     {
         ScrollStateHelper.SaveScrollOffset(grid);
         ViewModel.SaveState();
+
+        // Cleanup bindings and handlers to avoid keeping generated binding tracking objects alive
+        Dispose();
+
         base.OnNavigatingFrom(e);
     }
 
@@ -131,7 +140,41 @@ public sealed partial class AlbumsPage : Page, IDisposable
 
     public void Dispose()
     {
-        Loaded -= Page_Loaded;
-        ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+        if (!this.DispatcherQueue.HasThreadAccess)
+        {
+            this.DispatcherQueue.TryEnqueue(() => Dispose());
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _disposed, true))
+            return;
+
+        try
+        {
+            Loaded -= Page_Loaded;
+
+            if (ViewModel != null)
+                ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+
+            if (grid is not null)
+                grid.ItemsSource = null;
+
+            if (ZoomoutCollectionGrid is not null)
+                ZoomoutCollectionGrid.ItemsSource = null;
+
+            if (groupedItemsViewSource is not null)
+            {
+                groupedItemsViewSource.Source = null;
+                groupedItemsViewSource.IsSourceGrouped = false;
+            }
+
+            DataContext = null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during Dispose in AlbumsPage");
+        }
+
+        _disposed = true;
     }
 }


### PR DESCRIPTION
Refactor playlist menu logic to use attached properties and static event handlers, preventing memory leaks and closure issues. Add robust Dispose() methods to Albums, Artists, and Tracks pages to detach event handlers, clear bindings, and release resources on navigation. Inject logger for error reporting during cleanup. Ensure all disposal runs on the correct UI thread. These changes enhance memory management, reduce resource leaks, and improve overall app stability and maintainability.