### PR TITLE
Remove backdrop timer & fade animations, randomize on track change

### DIFF
--- a/Infrastructure/Rok.Infrastructure/Files/BackdropPicture.cs
+++ b/Infrastructure/Rok.Infrastructure/Files/BackdropPicture.cs
@@ -91,8 +91,7 @@ public class BackdropPicture
 
     public string GetRandomGenericBackdrop()
     {
-        Random random = new();
-        int index = random.Next(1, 12);
+        int index = Random.Shared.Next(1, 12);
 
         return $"ms-appx:///Assets/Backdrop/wallpaper{index}.jpg";
     }

--- a/Presentation/Commons/FullScreenControl.xaml
+++ b/Presentation/Commons/FullScreenControl.xaml
@@ -43,32 +43,6 @@
             </DoubleAnimation>
         </Storyboard>
 
-        <!-- Fade in for new backdrop -->
-        <Storyboard x:Key="BackdropFadeIn">
-            <DoubleAnimation
-               Storyboard.TargetName="BackdropImage"
-               Storyboard.TargetProperty="Opacity"
-               From="0" To="1"
-               Duration="0:0:1.5">
-                <DoubleAnimation.EasingFunction>
-                    <QuadraticEase EasingMode="EaseOut"/>
-                </DoubleAnimation.EasingFunction>
-            </DoubleAnimation>
-        </Storyboard>
-
-        <!-- Fade out for old backdrop -->
-        <Storyboard x:Key="BackdropFadeOut">
-            <DoubleAnimation
-               Storyboard.TargetName="BackdropImage"
-               Storyboard.TargetProperty="Opacity"
-               From="1" To="0"
-               Duration="0:0:1">
-                <DoubleAnimation.EasingFunction>
-                    <QuadraticEase EasingMode="EaseIn"/>
-                </DoubleAnimation.EasingFunction>
-            </DoubleAnimation>
-        </Storyboard>
-
         <!-- Cover entrance animation -->
         <Storyboard x:Key="CoverEntranceAnimation">
             <DoubleAnimation
@@ -384,6 +358,9 @@
             </Border>
 
             <Grid x:Name="trackInfo">
+
+                <Grid>
+
                 <TextBlock x:Name="title" 
                        Text="{x:Bind PlayerViewModel.CurrentTrack.Title, Mode=OneWay}" 
                        VerticalAlignment="Bottom" 


### PR DESCRIPTION
Removed automatic backdrop rotation via DispatcherTimer and deleted fade-in/out Storyboard animations from XAML and code-behind. Now, a new backdrop is randomly selected on each track change, using Random.Shared, with simplified index management. If no artist-specific backdrop is available, a generic one is chosen. No more periodic rotation or fade transitions. Also, added an extra Grid wrapper around the "title" TextBlock in XAML for layout purposes. This streamlines backdrop handling and reduces UI complexity.