### PR TITLE
refactor(styles): move RatingControl styles to dedicated XAML file

### DIFF
--- a/Presentation/App.xaml
+++ b/Presentation/App.xaml
@@ -59,6 +59,7 @@
                 <ResourceDictionary Source="ms-appx:///Styles/NovaStyles.xaml" />
                 <ResourceDictionary Source="ms-appx:///Styles/ButtonStyles.xaml" />
                 <ResourceDictionary Source="ms-appx:///Styles/ControlsStyles.xaml" />
+                <ResourceDictionary Source="ms-appx:///Styles/RatingControlStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Presentation/Commons/RatingControlLightControl.xaml.cs
+++ b/Presentation/Commons/RatingControlLightControl.xaml.cs
@@ -11,7 +11,7 @@ public sealed partial class RatingControlLightControl : UserControl
     public RatingControlLightControl()
     {
         InitializeComponent();
-        Loaded += (_, _) => ApplyRatingToVisuals(); // assure l’état initial
+        Loaded += (_, _) => ApplyRatingToVisuals();
     }
 
     private const int DefaultMaxRating = 5;

--- a/Presentation/Pages/AlbumPage.xaml
+++ b/Presentation/Pages/AlbumPage.xaml
@@ -226,6 +226,7 @@
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="tracks:TrackViewModel">
                         <Grid Background="Transparent">
+                            
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="{ThemeResource gridHeaderTracksTitleColumnWidth}" />
                                 <ColumnDefinition Width="{ThemeResource gridHeaderTracksArtistColumnWidth}" />

--- a/Presentation/Pages/ArtistPage.xaml
+++ b/Presentation/Pages/ArtistPage.xaml
@@ -271,6 +271,7 @@
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="tracks:TrackViewModel">
                                 <Grid Background="Transparent">
+                                    
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="{ThemeResource gridHeaderTracksTitleColumnWidth}" />
                                         <ColumnDefinition Width="{ThemeResource gridHeaderTracksAlbumColumnWidth}" />
@@ -304,6 +305,7 @@
 
                                     <StackPanel Grid.Column="0"
                                                 Orientation="Horizontal">
+                                        
                                         <TextBlock x:Name="RowIndexText"
                                                    Style="{StaticResource gridTracksRowIndexText}" />
 

--- a/Presentation/Pages/OptionsPage.xaml
+++ b/Presentation/Pages/OptionsPage.xaml
@@ -412,7 +412,7 @@
                                        FontWeight="Bold"
                                        Text="RoK music player"
                                        VerticalAlignment="Bottom"
-                                       Foreground="{StaticResource AccentTextFillColorPrimaryBrush}" />
+                                       Foreground="{ThemeResource AccentAAFillColorTertiaryBrush}" />
                             <TextBlock FontSize="18"
                                        FontStyle="Italic"
                                        VerticalAlignment="Bottom"

--- a/Presentation/Pages/TracksPage.xaml
+++ b/Presentation/Pages/TracksPage.xaml
@@ -171,9 +171,7 @@
 
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="tracks:TrackViewModel">
-                                <Grid HorizontalAlignment="Stretch"
-                                      Background="Transparent"
-                                      Margin="0,0,20,10">
+                                <Grid Background="Transparent">
 
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="{ThemeResource gridHeaderTracksTitleColumnWidth}" />
@@ -215,6 +213,7 @@
 
                                     <StackPanel Grid.Column="0"
                                                 Orientation="Horizontal">
+
                                         <HyperlinkButton Style="{StaticResource gridTracksTitleText}"
                                                          Command="{x:Bind ListenCommand}"
                                                          CommandParameter="{x:Bind}" />

--- a/Presentation/Rok.csproj
+++ b/Presentation/Rok.csproj
@@ -59,6 +59,7 @@
 		<None Remove="Pages\TrackPage.xaml" />
 		<None Remove="Pages\TracksPage.xaml" />
 		<None Remove="Pages\WelcomePage.xaml" />
+		<None Remove="Styles\RatingControlStyles.xaml" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -253,6 +254,9 @@
 	  <None Update="appsettings.json">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>
+	  <Page Update="Styles\RatingControlStyles.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </Page>
 	  <Page Update="Commons\PieChart.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </Page>

--- a/Presentation/Styles/ControlsStyles.xaml
+++ b/Presentation/Styles/ControlsStyles.xaml
@@ -5,7 +5,6 @@
     xmlns:common="using:Rok.Commons" 
     xmlns:tracks="using:Rok.Logic.ViewModels.Tracks">
 
-    
     <!-- List pages -->
 
     <x:Double x:Key="headerListRowHeight">40</x:Double>
@@ -119,6 +118,7 @@
 
     <Style x:Key="gridHeaderTracksText" TargetType="TextBlock">
         <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="Margin" Value="20,0,0,0" />
     </Style>
 
     <Style x:Key="gridTracksRowIndexText" TargetType="TextBlock">
@@ -176,21 +176,6 @@
         </Setter>
     </Style>
 
-    <Style x:Key="gridTracksScore" TargetType="common:RatingControlLightControl">
-        <Setter Property="MaxRating" Value="5"/>
-        <Setter Property="Margin" Value="0"/>
-        <Setter Property="StarSize" Value="16"/>
-        <Setter Property="HorizontalAlignment" Value="Left"/>
-        <Setter Property="VerticalAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Bottom"/>
-        <Setter Property="StarEmptyColor" Value="Transparent"/>
-        <Setter Property="StarSelectedColor" Value="{ThemeResource SystemAccentColor}"/>
-        <Setter Property="StarPointerOverColor" Value="{ThemeResource SystemAccentColorDark3}"/>
-        <Setter Property="StarCheckedPointerOverColor" Value="{ThemeResource SystemAccentColorDark3}"/>
-        <Setter Property="StarStrokeColor" Value="#FF666666"/>
-        <Setter Property="Width" Value="130"/>
-    </Style>
-    
     <Style x:Name="tracksListViewItem" TargetType="ListViewItem">
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>

--- a/Presentation/Styles/RatingControlStyles.xaml
+++ b/Presentation/Styles/RatingControlStyles.xaml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:common="using:Rok.Commons">
+
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <Color x:Key="StarStrokeColor">#66000000</Color>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Dark">
+            <Color x:Key="StarStrokeColor">#66FFFFFF</Color>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Default">
+            <Color x:Key="StarStrokeColor">#66000000</Color>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    <Style x:Key="gridTracksScore"
+           TargetType="common:RatingControlLightControl">
+        <Setter Property="MaxRating"
+                Value="5" />
+
+        <Setter Property="Margin"
+                Value="0" />
+
+        <Setter Property="StarSize"
+                Value="16" />
+
+        <Setter Property="HorizontalAlignment"
+                Value="Right" />
+
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+
+        <Setter Property="VerticalContentAlignment"
+                Value="Bottom" />
+
+        <Setter Property="StarEmptyColor"
+                Value="Transparent" />
+
+        <Setter Property="StarSelectedColor"
+                Value="{ThemeResource SystemAccentColor}" />
+
+        <Setter Property="StarPointerOverColor"
+                Value="{ThemeResource SystemAccentColorLight3}" />
+
+        <Setter Property="StarCheckedPointerOverColor"
+                Value="{ThemeResource SystemAccentColorLight2}" />
+
+        <Setter Property="StarStrokeColor"
+                Value="{ThemeResource StarStrokeColor}" />
+
+        <Setter Property="Width"
+                Value="130" />
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
Moved gridTracksScore style from ControlsStyles.xaml to new RatingControlStyles.xaml. Added theme-aware StarStrokeColor for RatingControlLightControl. Updated App.xaml to merge the new style dictionary. Registered RatingControlStyles.xaml in Rok.csproj for build and packaging. Minor UI tweaks in AlbumPage, ArtistPage, TracksPage, and ArtistPage for grid layout. Changed accent text color in OptionsPage to use a theme resource. No functional changes to RatingControlLightControl C# code. This improves style modularity and theme support for rating controls.