### PR TITLE
Separate smart playlists from regular playlists in UI

### DIFF
--- a/Presentation/Logic/ViewModels/Playlists/PlaylistsViewModel.cs
+++ b/Presentation/Logic/ViewModels/Playlists/PlaylistsViewModel.cs
@@ -13,6 +13,8 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
 
     public RangeObservableCollection<PlaylistViewModel> Playlists { get; private set; } = [];
 
+    public RangeObservableCollection<PlaylistViewModel> SmartPlaylists { get; private set; } = [];
+
     public RelayCommand NewSmartPlaylistCommand { get; private set; }
     public RelayCommand NewPlaylistCommand { get; private set; }
 
@@ -66,7 +68,10 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
     private void RefreshPlaylists()
     {
         Playlists.Clear();
-        Playlists.AddRange(_dataLoader.ViewModels);
+        Playlists.AddRange(_dataLoader.ViewModels.Where(c => !c.Playlist.IsSmart));
+
+        SmartPlaylists.Clear();
+        SmartPlaylists.AddRange(_dataLoader.ViewModels.Where(c => c.Playlist.IsSmart));
     }
 
     private async Task NewSmartPlaylistAsync()

--- a/Presentation/Pages/PlaylistsPage.xaml
+++ b/Presentation/Pages/PlaylistsPage.xaml
@@ -47,10 +47,27 @@
                 </LinearGradientBrush>
             </Grid.Background>
 
-            <common:GridViewExtended Grid.Row="2"
-                                     x:Name="grid"
+            <ScrollViewer>
+                <StackPanel>
+
+                
+                
+                <GridViewHeaderItem FontSize="24"
+                                    FontWeight="Bold"
+                                    HorizontalAlignment="Left">
+                    <GridViewHeaderItem.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <SymbolIcon Symbol="OutlineStar"
+                                        Margin="4,0,4,0" />
+                            <TextBlock x:Uid="smartPlaylistHeader"></TextBlock>
+                        </StackPanel>
+                    </GridViewHeaderItem.Content>
+                </GridViewHeaderItem>
+
+                <common:GridViewExtended Grid.Row="2"
+                                     x:Name="gridSmartPlaylist"
                                      ContainerContentChanging="grid_ContainerContentChanging"
-                                     ItemsSource="{x:Bind ViewModel.Playlists}"
+                                     ItemsSource="{x:Bind ViewModel.SmartPlaylists}"
                                      Margin="0"
                                      ScrollViewer.VerticalScrollMode="Enabled"
                                      ScrollViewer.VerticalScrollBarVisibility="Auto">
@@ -65,14 +82,7 @@
                                                        PlayButtonVisibility="Visible"
                                                        Command="{x:Bind ListenCommand}" />
                             </Border>
-
-                            <SymbolIcon Symbol="OutlineStar"
-                                        Foreground="Yellow"
-                                        VerticalAlignment="Top"
-                                        HorizontalAlignment="Right"
-                                        Margin="0,5,5,0"
-                                        Visibility="{x:Bind Playlist.IsSmart, Converter={StaticResource BoolToVisibilityConverter}}" />
-
+                           
                             <Grid Style="{StaticResource GridCoverBottomStyle}">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="30" />
@@ -105,6 +115,73 @@
                     </ItemsPanelTemplate>
                 </GridView.ItemsPanel>
             </common:GridViewExtended>
+
+                <GridViewHeaderItem FontSize="24"
+                                    FontWeight="Bold"
+                                    HorizontalAlignment="Left">
+                    <GridViewHeaderItem.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <SymbolIcon Symbol="Shop"
+                                        Margin="4,0,4,0" />
+                            <TextBlock x:Uid="playlistHeader"></TextBlock>
+                        </StackPanel>
+                    </GridViewHeaderItem.Content>
+                </GridViewHeaderItem>
+
+                <common:GridViewExtended Grid.Row="2"
+                                     x:Name="gridPlaylist"
+                                     ContainerContentChanging="grid_ContainerContentChanging"
+                                     ItemsSource="{x:Bind ViewModel.Playlists}"
+                                     Margin="0"
+                                     ScrollViewer.VerticalScrollMode="Enabled"
+                                     ScrollViewer.VerticalScrollBarVisibility="Auto">
+
+                <GridView.ItemTemplate>
+                    <DataTemplate x:DataType="a:PlaylistViewModel">
+
+                        <Grid Style="{StaticResource MainGridCoverStyle}">
+                            <Border CornerRadius="10">
+                                <common:PictureControl Style="{StaticResource PictureCoverStyle}"
+                                                       Cover="{x:Bind Picture, Mode=OneWay}"
+                                                       PlayButtonVisibility="Visible"
+                                                       Command="{x:Bind ListenCommand}" />
+                            </Border>
+
+                            <Grid Style="{StaticResource GridCoverBottomStyle}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="30" />
+                                    <RowDefinition Height="30" />
+                                </Grid.RowDefinitions>
+
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+
+                                <HyperlinkButton Grid.ColumnSpan="2"
+                                                 Content="{x:Bind Playlist.Name}"
+                                                 Command="{x:Bind PlaylistOpenCommand}"
+                                                 Style="{StaticResource GridCoverBottomFirstLineStyle}" />
+                                <TextBlock Grid.Row="1"
+                                           Style="{StaticResource GridCoverBottomSecondLineStyle}"
+                                           Text="{x:Bind SubTitle, Mode=OneWay}" />
+                            </Grid>
+                        </Grid>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+
+                <GridView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <ItemsWrapGrid Orientation="Horizontal"
+                                       ItemHeight="320"
+                                       ItemWidth="320"
+                                       Margin="0,0,2,2" />
+                    </ItemsPanelTemplate>
+                </GridView.ItemsPanel>
+            </common:GridViewExtended>
+                
+            </StackPanel>
+            </ScrollViewer>
         </Grid>
     </Grid>
 </Page>

--- a/Presentation/Pages/PlaylistsPage.xaml.cs
+++ b/Presentation/Pages/PlaylistsPage.xaml.cs
@@ -1,6 +1,5 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using Rok.Commons;
 using Rok.Logic.ViewModels.Playlists;
 
 namespace Rok.Pages;
@@ -26,22 +25,8 @@ public sealed partial class PlaylistsPage : Page, IDisposable
     }
 
 
-    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
-    {
-        ScrollStateHelper.SaveScrollOffset(grid);
-
-        base.OnNavigatingFrom(e);
-    }
-
-
-    private void Page_Loaded(object sender, RoutedEventArgs e)
-    {
-        ScrollStateHelper.RestoreScrollOffset(grid);
-    }
-
     public void Dispose()
     {
-        Loaded -= Page_Loaded;
     }
 
     private void grid_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1122,4 +1122,10 @@
   <data name="resetListenCount.Label" xml:space="preserve">
     <value>Reset listen count</value>
   </data>
+  <data name="playlistHeader.Text" xml:space="preserve">
+    <value>Playlists</value>
+  </data>
+  <data name="smartPlaylistHeader.Text" xml:space="preserve">
+    <value>Smart playlists</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1122,4 +1122,10 @@
   <data name="resetListenCount.Label" xml:space="preserve">
     <value>Réinitialiser le nombre d'écoutes</value>
   </data>
+  <data name="playlistHeader.Text" xml:space="preserve">
+    <value>Playlists</value>
+  </data>
+  <data name="smartPlaylistHeader.Text" xml:space="preserve">
+    <value>Smart playlists</value>
+  </data>
 </root>


### PR DESCRIPTION
Distinct sections for smart and regular playlists are now displayed on the Playlists page. Added a SmartPlaylists collection in PlaylistsViewModel and updated refresh logic. Each section has its own GridViewExtended and localized header. Removed per-item star icon for smart playlists; section header now indicates type. Scroll state management code was removed due to new layout. Resource files updated with new section headers in English and French. Improves clarity and navigation for users with many playlists.