### PR TITLE
feat(statistics): add user library statistics & reset listen count

### DIFF
--- a/Core/Rok.Application/Features/Albums/Command/ResetAlbumListenCountCommandHandler.cs
+++ b/Core/Rok.Application/Features/Albums/Command/ResetAlbumListenCountCommandHandler.cs
@@ -1,0 +1,20 @@
+﻿using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Albums.Command;
+
+public class ResetAlbumListenCountCommand : ICommand<Result<bool>>
+{
+}
+
+public class ResetAlbumListenCountCommandHandler(IAlbumRepository _albumRepository) : ICommandHandler<ResetAlbumListenCountCommand, Result<bool>>
+{
+    public async Task<Result<bool>> HandleAsync(ResetAlbumListenCountCommand message, CancellationToken cancellationToken)
+    {
+        bool result = await _albumRepository.ResetListenCountAsync();
+
+        if (result)
+            return Result<bool>.Success(result);
+        else
+            return Result<bool>.Fail("Failed to reset album listen count.");
+    }
+}

--- a/Core/Rok.Application/Features/Artists/Command/ResetArtistListenCountCommandHandler.cs
+++ b/Core/Rok.Application/Features/Artists/Command/ResetArtistListenCountCommandHandler.cs
@@ -1,0 +1,20 @@
+﻿using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Artists.Command;
+
+public class ResetArtistListenCountCommand : ICommand<Result<bool>>
+{
+}
+
+public class ResetArtistListenCountCommandHandler(IArtistRepository _artistRepository) : ICommandHandler<ResetArtistListenCountCommand, Result<bool>>
+{
+    public async Task<Result<bool>> HandleAsync(ResetArtistListenCountCommand message, CancellationToken cancellationToken)
+    {
+        bool result = await _artistRepository.ResetListenCountAsync();
+
+        if (result)
+            return Result<bool>.Success(result);
+        else
+            return Result<bool>.Fail("Failed to reset artist listen count.");
+    }
+}

--- a/Core/Rok.Application/Features/Genres/Command/ResetGenreListenCountCommandHandler.cs
+++ b/Core/Rok.Application/Features/Genres/Command/ResetGenreListenCountCommandHandler.cs
@@ -1,0 +1,20 @@
+﻿using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Genres.Command;
+
+public class ResetGenreListenCountCommand : ICommand<Result<bool>>
+{
+}
+
+public class ResetGenreListenCountCommandHandler(IGenreRepository _genreRepository) : ICommandHandler<ResetGenreListenCountCommand, Result<bool>>
+{
+    public async Task<Result<bool>> HandleAsync(ResetGenreListenCountCommand message, CancellationToken cancellationToken)
+    {
+        bool result = await _genreRepository.ResetListenCountAsync();
+
+        if (result)
+            return Result<bool>.Success(result);
+        else
+            return Result<bool>.Fail("Failed to reset genre listen count.");
+    }
+}

--- a/Core/Rok.Application/Features/Genres/Command/UpdateGenretLastListenCommandHandler.cs
+++ b/Core/Rok.Application/Features/Genres/Command/UpdateGenretLastListenCommandHandler.cs
@@ -1,0 +1,22 @@
+﻿using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Genres.Command;
+
+public class UpdateGenretLastListenCommand(long id) : ICommand<Result<bool>>
+{
+    [RequiredGreaterThanZero]
+    public long Id { get; init; } = id;
+}
+
+public class UpdateGenretLastListenCommandHandler(IGenreRepository _genreRepository) : ICommandHandler<UpdateGenretLastListenCommand, Result<bool>>
+{
+    public async Task<Result<bool>> HandleAsync(UpdateGenretLastListenCommand message, CancellationToken cancellationToken)
+    {
+        bool result = await _genreRepository.UpdateLastListenAsync(message.Id);
+
+        if (result)
+            return Result<bool>.Success(result);
+        else
+            return Result<bool>.Fail("Failed to update genre last listen status.");
+    }
+}

--- a/Core/Rok.Application/Features/Statistics/Query/GetStatisticsQueryHandler.cs
+++ b/Core/Rok.Application/Features/Statistics/Query/GetStatisticsQueryHandler.cs
@@ -1,0 +1,123 @@
+﻿using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Statistics.Query;
+
+
+public class GetStatisticsQuery : IQuery<UserStatisticsDto>
+{
+}
+
+public class GetStatisticsQueryHandler(ITrackRepository _trackRepository, IAlbumRepository _albumRepository, IArtistRepository _artistRepository, IGenreRepository _genreRepository) : IQueryHandler<GetStatisticsQuery, UserStatisticsDto>
+{
+    public async Task<UserStatisticsDto> HandleAsync(GetStatisticsQuery request, CancellationToken cancellationToken)
+    {
+        IEnumerable<TrackEntity> tracksEnum = await _trackRepository.GetAllAsync(RepositoryConnectionKind.Background);
+        IEnumerable<AlbumEntity> albumsEnum = await _albumRepository.GetAllAsync(RepositoryConnectionKind.Background);
+        IEnumerable<ArtistEntity> artistsEnum = await _artistRepository.GetAllAsync(RepositoryConnectionKind.Background);
+        IEnumerable<GenreEntity> genresEnum = await _genreRepository.GetAllAsync(RepositoryConnectionKind.Background);
+
+        List<TrackEntity> tracks = tracksEnum.ToList();
+        List<AlbumEntity> albums = albumsEnum.ToList();
+        List<ArtistEntity> artists = artistsEnum.ToList();
+        List<GenreEntity> genres = genresEnum.ToList();
+
+        UserStatisticsDto dto = new()
+        {
+            TotalTracks = tracks.Count,
+            TotalSizeBytes = tracks.Sum(t => t.Size),
+            TotalDurationSeconds = tracks.Sum(t => t.Duration),
+            TotalAlbums = albums.Count,
+            TotalArtists = artists.Count,
+            TotalGenres = genres.Count,
+            TracksListenedCount = tracks.Count(t => t.ListenCount > 0)
+        };
+        dto.TracksNeverListenedCount = dto.TotalTracks - dto.TracksListenedCount;
+
+        ComputeTrackTypes(dto, tracks);
+        ComputeAlbumTypes(dto, albums);
+        ComputeArtistsByGenre(dto, genres);
+
+        ComputeTopAlbums(dto, albums);
+        ComputeTopArtists(dto, artists);
+        ComputeTopGenres(dto, genres);
+        ComputeTopTracks(dto, tracks);
+
+        return dto;
+    }
+
+    private static void ComputeTrackTypes(UserStatisticsDto dto, List<TrackEntity> tracks)
+    {
+        List<NamedCount> fileTypeGroups = tracks
+             .Where(t => !string.IsNullOrWhiteSpace(t.MusicFile))
+             .Select(t =>
+             {
+                 string ext = Path.GetExtension(t.MusicFile ?? string.Empty).ToLowerInvariant().TrimStart('.');
+                 return string.IsNullOrEmpty(ext) ? "unknown" : ext;
+             })
+             .GroupBy(ext => ext)
+             .Select(g => new NamedCount { Name = g.Key, Count = g.Count() })
+             .OrderByDescending(x => x.Count)
+             .ToList();
+
+        dto.TracksByFileType = fileTypeGroups;
+    }
+
+    private static void ComputeAlbumTypes(UserStatisticsDto dto, List<AlbumEntity> albums)
+    {
+        int liveCount = albums.Count(a => a.IsLive);
+        int compilationCount = albums.Count(a => a.IsCompilation);
+        int bestofCount = albums.Count(a => a.IsBestOf);
+        int studioCount = albums.Count(a => !a.IsLive && !a.IsCompilation && !a.IsBestOf);
+
+        dto.AlbumsByType.Add(new NamedCount { Name = "studio", Count = studioCount });
+        dto.AlbumsByType.Add(new NamedCount { Name = "live", Count = liveCount });
+        dto.AlbumsByType.Add(new NamedCount { Name = "compilation", Count = compilationCount });
+        dto.AlbumsByType.Add(new NamedCount { Name = "bestof", Count = bestofCount });
+    }
+
+    private static void ComputeArtistsByGenre(UserStatisticsDto dto, List<GenreEntity> genres)
+    {
+        List<NamedCount> artistsByGenre = genres
+            .Select(g => new NamedCount { Name = string.IsNullOrWhiteSpace(g.Name) ? "unknown" : g.Name, Count = g.ArtistCount })
+            .OrderByDescending(x => x.Count)
+            .Take(10)
+            .ToList();
+        dto.ArtistsByGenre = artistsByGenre;
+    }
+
+    private static void ComputeTopAlbums(UserStatisticsDto dto, List<AlbumEntity> albums)
+    {
+        dto.TopAlbums = albums
+           .OrderByDescending(a => a.ListenCount)
+           .Take(20)
+           .Select(a => new TopItem { Id = a.Id, Name = a.Name, ListenCount = a.ListenCount })
+           .ToList();
+    }
+
+    private static void ComputeTopArtists(UserStatisticsDto dto, List<ArtistEntity> artists)
+    {
+        dto.TopArtists = artists
+            .OrderByDescending(ar => ar.ListenCount)
+            .Take(20)
+            .Select(ar => new TopItem { Id = ar.Id, Name = ar.Name, ListenCount = ar.ListenCount })
+            .ToList();
+    }
+
+    private static void ComputeTopGenres(UserStatisticsDto dto, List<GenreEntity> genres)
+    {
+        dto.TopGenres = genres
+            .OrderByDescending(ar => ar.ListenCount)
+            .Take(20)
+            .Select(ar => new TopItem { Id = ar.Id, Name = ar.Name, ListenCount = ar.ListenCount })
+            .ToList();
+    }
+
+    private static void ComputeTopTracks(UserStatisticsDto dto, List<TrackEntity> tracks)
+    {
+        dto.TopTracks = tracks
+             .OrderByDescending(t => t.ListenCount)
+             .Take(20)
+             .Select(t => new TopItem { Id = t.Id, Name = t.Title, ListenCount = t.ListenCount })
+             .ToList();
+    }
+}

--- a/Core/Rok.Application/Features/Statistics/UserStatisticsDto.cs
+++ b/Core/Rok.Application/Features/Statistics/UserStatisticsDto.cs
@@ -1,0 +1,41 @@
+﻿namespace Rok.Application.Features.Statistics;
+
+public class NamedCount
+{
+    public string Name { get; set; } = string.Empty;
+    public int Count { get; set; }
+}
+
+public class TopItem : NamedCount
+{
+    public long Id { get; set; }
+
+    public int ListenCount
+    {
+        get => Count;
+        set => Count = value;
+    }
+}
+
+public class UserStatisticsDto
+{
+    public long TotalTracks { get; set; }
+    public long TotalSizeBytes { get; set; }
+    public long TotalDurationSeconds { get; set; }
+
+    public long TotalAlbums { get; set; }
+    public long TotalArtists { get; set; }
+    public long TotalGenres { get; set; }
+
+    public long TracksListenedCount { get; set; }
+    public long TracksNeverListenedCount { get; set; }
+
+    public List<NamedCount> TracksByFileType { get; set; } = new();
+    public List<NamedCount> AlbumsByType { get; set; } = new();
+    public List<NamedCount> ArtistsByGenre { get; set; } = new();
+
+    public List<TopItem> TopAlbums { get; set; } = new();
+    public List<TopItem> TopArtists { get; set; } = new();
+    public List<TopItem> TopTracks { get; set; } = new();
+    public List<TopItem> TopGenres { get; set; } = new();
+}

--- a/Core/Rok.Application/Features/Tracks/Command/ResetTrackListenCountCommandHandler.cs
+++ b/Core/Rok.Application/Features/Tracks/Command/ResetTrackListenCountCommandHandler.cs
@@ -1,0 +1,20 @@
+﻿using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Tracks.Command;
+
+public class ResetTrackListenCountCommand : ICommand<Result<bool>>
+{
+}
+
+public class ResetTrackListenCountCommandHandler(ITrackRepository _trackRepository) : ICommandHandler<ResetTrackListenCountCommand, Result<bool>>
+{
+    public async Task<Result<bool>> HandleAsync(ResetTrackListenCountCommand message, CancellationToken cancellationToken)
+    {
+        bool result = await _trackRepository.ResetListenCountAsync();
+
+        if (result)
+            return Result<bool>.Success(result);
+        else
+            return Result<bool>.Fail("Failed to reset track listen count.");
+    }
+}

--- a/Core/Rok.Application/Interfaces/IAlbumRepository.cs
+++ b/Core/Rok.Application/Interfaces/IAlbumRepository.cs
@@ -16,6 +16,8 @@ public interface IAlbumRepository : IRepository<AlbumEntity>
 
     Task<bool> UpdateLastListenAsync(long id, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 
+    Task<bool> ResetListenCountAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
     Task<int> DeleteOrphansAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 
     Task<bool> UpdateStatisticsAsync(long id, int trackCount, long duration, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);

--- a/Core/Rok.Application/Interfaces/IArtistRepository.cs
+++ b/Core/Rok.Application/Interfaces/IArtistRepository.cs
@@ -14,6 +14,8 @@ public interface IArtistRepository : IRepository<ArtistEntity>
 
     Task<bool> UpdateLastListenAsync(long id, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 
+    Task<bool> ResetListenCountAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
     Task<int> DeleteOrphansAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 
     Task<bool> UpdateStatisticsAsync(long id, int trackCount, long totalDurationSeconds, int albumCount, int bestOfCount, int liveCount, int compilationCount, int? yearMini, int? yearMaxi, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);

--- a/Core/Rok.Application/Interfaces/IGenreRepository.cs
+++ b/Core/Rok.Application/Interfaces/IGenreRepository.cs
@@ -6,6 +6,8 @@ public interface IGenreRepository : IRepository<GenreEntity>
 
     Task<bool> UpdateLastListenAsync(long id, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 
+    Task<bool> ResetListenCountAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
     Task<int> DeleteOrphansAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 
     Task<bool> UpdateStatisticsAsync(long id, int trackCount, int artistCount, int albumCount, int bestOfCount, int liveCount, int compilationCount, long totalDurationSeconds, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);

--- a/Core/Rok.Application/Interfaces/ITrackRepository.cs
+++ b/Core/Rok.Application/Interfaces/ITrackRepository.cs
@@ -20,6 +20,8 @@ public interface ITrackRepository : IRepository<TrackEntity>
 
     Task<bool> UpdateLastListenAsync(long id, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 
+    Task<bool> ResetListenCountAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
     Task<bool> UpdateSkipCountAsync(long id, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 
     Task<bool> UpdateFileDateAsync(long id, DateTime fileDate, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);

--- a/Core/Rok.Application/Rok.Application.csproj
+++ b/Core/Rok.Application/Rok.Application.csproj
@@ -20,8 +20,4 @@
     <ProjectReference Include="..\Rok.Shared\Rok.Shared.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Features\Genres\Command\" />
-  </ItemGroup>
-
 </Project>

--- a/Infrastructure/Rok.Infrastructure/Repositories/AlbumRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/AlbumRepository.cs
@@ -10,6 +10,7 @@ public class AlbumRepository(IDbConnection connection, [FromKeyedServices("Backg
 {
     private const string UpdateFavoriteSql = "UPDATE albums SET isFavorite = @isFavorite WHERE Id = @id";
     private const string UpdateLastListenSql = "UPDATE albums SET listenCount = listenCount + 1, lastListen = @lastListen WHERE Id = @id";
+    private const string ResetListenCountSql = "UPDATE albums SET listenCount = 0";
     private const string UpdateStatisticsSql = "UPDATE albums SET trackCount = @trackCount, duration = @duration WHERE id = @id";
     private const string UpdateMetadataAttemptSql = "UPDATE albums SET getMetaDataLastAttempt = @lastAttemptDate WHERE id = @id";
     private const string DeleteOrphansSql = "DELETE FROM albums WHERE id NOT IN (SELECT DISTINCT albumId FROM tracks WHERE albumId IS NOT NULL)";
@@ -77,6 +78,11 @@ public class AlbumRepository(IDbConnection connection, [FromKeyedServices("Backg
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(id);
 
         return await ExecuteUpdateAsync(UpdateLastListenSql, new { lastListen = DateTime.UtcNow, id }, kind);
+    }
+
+    public async Task<bool> ResetListenCountAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
+    {
+        return await ExecuteUpdateAsync(ResetListenCountSql, kind);
     }
 
     public async Task<bool> UpdateStatisticsAsync(long id, int trackCount, long duration, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)

--- a/Infrastructure/Rok.Infrastructure/Repositories/ArtistRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/ArtistRepository.cs
@@ -10,6 +10,7 @@ public class ArtistRepository(IDbConnection connection, [FromKeyedServices("Back
 {
     private const string UpdateFavoriteSql = "UPDATE artists SET isFavorite = @isFavorite WHERE Id = @id";
     private const string UpdateLastListenSql = "UPDATE artists SET listenCount = listenCount + 1, lastListen = @lastListen WHERE Id = @id";
+    private const string ResetListenCountSql = "UPDATE artists SET listenCount = 0";
     private const string UpdateStatisticsSql = "UPDATE artists SET trackCount = @trackCount, totalDurationSeconds = @totalDurationSeconds, albumCount = @albumCount, bestOfCount = @bestOfCount, liveCount = @liveCount, compilationCount = @compilationCount, yearMini = @yearMini, yearMaxi = @yearMaxi WHERE id = @id";
     private const string UpdateMetadataAttemptSql = "UPDATE artists SET getMetaDataLastAttempt = @lastAttemptDate WHERE id = @id";
     private const string DeleteOrphansSql = "DELETE FROM artists WHERE id NOT IN (SELECT DISTINCT artistId FROM tracks WHERE artistId IS NOT NULL)";
@@ -72,6 +73,11 @@ public class ArtistRepository(IDbConnection connection, [FromKeyedServices("Back
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(id);
 
         return await ExecuteUpdateAsync(UpdateLastListenSql, new { lastListen = DateTime.UtcNow, id }, kind);
+    }
+
+    public async Task<bool> ResetListenCountAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
+    {
+        return await ExecuteUpdateAsync(ResetListenCountSql, kind);
     }
 
     public async Task<bool> UpdateStatisticsAsync(long id, int trackCount, long totalDurationSeconds, int albumCount, int bestOfCount, int liveCount, int compilationCount, int? yearMini, int? yearMaxi, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)

--- a/Infrastructure/Rok.Infrastructure/Repositories/GenreRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/GenreRepository.cs
@@ -7,7 +7,8 @@ namespace Rok.Infrastructure.Repositories;
 public class GenreRepository(IDbConnection connection, [FromKeyedServices("BackgroundConnection")] IDbConnection backgroundConnection, ILogger<GenreRepository> logger) : GenericRepository<GenreEntity>(connection, backgroundConnection, null, logger), IGenreRepository
 {
     private const string UpdateFavoriteSql = "UPDATE genres SET isFavorite = @isFavorite WHERE Id = @id";
-    private const string UpdateLastListenSql = "UPDATE albums SET listenCount = listenCount + 1, lastListen = @lastListen WHERE Id = @id";
+    private const string UpdateLastListenSql = "UPDATE genres SET listenCount = listenCount + 1, lastListen = @lastListen WHERE Id = @id";
+    private const string ResetListenCountSql = "UPDATE genres SET listenCount = 0";
     private const string UpdateStatisticsSql = "UPDATE genres SET trackCount = @trackCount, artistCount = @artistCount, albumCount = @albumCount, bestOfCount = @bestOfCount, liveCount = @liveCount, compilationCount = @compilationCount, totalDurationSeconds = @totalDurationSeconds WHERE id = @id";
     private const string DeleteOrphansSql = "DELETE FROM genres WHERE id NOT IN (SELECT DISTINCT genreId FROM tracks WHERE genreId IS NOT NULL)";
 
@@ -24,6 +25,11 @@ public class GenreRepository(IDbConnection connection, [FromKeyedServices("Backg
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(id);
 
         return await ExecuteUpdateAsync(UpdateLastListenSql, new { lastListen = DateTime.UtcNow, id }, kind);
+    }
+
+    public async Task<bool> ResetListenCountAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
+    {
+        return await ExecuteUpdateAsync(ResetListenCountSql, kind);
     }
 
     public async Task<int> DeleteOrphansAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)

--- a/Infrastructure/Rok.Infrastructure/Repositories/TrackRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/TrackRepository.cs
@@ -9,6 +9,7 @@ public class TrackRepository(IDbConnection db, [FromKeyedServices("BackgroundCon
 {
     private const string UpdateScoreSql = "UPDATE tracks SET score = @score WHERE Id = @id";
     private const string UpdateLastListenSql = "UPDATE tracks SET listenCount = listenCount + 1, lastListen = @lastListen WHERE Id = @id";
+    private const string ResetListenCountSql = "UPDATE tracks SET listenCount = 0";
     private const string UpdateSkipCountSql = "UPDATE tracks SET skipCount = skipCount + 1, lastSkip = @lastSkip WHERE Id = @id";
     private const string UpdateFileDateSql = "UPDATE tracks SET fileDate = @fileDate WHERE id = @id";
     private const string UpdateGetLyricsLastAttemptSql = "UPDATE tracks SET getLyricsLastAttempt = @lastAttemptDate WHERE id = @id";
@@ -34,8 +35,6 @@ public class TrackRepository(IDbConnection db, [FromKeyedServices("BackgroundCon
 
         return await ExecuteQueryAsync(sql, kind, new { playlistId });
     }
-
-
 
     public new async Task<TrackEntity?> GetByNameAsync(string name, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
     {
@@ -123,6 +122,11 @@ public class TrackRepository(IDbConnection db, [FromKeyedServices("BackgroundCon
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(id);
 
         return await ExecuteUpdateAsync(UpdateLastListenSql, new { lastListen = DateTime.UtcNow, id }, kind);
+    }
+
+    public async Task<bool> ResetListenCountAsync(RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
+    {
+        return await ExecuteUpdateAsync(ResetListenCountSql, kind);
     }
 
     public async Task<bool> UpdateSkipCountAsync(long id, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)

--- a/Presentation/Commons/PieChart.xaml
+++ b/Presentation/Commons/PieChart.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl x:Class="Rok.Commons.PieChart"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:Rok.Commons"             
+             xmlns:sys="using:System"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             x:Name="Root"
+             mc:Ignorable="d">
+
+    <StackPanel>
+        <TextBlock Text="{x:Bind Title, Mode=OneWay}"
+                   FontSize="14"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,8" />
+        <Grid>
+            <Canvas x:Name="PartCanvas"
+                    x:FieldModifier="private"
+                    Width="180"
+                    Height="180"
+                    HorizontalAlignment="Left" />
+        </Grid>
+
+        <StackPanel x:Name="PartLegend"
+                    x:FieldModifier="private"
+                    Orientation="Vertical"
+                    Margin="0,8,0,0" />
+    </StackPanel>
+</UserControl>

--- a/Presentation/Commons/PieChart.xaml.cs
+++ b/Presentation/Commons/PieChart.xaml.cs
@@ -1,0 +1,159 @@
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Shapes;
+using Rok.Application.Features.Statistics;
+using Windows.Foundation;
+using Windows.UI;
+using Path = Microsoft.UI.Xaml.Shapes.Path;
+
+
+namespace Rok.Commons;
+
+public sealed partial class PieChart : UserControl
+{
+    public PieChart()
+    {
+        this.InitializeComponent();
+        this.SizeChanged += (_, _) => Redraw();
+    }
+
+    public static readonly DependencyProperty ItemsProperty =
+        DependencyProperty.Register(nameof(Items), typeof(IEnumerable<NamedCount>), typeof(PieChart),
+            new PropertyMetadata(null, (d, e) => ((PieChart)d).Redraw()));
+
+
+    public IEnumerable<NamedCount>? Items
+    {
+        get => (IEnumerable<NamedCount>?)GetValue(ItemsProperty);
+        set => SetValue(ItemsProperty, value);
+    }
+
+    public static readonly DependencyProperty TitleProperty =
+        DependencyProperty.Register(nameof(Title), typeof(string), typeof(PieChart),
+            new PropertyMetadata(string.Empty));
+
+    public string Title
+    {
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    private static readonly Brush[] Palette = new Brush[]
+    {
+        new SolidColorBrush(Color.FromArgb(0xFF, 0x4C, 0xAF, 0x50)), // green
+        new SolidColorBrush(Color.FromArgb(0xFF, 0x21, 0x96, 0xF3)), // blue
+        new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xC1, 0x07)), // amber
+        new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0x57, 0x22)), // deep orange
+        new SolidColorBrush(Color.FromArgb(0xFF, 0x9C, 0x27, 0xB0)), // purple
+        new SolidColorBrush(Color.FromArgb(0xFF, 0x00, 0x96, 0x88)), // teal
+        new SolidColorBrush(Color.FromArgb(0xFF, 0xE2, 0x3A, 0x2C)), // red
+        new SolidColorBrush(Color.FromArgb(0xFF, 0x7C, 0x4D, 0xFF)), // indigo-ish
+    };
+
+    private void Redraw()
+    {
+        Canvas? canvas = PartCanvas;
+        StackPanel? legend = PartLegend;
+
+        if (canvas is null || legend is null)
+            return;
+
+        canvas.Children.Clear();
+        legend.Children.Clear();
+
+        List<NamedCount> items = (Items ?? Enumerable.Empty<NamedCount>()).Where(i => i != null && i.Count > 0).OrderByDescending(c => c.Count).ToList();
+        double total = items.Sum(i => (double)i.Count);
+
+        double width = canvas.ActualWidth > 0 ? canvas.ActualWidth : canvas.Width;
+        double height = canvas.ActualHeight > 0 ? canvas.ActualHeight : canvas.Height;
+        double size = Math.Min(width, height);
+        double cx = size / 2.0;
+        double cy = size / 2.0;
+        double radius = size / 2.0;
+
+        if (total <= 0 || !items.Any())
+        {
+            // draw empty circle
+            Ellipse empty = new()
+            {
+                Width = size,
+                Height = size,
+                Fill = new SolidColorBrush(Color.FromArgb(0xFF, 0xEE, 0xEE, 0xEE)),
+                Stroke = new SolidColorBrush(Color.FromArgb(0xFF, 0xCC, 0xCC, 0xCC)),
+                StrokeThickness = 1
+            };
+            Canvas.SetLeft(empty, 0);
+            Canvas.SetTop(empty, 0);
+            canvas.Children.Add(empty);
+            legend.Children.Add(new TextBlock { Text = "No data", Foreground = new SolidColorBrush(Colors.Gray) });
+            return;
+        }
+
+        double startAngle = -90.0; // start at top
+
+        for (int i = 0; i < items.Count; i++)
+        {
+            NamedCount it = items[i];
+            double sweep = it.Count / total * 360.0;
+            double endAngle = startAngle + sweep;
+
+            // compute percent early for tooltip and legend
+            double percent = it.Count / total * 100.0;
+
+            // compute points
+            Point startPoint = PointOnCircle(cx, cy, radius, startAngle);
+            Point endPoint = PointOnCircle(cx, cy, radius, endAngle);
+
+            bool isLargeArc = sweep > 180.0;
+
+            // build geometry: move to center, line to startPoint, arc to endPoint, line back to center (closed)
+            PathFigure pf = new() { StartPoint = new Point(cx, cy), IsClosed = true };
+            pf.Segments.Add(new LineSegment { Point = startPoint });
+            pf.Segments.Add(new ArcSegment
+            {
+                Point = endPoint,
+                Size = new Size(radius, radius),
+                IsLargeArc = isLargeArc,
+                SweepDirection = SweepDirection.Clockwise,
+                RotationAngle = 0
+            });
+            pf.Segments.Add(new LineSegment { Point = new Point(cx, cy) });
+
+            PathGeometry pg = new();
+            pg.Figures.Add(pf);
+
+            Path path = new()
+            {
+                Data = pg,
+                Fill = Palette[i % Palette.Length],
+                Stroke = new SolidColorBrush(Color.FromArgb(0x20, 0x00, 0x00, 0x00)),
+                StrokeThickness = 0.5
+            };
+
+            // set tooltip showing type, count and percent
+            string tipText = $"{it.Name} — {it.Count} ({percent:0.#}%)";
+            ToolTipService.SetToolTip(path, tipText);
+
+            canvas.Children.Add(path);
+
+            // legend row
+            StackPanel row = new() { Orientation = Orientation.Horizontal, Spacing = 8, Margin = new Thickness(0, 4, 0, 4) };
+            Rectangle rect = new() { Width = 14, Height = 14, Fill = Palette[i % Palette.Length] };
+            TextBlock txt = new() { Text = $"{it.Name} ({it.Count}) — {percent:0.#}%", VerticalAlignment = VerticalAlignment.Center };
+            row.Children.Add(rect);
+            row.Children.Add(txt);
+            legend.Children.Add(row);
+
+            startAngle = endAngle;
+        }
+    }
+
+    private static Point PointOnCircle(double cx, double cy, double r, double angleDegrees)
+    {
+        double rad = angleDegrees * Math.PI / 180.0;
+        double x = cx + (r * Math.Cos(rad));
+        double y = cy + (r * Math.Sin(rad));
+
+        return new Point(x, y);
+    }
+}

--- a/Presentation/DependencyInjection.cs
+++ b/Presentation/DependencyInjection.cs
@@ -20,6 +20,7 @@ using Rok.Logic.ViewModels.Playlists.Handlers;
 using Rok.Logic.ViewModels.Playlists.Services;
 using Rok.Logic.ViewModels.Search;
 using Rok.Logic.ViewModels.Start;
+using Rok.Logic.ViewModels.Statistics;
 using Rok.Logic.ViewModels.Track.Services;
 using Rok.Logic.ViewModels.Tracks;
 using Rok.Logic.ViewModels.Tracks.Handlers;
@@ -187,6 +188,7 @@ public static class DependencyInjection
         services.AddSingleton<MainViewModel>();
         services.AddTransient<SearchViewModel>();
         services.AddTransient<StartViewModel>();
+        services.AddTransient<StatisticsViewModel>();
 
 
         return services;

--- a/Presentation/Logic/ViewModels/Player/PlayerViewModel.cs
+++ b/Presentation/Logic/ViewModels/Player/PlayerViewModel.cs
@@ -355,7 +355,12 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
     private async Task UpdateListenCountAsync()
     {
         if (CurrentTrack != null)
+        {
             await _listenTracker.UpdateTrackListenAsync(CurrentTrack.Track.Id);
+
+            if (CurrentTrack.Track.GenreId.HasValue)
+                await _listenTracker.UpdateGenreListenAsync(CurrentTrack.Track.GenreId.Value);
+        }
 
         if (CurrentAlbum != null)
             await _listenTracker.UpdateAlbumListenAsync(CurrentAlbum.Album.Id);

--- a/Presentation/Logic/ViewModels/Player/Services/PlayerListenTracker.cs
+++ b/Presentation/Logic/ViewModels/Player/Services/PlayerListenTracker.cs
@@ -1,5 +1,6 @@
 using Rok.Application.Features.Albums.Command;
 using Rok.Application.Features.Artists.Command;
+using Rok.Application.Features.Genres.Command;
 using Rok.Application.Features.Tracks.Command;
 
 namespace Rok.Logic.ViewModels.Player.Services;
@@ -9,12 +10,14 @@ public class PlayerListenTracker(IMediator mediator)
     private readonly HashSet<long> _artistUpdatedCache = [];
     private readonly HashSet<long> _albumUpdatedCache = [];
     private readonly HashSet<long> _trackUpdatedCache = [];
+    private readonly HashSet<long> _genreUpdatedCache = [];
 
     public void ClearCache()
     {
         _artistUpdatedCache.Clear();
         _albumUpdatedCache.Clear();
         _trackUpdatedCache.Clear();
+        _genreUpdatedCache.Clear();
     }
 
     public async Task UpdateTrackListenAsync(long trackId)
@@ -42,5 +45,14 @@ public class PlayerListenTracker(IMediator mediator)
 
         await mediator.SendMessageAsync(new UpdateAlbumLastListenCommand(albumId));
         _albumUpdatedCache.Add(albumId);
+    }
+
+    public async Task UpdateGenreListenAsync(long genreId)
+    {
+        if (_genreUpdatedCache.Contains(genreId))
+            return;
+
+        await mediator.SendMessageAsync(new UpdateGenretLastListenCommand(genreId));
+        _genreUpdatedCache.Add(genreId);
     }
 }

--- a/Presentation/Logic/ViewModels/Statistics/StatisticsViewModel.cs
+++ b/Presentation/Logic/ViewModels/Statistics/StatisticsViewModel.cs
@@ -1,0 +1,128 @@
+﻿using Rok.Application.Features.Albums.Command;
+using Rok.Application.Features.Artists.Command;
+using Rok.Application.Features.Genres.Command;
+using Rok.Application.Features.Statistics;
+using Rok.Application.Features.Statistics.Query;
+using Rok.Application.Features.Tracks.Command;
+using System.Globalization;
+
+namespace Rok.Logic.ViewModels.Statistics;
+
+public class StatisticsViewModel : ObservableObject
+{
+    public UserStatisticsDto Current { get; private set; } = new();
+
+    private readonly IMediator _mediator;
+
+
+    public string FormatWithThousands(long value)
+    {
+        return value.ToString("N0");
+    }
+
+    public string TotalDuration
+    {
+        get
+        {
+            if (Current.TotalDurationSeconds <= 0)
+                return "0:00:00";
+
+            TimeSpan ts = TimeSpan.FromSeconds(Current.TotalDurationSeconds);
+            int days = ts.Days;
+            int hours = ts.Hours;
+            int minutes = ts.Minutes;
+
+            return string.Create(CultureInfo.InvariantCulture, $"{days}:{hours:D2}:{minutes:D2}");
+        }
+    }
+
+    public string TotalSize
+    {
+        get
+        {
+            if (Current.TotalSizeBytes <= 0)
+                return "0";
+
+            const long OneMB = 1_000_000L;
+            const long OneGB = 1_000_000_000L;
+
+            if (Current.TotalSizeBytes >= OneGB)
+            {
+                double gb = Current.TotalSizeBytes / (double)OneGB;
+                return $"{gb.ToString("0.##", CultureInfo.InvariantCulture)} GB";
+            }
+
+            double mb = Current.TotalSizeBytes / (double)OneMB;
+            long mbRounded = (long)Math.Round(mb);
+            return $"{FormatWithThousands(mbRounded)} MB";
+        }
+    }
+
+    public List<RankedTopItem> TopGenres { get; set; } = [];
+
+    public List<RankedTopItem> TopArtists { get; set; } = [];
+
+    public List<RankedTopItem> TopAlbums { get; set; } = [];
+
+    public List<RankedTopItem> TopTracks { get; set; } = [];
+
+    public AsyncRelayCommand ResetListenCountCommand { get; private set; }
+
+
+
+    public StatisticsViewModel(IMediator mediator)
+    {
+        _mediator = mediator;
+
+        ResetListenCountCommand = new AsyncRelayCommand(ResetListenCountAsync);
+    }
+
+
+    public async Task LoadAsync()
+    {
+        Current = await _mediator.SendMessageAsync(new GetStatisticsQuery());
+
+        TopTracks = (Current.TopTracks ?? new List<TopItem>())
+           .Select((t, i) => new RankedTopItem { Rank = i + 1, Id = t.Id, Name = t.Name, ListenCount = t.ListenCount })
+           .ToList();
+
+        TopAlbums = (Current.TopAlbums ?? new List<TopItem>())
+              .Select((t, i) => new RankedTopItem { Rank = i + 1, Id = t.Id, Name = t.Name, ListenCount = t.ListenCount })
+              .ToList();
+
+        TopArtists = (Current.TopArtists ?? new List<TopItem>())
+          .Select((t, i) => new RankedTopItem { Rank = i + 1, Id = t.Id, Name = t.Name, ListenCount = t.ListenCount })
+          .ToList();
+
+        TopGenres = (Current.TopGenres ?? new List<TopItem>())
+          .Select((t, i) => new RankedTopItem { Rank = i + 1, Id = t.Id, Name = t.Name, ListenCount = t.ListenCount })
+          .ToList();
+
+        OnPropertyChanged(nameof(Current));
+        OnPropertyChanged(nameof(TopTracks));
+        OnPropertyChanged(nameof(TopAlbums));
+        OnPropertyChanged(nameof(TopArtists));
+        OnPropertyChanged(nameof(TopGenres));
+        OnPropertyChanged(nameof(TotalDuration));
+        OnPropertyChanged(nameof(TotalSize));
+    }
+
+
+    private async Task ResetListenCountAsync()
+    {
+        await _mediator.SendMessageAsync(new ResetGenreListenCountCommand());
+        await _mediator.SendMessageAsync(new ResetArtistListenCountCommand());
+        await _mediator.SendMessageAsync(new ResetAlbumListenCountCommand());
+        await _mediator.SendMessageAsync(new ResetTrackListenCountCommand());
+
+        await LoadAsync();
+    }
+}
+
+public record RankedTopItem
+{
+    public int Rank { get; init; }
+    public long Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public int ListenCount { get; init; }
+}

--- a/Presentation/Pages/OptionsPage.xaml
+++ b/Presentation/Pages/OptionsPage.xaml
@@ -8,6 +8,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:enums="using:Rok.Shared.Enums" 
     xmlns:generic="using:System.Collections.Generic"
+    xmlns:statistics="using:Rok.Logic.ViewModels.Statistics"
+    xmlns:controls="using:Rok.Commons"
     mc:Ignorable="d"
     x:Name="OptionsView">
 
@@ -100,6 +102,298 @@
                             </ListView.ItemTemplate>
                         </ListView>
                     </StackPanel>
+                </Border>
+            </PivotItem>
+
+            <PivotItem x:Uid="OptionTabStatistics">
+
+                <Border Background="{ThemeResource CardBackgroundFillColorDefault}"
+                        Padding="4"
+                        CornerRadius="12"
+                        Margin="8">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <CommandBar Style="{StaticResource headerCommandBar}" HorizontalAlignment="Left">
+                            <AppBarButton x:Uid="resetListenCount"                                          
+                                          Style="{StaticResource headerGenericButton}"
+                                          Icon="Refresh"
+                                          Click="ResetListenCount_Click">
+                                <ToolTipService.ToolTip>
+                                    <TextBlock x:Uid="resetListenCountToolTip" />
+                                </ToolTipService.ToolTip>
+                            </AppBarButton>
+                        </CommandBar>
+
+                        <ScrollViewer Height="auto"
+                                  Grid.Row="1"
+                                  VerticalScrollBarVisibility="Auto">
+
+                        <StackPanel Spacing="16"
+                                    Margin="24,18,24,18">
+
+
+                            <ItemsControl>
+                                <ItemsControl.Items>
+                                    <TextBlock>
+                                    <Run x:Uid="StatGenres"
+                                         FontWeight="Bold" />
+                                    <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TotalGenres), Mode=OneWay}" />
+                                    </TextBlock>
+
+                                    <TextBlock>
+                                    <Run x:Uid="StatArtists"
+                                         FontWeight="Bold" />
+                                    <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TotalArtists), Mode=OneWay}" />
+                                    </TextBlock>
+
+                                    <TextBlock>
+                                    <Run x:Uid="StatAlbums"
+                                         FontWeight="Bold" />
+                                    <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TotalAlbums), Mode=OneWay}" />
+                                    </TextBlock>
+
+                                    <TextBlock>
+                                    <Run x:Uid="StatSongs"
+                                         FontWeight="Bold" />
+                                    <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TotalTracks), Mode=OneWay}" />
+                                    </TextBlock>
+
+                                    <TextBlock>
+                                    <Run x:Uid="StatListened"
+                                         FontWeight="Bold" />
+                                    <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TracksListenedCount), Mode=OneWay}" />
+                                    </TextBlock>
+
+                                    <TextBlock>
+                                    <Run x:Uid="StatTotalDurations"
+                                         FontWeight="Bold" />
+                                    <Run Text="{x:Bind StatisticsViewModel.TotalDuration, Mode=OneWay}" />
+                                    </TextBlock>
+
+                                    <TextBlock>
+                                    <Run x:Uid="StatTotalSize"
+                                         FontWeight="Bold" />
+                                    <Run Text="{x:Bind StatisticsViewModel.TotalSize, Mode=OneWay}" />
+                                    </TextBlock>
+                                </ItemsControl.Items>
+                            </ItemsControl>
+
+                            <!-- Top lists: three columns side by side -->
+                            <StackPanel Orientation="Horizontal"
+                                        Spacing="12">
+
+                                <!-- Top Genres -->
+                                <Border Background="{ThemeResource ContentDialogBackground}"
+                                        Padding="8"
+                                        CornerRadius="8"
+                                        Width="300">
+                                    <StackPanel>
+                                        <TextBlock x:Uid="StatTopGenres"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="14" />
+                                        <ScrollViewer Height="550"
+                                                      VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopGenres, Mode=OneWay}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="statistics:RankedTopItem">
+                                                        <Grid Margin="4">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="32" />
+                                                                <ColumnDefinition Width="160" />
+                                                                <ColumnDefinition Width="60" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Grid.Column="0"
+                                                                       Text="{x:Bind Rank}"
+                                                                       HorizontalAlignment="Center"
+                                                                       VerticalAlignment="Center"
+                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{x:Bind Name}"
+                                                                       TextTrimming="CharacterEllipsis"
+                                                                       VerticalAlignment="Center" />
+                                                            <TextBlock Grid.Column="2"
+                                                                       Text="{x:Bind ListenCount}"
+                                                                       HorizontalAlignment="Right"
+                                                                       VerticalAlignment="Center" />
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </StackPanel>
+                                </Border>
+
+                                <!-- Top Artists -->
+                                <Border Background="{ThemeResource ContentDialogBackground}"
+                                        Padding="8"
+                                        CornerRadius="8"
+                                        Width="300">
+                                    <StackPanel>
+                                        <TextBlock x:Uid="StatTopArtists"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="14" />
+                                        <ScrollViewer Height="550"
+                                                      VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopArtists, Mode=OneWay}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="statistics:RankedTopItem">
+                                                        <Grid Margin="4">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="32" />
+                                                                <ColumnDefinition Width="160" />
+                                                                <ColumnDefinition Width="60" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Grid.Column="0"
+                                                                       Text="{x:Bind Rank}"
+                                                                       HorizontalAlignment="Center"
+                                                                       VerticalAlignment="Center"
+                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{x:Bind Name}"
+                                                                       TextTrimming="CharacterEllipsis"
+                                                                       VerticalAlignment="Center" />
+                                                            <TextBlock Grid.Column="2"
+                                                                       Text="{x:Bind ListenCount}"
+                                                                       HorizontalAlignment="Right"
+                                                                       VerticalAlignment="Center" />
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </StackPanel>
+                                </Border>
+
+                                <!-- Top Albums -->
+                                <Border Background="{ThemeResource ContentDialogBackground}"
+                                        Padding="8"
+                                        CornerRadius="8"
+                                        Width="300">
+                                    <StackPanel>
+                                        <TextBlock x:Uid="StatTopAlbums"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="14" />
+                                        <ScrollViewer Height="550"
+                                                      VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopAlbums, Mode=OneWay}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="statistics:RankedTopItem">
+                                                        <Grid Margin="4">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="32" />
+                                                                <ColumnDefinition Width="160" />
+                                                                <ColumnDefinition Width="60" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Grid.Column="0"
+                                                                       Text="{x:Bind Rank}"
+                                                                       HorizontalAlignment="Center"
+                                                                       VerticalAlignment="Center"
+                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{x:Bind Name}"
+                                                                       TextTrimming="CharacterEllipsis"
+                                                                       VerticalAlignment="Center" />
+                                                            <TextBlock Grid.Column="2"
+                                                                       HorizontalAlignment="Right"
+                                                                       Text="{x:Bind ListenCount}"
+                                                                       VerticalAlignment="Center" />
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </StackPanel>
+                                </Border>
+
+                                <!-- Top Tracks -->
+                                <Border Background="{ThemeResource ContentDialogBackground}"
+                                        Padding="8"
+                                        CornerRadius="8"
+                                        Width="300">
+                                    <StackPanel>
+                                        <TextBlock x:Uid="StatTopSongs"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="14" />
+                                        <ScrollViewer Height="550"
+                                                      VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopTracks, Mode=OneWay}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="statistics:RankedTopItem">
+                                                        <Grid Margin="4">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="32" />
+                                                                <ColumnDefinition Width="160" />
+                                                                <ColumnDefinition Width="60" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Grid.Column="0"
+                                                                       Text="{x:Bind Rank}"
+                                                                       HorizontalAlignment="Center"
+                                                                       VerticalAlignment="Center"
+                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{x:Bind Name}"
+                                                                       TextTrimming="CharacterEllipsis"
+                                                                       VerticalAlignment="Center" />
+                                                            <TextBlock Grid.Column="2"
+                                                                       Text="{x:Bind ListenCount}"
+                                                                       HorizontalAlignment="Right"
+                                                                       VerticalAlignment="Center" />
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+
+
+                            <!-- Charts -->
+                            <StackPanel Orientation="Horizontal"
+                                        Spacing="12">
+
+                                <Border Background="{ThemeResource ContentDialogBackground}"
+                                        Padding="8"
+                                        CornerRadius="8"
+                                        Width="300">
+                                    <ScrollViewer Height="500"
+                                                  VerticalScrollBarVisibility="Auto">
+                                        <controls:PieChart x:Uid="StartTracksByFileType"
+                                                           Items="{x:Bind StatisticsViewModel.Current.TracksByFileType, Mode=OneWay}" />
+                                    </ScrollViewer>
+                                </Border>
+
+                                <Border Background="{ThemeResource ContentDialogBackground}"
+                                        Padding="8"
+                                        CornerRadius="8"
+                                        Width="300">
+                                    <ScrollViewer Height="500"
+                                                  VerticalScrollBarVisibility="Auto">
+                                        <controls:PieChart x:Uid="StartAlbumsByType"
+                                                           Items="{x:Bind StatisticsViewModel.Current.AlbumsByType, Mode=OneWay}" />
+                                    </ScrollViewer>
+                                </Border>
+
+                                <Border Background="{ThemeResource ContentDialogBackground}"
+                                        Padding="8"
+                                        CornerRadius="8"
+                                        Width="300">
+                                    <ScrollViewer Height="500"
+                                                  VerticalScrollBarVisibility="Auto">
+                                        <controls:PieChart x:Uid="StartArtistsByGenre"
+                                                           Items="{x:Bind StatisticsViewModel.Current.ArtistsByGenre, Mode=OneWay}" />
+                                    </ScrollViewer>
+                                </Border>
+                            </StackPanel>
+
+                        </StackPanel>
+
+                    </ScrollViewer>
+                    </Grid>
                 </Border>
             </PivotItem>
 

--- a/Presentation/Pages/OptionsPage.xaml.cs
+++ b/Presentation/Pages/OptionsPage.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml.Controls;
+using Rok.Logic.ViewModels.Statistics;
 using Windows.ApplicationModel;
 using Windows.Storage;
 using Windows.Storage.AccessCache;
@@ -27,6 +28,10 @@ public sealed partial class OptionsPage : Page
 
     private readonly IFolderResolver _folderResolver;
 
+    private readonly ResourceLoader _resourceLoader;
+
+    private StatisticsViewModel StatisticsViewModel { get; }
+
     public string AppVersionString
     {
         get
@@ -43,6 +48,9 @@ public sealed partial class OptionsPage : Page
 
         Options = App.ServiceProvider.GetRequiredService<IAppOptions>();
         _folderResolver = App.ServiceProvider.GetRequiredService<IFolderResolver>();
+        _resourceLoader = App.ServiceProvider.GetRequiredService<ResourceLoader>();
+
+        StatisticsViewModel = App.ServiceProvider.GetRequiredService<StatisticsViewModel>();
     }
 
     protected override async void OnNavigatedTo(Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
@@ -59,6 +67,8 @@ public sealed partial class OptionsPage : Page
                 _paths.Add(new PathItem(token, path));
             }
         }
+
+        await StatisticsViewModel.LoadAsync();
     }
 
     private void StorePageButton_Click(object sender, RoutedEventArgs e)
@@ -157,6 +167,23 @@ public sealed partial class OptionsPage : Page
         }
     }
 
+    private async void ResetListenCount_Click(object sender, RoutedEventArgs e)
+    {
+        ContentDialog dialog = new()
+        {
+            XamlRoot = XamlRoot,
+            Title = _resourceLoader.GetString("ResetListenCountConfirmationTitle"),
+            Content = _resourceLoader.GetString("ResetListenCountTitleConfirmation"),
+            PrimaryButtonText = _resourceLoader.GetString("YesButton"),
+            CloseButtonText = _resourceLoader.GetString("CancelButton"),
+            DefaultButton = ContentDialogButton.Close
+        };
+
+        ContentDialogResult result = await dialog.ShowAsync();
+
+        if (result == ContentDialogResult.Primary && StatisticsViewModel.ResetListenCountCommand.CanExecute(null))
+            StatisticsViewModel.ResetListenCountCommand.Execute(null);
+    }
 }
 
 public class PathItem(string key, string value)

--- a/Presentation/Rok.csproj
+++ b/Presentation/Rok.csproj
@@ -40,6 +40,7 @@
 		<None Remove="Commons\InlineEditableText.xaml" />
 		<None Remove="Commons\NotificationControl.xaml" />
 		<None Remove="Commons\NotificationItemControl.xaml" />
+		<None Remove="Commons\PieChart.xaml" />
 		<None Remove="Commons\PlaylistGroup.xaml" />
 		<None Remove="Commons\PlaylistGroupFilter.xaml" />
 		<None Remove="Commons\RatingControlLightControl.xaml" />
@@ -252,6 +253,9 @@
 	  <None Update="appsettings.json">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>
+	  <Page Update="Commons\PieChart.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </Page>
 	  <None Update="Package.appxmanifest">
 	    <SubType>Designer</SubType>
 	  </None>

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1065,4 +1065,61 @@
   <data name="tracksViewGroupByScore" xml:space="preserve">
     <value>score</value>
   </data>
+  <data name="OptionTabStatistics.Header" xml:space="preserve">
+    <value>Statistics</value>
+  </data>
+  <data name="StatGenres.Text" xml:space="preserve">
+    <value>🔹Genres: </value>
+  </data>
+  <data name="StatArtists.Text" xml:space="preserve">
+    <value>🔹Artists: </value>
+  </data>
+  <data name="StatAlbums.Text" xml:space="preserve">
+    <value>🔹Albums: </value>
+  </data>
+  <data name="StatSongs.Text" xml:space="preserve">
+    <value>🔹Songs: </value>
+  </data>
+  <data name="StatTotalDurations.Text" xml:space="preserve">
+    <value>🔹Total durations: </value>
+  </data>
+  <data name="StatTotalSize.Text" xml:space="preserve">
+    <value>🔹Total size: </value>
+  </data>
+  <data name="StatTopGenres.Text" xml:space="preserve">
+    <value>🏅 Top Genres</value>
+  </data>
+  <data name="StatTopArtists.Text" xml:space="preserve">
+    <value>🏅 Top Artists</value>
+  </data>
+  <data name="StatTopAlbums.Text" xml:space="preserve">
+    <value>🏅 Top Albums</value>
+  </data>
+  <data name="StatTopSongs.Text" xml:space="preserve">
+    <value>🏅 Top Songs</value>
+  </data>
+  <data name="StartTracksByFileType.Title" xml:space="preserve">
+    <value>Tracks by file type</value>
+  </data>
+  <data name="StartAlbumsByType.Title" xml:space="preserve">
+    <value>Albums by type</value>
+  </data>
+  <data name="StartArtistsByGenre.Title" xml:space="preserve">
+    <value>Artists by genre</value>
+  </data>
+  <data name="StatListened.Text" xml:space="preserve">
+    <value>🔹Listened:</value>
+  </data>
+  <data name="ResetListenCountConfirmationTitle" xml:space="preserve">
+    <value>Confirmation</value>
+  </data>
+  <data name="ResetListenCountTitleConfirmation" xml:space="preserve">
+    <value>Do you want to reset listen count?</value>
+  </data>
+  <data name="resetListenCountToolTip.Text" xml:space="preserve">
+    <value>Reset listen count</value>
+  </data>
+  <data name="resetListenCount.Label" xml:space="preserve">
+    <value>Reset listen count</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1065,4 +1065,61 @@
   <data name="tracksViewGroupByScore" xml:space="preserve">
     <value>score</value>
   </data>
+  <data name="OptionTabStatistics.Header" xml:space="preserve">
+    <value>Statistiques</value>
+  </data>
+  <data name="StatGenres.Text" xml:space="preserve">
+    <value>🔹Genres : </value>
+  </data>
+  <data name="StatArtists.Text" xml:space="preserve">
+    <value>🔹Artistes : </value>
+  </data>
+  <data name="StatAlbums.Text" xml:space="preserve">
+    <value>🔹Albums : </value>
+  </data>
+  <data name="StatSongs.Text" xml:space="preserve">
+    <value>🔹Chansons : </value>
+  </data>
+  <data name="StatTotalDurations.Text" xml:space="preserve">
+    <value>🔹Durée totale : </value>
+  </data>
+  <data name="StatTotalSize.Text" xml:space="preserve">
+    <value>🔹Taille totale : </value>
+  </data>
+  <data name="StatTopGenres.Text" xml:space="preserve">
+    <value>🏅 Top Genres</value>
+  </data>
+  <data name="StatTopArtists.Text" xml:space="preserve">
+    <value>🏅 Top Artistes</value>
+  </data>
+  <data name="StatTopAlbums.Text" xml:space="preserve">
+    <value>🏅 Top Albums</value>
+  </data>
+  <data name="StatTopSongs.Text" xml:space="preserve">
+    <value>🏅 Top chansons</value>
+  </data>
+  <data name="StartTracksByFileType.Title" xml:space="preserve">
+    <value>Chansons par type</value>
+  </data>
+  <data name="StartAlbumsByType.Title" xml:space="preserve">
+    <value>Albums par type</value>
+  </data>
+  <data name="StartArtistsByGenre.Title" xml:space="preserve">
+    <value>Artistes par genre</value>
+  </data>
+  <data name="StatListened.Text" xml:space="preserve">
+    <value>🔹Ecoutés :</value>
+  </data>
+  <data name="ResetListenCountTitleConfirmation" xml:space="preserve">
+    <value>Voulez-vous réinitialiser le nombre d'écoutes ?</value>
+  </data>
+  <data name="ResetListenCountConfirmationTitle" xml:space="preserve">
+    <value>Confirmation</value>
+  </data>
+  <data name="resetListenCountToolTip.Text" xml:space="preserve">
+    <value>Réinitialiser le nombre d'écoutes</value>
+  </data>
+  <data name="resetListenCount.Label" xml:space="preserve">
+    <value>Réinitialiser le nombre d'écoutes</value>
+  </data>
 </root>


### PR DESCRIPTION
Add a new "Statistics" tab in Options page with global library stats, top lists, and pie charts. Introduce StatisticsViewModel to aggregate and expose stats. Add PieChart control for visualizing distributions. Implement listen count reset for tracks, albums, artists, genres (UI + backend). Update repositories and application layer with reset methods and commands. Extend PlayerListenTracker to update genre listens. Localize new UI labels and tooltips.
Update DI and project files for new features.
Provides users with analytics and listen count management.