### PR TITLE
feat: add automatic text translation feature

### DIFF
--- a/Core/Rok.Application/Interfaces/ITranslateService.cs
+++ b/Core/Rok.Application/Interfaces/ITranslateService.cs
@@ -1,0 +1,8 @@
+﻿namespace Rok.Application.Interfaces;
+
+public interface ITranslateService
+{
+    bool IsEnable { get; set; }
+
+    Task<string?> TranslateAsync(string text, string targetLang, CancellationToken cancellationToken = default);
+}

--- a/Core/Rok.Application/Options/TranslateApiOptions.cs
+++ b/Core/Rok.Application/Options/TranslateApiOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Rok.Application.Options;
+
+public sealed class TranslateApiOptions
+{
+    public string? BaseAddress { get; set; } = "https://roktranslate-api.fpc-france.com";
+
+    public string? ApiKey { get; set; }
+}

--- a/Infrastructure/Rok.Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/Rok.Infrastructure/DependencyInjection.cs
@@ -13,6 +13,7 @@ using Rok.Infrastructure.Repositories;
 using Rok.Infrastructure.Social;
 using Rok.Infrastructure.Tag;
 using Rok.Infrastructure.Telemetry;
+using Rok.Infrastructure.Translate;
 using Serilog;
 using Serilog.Events;
 using Windows.Storage;
@@ -58,6 +59,7 @@ public static class DependencyInjection
 
         services.AddSingleton<ITagService, TagService>();
         services.AddSingleton<INovaApiService, NovaApiService>();
+        services.AddSingleton<ITranslateService, TranslateService>();
         services.AddSingleton<ILastFmClient, LastFmClient>();
         services.AddSingleton<ITelemetryClient, TelemetryClient>();
         services.AddSingleton<DiscordRichPresenceService>();

--- a/Infrastructure/Rok.Infrastructure/Translate/TranslateService.cs
+++ b/Infrastructure/Rok.Infrastructure/Translate/TranslateService.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Rok.Application.Interfaces;
+using Rok.Application.Options;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+
+namespace Rok.Infrastructure.Translate;
+
+public class TranslateService : ITranslateService
+{
+    private readonly HttpClient _httpClient;
+
+    private readonly ILogger<TranslateService> _logger;
+
+    public bool IsEnable { get; set; } = true;
+
+    private readonly TranslateApiOptions _apiOptions;
+
+    private readonly IAppOptions _appOptions;
+
+
+    public TranslateService(HttpClient httpClient, IAppOptions appOptions, IOptions<TranslateApiOptions> apiOptions, ILogger<TranslateService> logger)
+    {
+        _httpClient = httpClient;
+        _appOptions = appOptions;
+        _apiOptions = apiOptions.Value;
+        _logger = logger;
+
+        ConfigureHttpClient();
+    }
+
+
+    private void ConfigureHttpClient()
+    {
+        if (!_appOptions.NovaApiEnabled || _apiOptions.BaseAddress is null)
+        {
+            _logger.LogInformation("Translate API is disabled.");
+
+            IsEnable = false;
+            return;
+        }
+
+        _logger.LogInformation("Translate API is enabled.");
+
+        string appVersion = GetAppVersion();
+
+        _httpClient.BaseAddress = new Uri(_apiOptions.BaseAddress);
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", $"Rok/{appVersion}");
+        _httpClient.Timeout = TimeSpan.FromSeconds(30);
+    }
+
+
+    private static string GetAppVersion()
+    {
+        Assembly assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        return assembly.GetName().Version?.ToString() ?? "0.0.0";
+    }
+
+
+    public async Task<string?> TranslateAsync(string text, string targetLang, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(text))
+            return string.Empty;
+        if (string.IsNullOrEmpty(targetLang))
+            return text;
+        if (!IsEnable)
+            return text;
+
+        string sourceLang = "auto";
+
+        var payload = new
+        {
+            q = text,
+            source = sourceLang,
+            target = targetLang,
+            format = "text",
+            api_key = _apiOptions.ApiKey
+        };
+
+        string json = JsonSerializer.Serialize(payload);
+        using StringContent content = new(json, Encoding.UTF8, "application/json");
+
+        using HttpResponseMessage resp = await _httpClient.PostAsync("/translate", content, cancellationToken).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+            return null;
+
+        using Stream stream = await resp.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using JsonDocument doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        if (doc.RootElement.TryGetProperty("translatedText", out JsonElement translated))
+            return translated.GetString();
+
+        return string.Empty;
+
+        // {"detectedLanguage":{"confidence":90.0,"language":"en"},"translatedText":"Bonjour"}
+    }
+
+
+    public static string NormalizeLanguageForLibreTranslate(string? languageTag, string defaultLang = "fr")
+    {
+        if (string.IsNullOrWhiteSpace(languageTag))
+            return defaultLang;
+
+        try
+        {
+            CultureInfo culture = new(languageTag);
+            string two = culture.TwoLetterISOLanguageName?.ToLowerInvariant() ?? defaultLang;
+            return string.IsNullOrWhiteSpace(two) ? defaultLang : two;
+        }
+        catch (CultureNotFoundException)
+        {
+            string[] parts = languageTag.Split(new[] { '-' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0)
+                return defaultLang;
+
+            string primary = parts[0].ToLowerInvariant();
+            if (primary.Length == 2)
+                return primary;
+
+            return primary.Length >= 2 ? primary.Substring(0, 2) : defaultLang;
+        }
+    }
+}

--- a/Presentation/App.xaml.cs
+++ b/Presentation/App.xaml.cs
@@ -25,7 +25,7 @@ namespace Rok
             this.InitializeComponent();
 
 #if DEBUG
-            Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = "en";
+            Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = "fr";
 #endif
         }
 
@@ -105,6 +105,7 @@ namespace Rok
             services.AddSingleton<IConfiguration>(config);
             services.Configure<TelemetryOptions>(config.GetSection("Telemetry"));
             services.Configure<NovaApiOptions>(config.GetSection("NovaApi"));
+            services.Configure<TranslateApiOptions>(config.GetSection("TranslateApi"));
             services.Configure<DiscordOptions>(config.GetSection("Discord"));
 
             services.AddHttpClient();

--- a/Presentation/Logic/Services/DialogService.cs
+++ b/Presentation/Logic/Services/DialogService.cs
@@ -1,68 +1,284 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using Microsoft.UI;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation;
+using Windows.UI;
 using Windows.UI.Text;
 
 namespace Rok.Logic.Services;
 
-
-public sealed class DialogService : IDialogService
+public sealed class DialogService(ResourceLoader resourceLoader, ITranslateService translateService) : IDialogService
 {
-    public async Task ShowTextAsync(string title, string content, string closeButtonText)
+    public async Task ShowTextAsync(string title, string content, bool showTranslateButton = false, string targetLanguage = "fr")
     {
-        Func<Task> show = async Task () =>
+        string closeButtonText = resourceLoader.GetString("Close");
+        string translateButtonText = resourceLoader.GetString("Translate");
+        string originalButtonText = resourceLoader.GetString("Original");
+
+        Func<Task> show = async () =>
         {
             FrameworkElement? root = App.MainWindow.Content as FrameworkElement;
             ElementTheme theme = root?.ActualTheme ?? ElementTheme.Default;
 
-            ContentDialog dialog = new()
-            {
-                XamlRoot = root?.XamlRoot ?? App.MainWindow.Content.XamlRoot,
-                RequestedTheme = theme,
-                Title = title,
-                MinWidth = 800,
-                Width = 800,
-                Content = new ScrollViewer
-                {
-                    Content = new TextBlock
-                    {
-                        Text = content ?? string.Empty,
-                        TextWrapping = TextWrapping.Wrap,
-                        IsTextSelectionEnabled = true,
-                        FontStyle = FontStyle.Normal,
-                    },
-                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                    HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
-                    MaxHeight = 500,
-                    MinWidth = 800
-                },
-                CloseButtonText = closeButtonText,
-                DefaultButton = ContentDialogButton.Close
-            };
+            string originalText = content ?? string.Empty;
+            string? translatedText = null;
+            bool isShowingTranslated = false;
+            bool translating = false;
 
-            await dialog.ShowAsync();
+            TextBlock textBlock = CreateMainTextBlock(originalText);
+            ScrollViewer scrollViewer = CreateScrollViewer(textBlock);
+
+            Grid contentGrid = new();
+            contentGrid.Children.Add(scrollViewer);
+
+            (Grid? overlay, ProgressRing? progressRing) = CreateOverlay(resourceLoader.GetString("Translating") ?? "Translating...");
+            contentGrid.Children.Add(overlay);
+
+            ContentDialog dialog = CreateDialog(root, theme, title, contentGrid, closeButtonText);
+
+            contentGrid.MinWidth = dialog.MinWidth;
+            contentGrid.MinHeight = dialog.MinHeight;
+            scrollViewer.HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Stretch;
+            scrollViewer.MinWidth = contentGrid.MinWidth;
+
+            TypedEventHandler<ContentDialog, ContentDialogButtonClickEventArgs>? secondaryHandler = null;
+
+            void ShowOverlay()
+            {
+                overlay.Visibility = Visibility.Visible;
+                progressRing.IsActive = true;
+            }
+
+            void HideOverlay()
+            {
+                progressRing.IsActive = false;
+                overlay.Visibility = Visibility.Collapsed;
+            }
+
+            if (showTranslateButton)
+            {
+                string translateLabel = translateButtonText;
+                string originalLabel = originalButtonText;
+
+                dialog.SecondaryButtonText = translateLabel;
+                dialog.IsSecondaryButtonEnabled = true;
+
+                secondaryHandler = async (ContentDialog sender, ContentDialogButtonClickEventArgs args) =>
+                {
+                    if (translating)
+                    {
+                        args.Cancel = true;
+                        return;
+                    }
+
+                    if (translatedText != null)
+                    {
+                        args.Cancel = true;
+
+                        if (isShowingTranslated)
+                        {
+                            RunOnUi(() =>
+                            {
+                                textBlock.Text = originalText;
+                                dialog.SecondaryButtonText = translateLabel;
+                            });
+
+                            isShowingTranslated = false;
+                            return;
+                        }
+
+                        RunOnUi(() =>
+                        {
+                            textBlock.Text = translatedText!;
+                            dialog.SecondaryButtonText = originalLabel;
+                        });
+
+                        isShowingTranslated = true;
+                        return;
+                    }
+
+                    if (!translateService.IsEnable)
+                    {
+                        args.Cancel = true;
+                        return;
+                    }
+
+                    translating = true;
+                    args.Cancel = true;
+
+                    try
+                    {
+                        RunOnUi(() =>
+                        {
+                            ShowOverlay();
+                            dialog.IsSecondaryButtonEnabled = false;
+                        });
+
+                        string? result = await translateService.TranslateAsync(originalText, targetLanguage).ConfigureAwait(false);
+
+                        if (!string.IsNullOrEmpty(result))
+                        {
+                            translatedText = result;
+
+                            RunOnUi(() =>
+                            {
+                                textBlock.Text = translatedText;
+                                dialog.SecondaryButtonText = originalLabel;
+                            });
+
+                            isShowingTranslated = true;
+                        }
+                        else
+                        {
+                            RunOnUi(() => dialog.IsSecondaryButtonEnabled = true);
+                        }
+                    }
+                    catch
+                    {
+                        RunOnUi(() => dialog.IsSecondaryButtonEnabled = true);
+                    }
+                    finally
+                    {
+                        RunOnUi(() =>
+                        {
+                            HideOverlay();
+                            dialog.IsSecondaryButtonEnabled = true;
+                        });
+
+                        translating = false;
+                    }
+                };
+
+                dialog.SecondaryButtonClick += secondaryHandler;
+            }
+
+            try
+            {
+                await dialog.ShowAsync();
+            }
+            finally
+            {
+                if (secondaryHandler != null)
+                    dialog.SecondaryButtonClick -= secondaryHandler;
+            }
         };
 
+        await RunOnUiAsync(show);
+    }
+
+
+    private static TextBlock CreateMainTextBlock(string text)
+    {
+        return new TextBlock
+        {
+            Text = text ?? string.Empty,
+            TextWrapping = TextWrapping.Wrap,
+            IsTextSelectionEnabled = true,
+            FontStyle = FontStyle.Normal
+        };
+    }
+
+
+    private static ScrollViewer CreateScrollViewer(UIElement content)
+    {
+        return new ScrollViewer
+        {
+            Content = content,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            MaxHeight = 500,
+            MinWidth = 760
+        };
+    }
+
+
+    private static (Grid overlay, ProgressRing progressRing) CreateOverlay(string translatingLabelText)
+    {
+        ProgressRing progressRing = new()
+        {
+            IsActive = false,
+            Width = 36,
+            Height = 36,
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+
+        TextBlock translatingLabel = new()
+        {
+            Text = translatingLabelText,
+            Margin = new Thickness(8, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = new SolidColorBrush(Colors.White)
+        };
+
+        StackPanel overlayContent = new()
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        overlayContent.Children.Add(progressRing);
+        overlayContent.Children.Add(translatingLabel);
+
+        Grid overlay = new()
+        {
+            Background = new SolidColorBrush(Color.FromArgb(96, 0, 0, 0)),
+            Visibility = Visibility.Collapsed,
+            IsHitTestVisible = true
+        };
+        overlay.Children.Add(overlayContent);
+
+        return (overlay, progressRing);
+    }
+
+
+    private static ContentDialog CreateDialog(FrameworkElement? root, ElementTheme theme, string title, object contentGrid, string closeButtonText)
+    {
+        return new ContentDialog
+        {
+            XamlRoot = root?.XamlRoot ?? App.MainWindow.Content.XamlRoot,
+            RequestedTheme = theme,
+            Title = title,
+            MinHeight = 300,
+            MinWidth = 300,
+            Content = contentGrid,
+            CloseButtonText = closeButtonText,
+            DefaultButton = ContentDialogButton.Close
+        };
+    }
+
+
+    private static void RunOnUi(Action action)
+    {
         if (App.MainWindow.DispatcherQueue.HasThreadAccess)
         {
-            await show();
+            action();
+            return;
         }
-        else
+
+        _ = App.MainWindow.DispatcherQueue.TryEnqueue(() => action());
+    }
+
+    private static Task RunOnUiAsync(Func<Task> func)
+    {
+        if (App.MainWindow.DispatcherQueue.HasThreadAccess)
+            return func();
+
+        TaskCompletionSource<object?> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _ = App.MainWindow.DispatcherQueue.TryEnqueue(() =>
         {
-            TaskCompletionSource tcs = new();
-
-            _ = App.MainWindow.DispatcherQueue.TryEnqueue(async () =>
+            Task task = func();
+            task.ContinueWith(t =>
             {
-                try
-                {
-                    await show();
-                    tcs.SetResult();
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            });
+                if (t.IsFaulted)
+                    tcs.SetException(t.Exception!.Flatten());
+                else if (t.IsCanceled)
+                    tcs.SetCanceled();
+                else
+                    tcs.SetResult(null);
+            }, TaskScheduler.Default);
+        });
 
-            await tcs.Task;
-        }
+        return tcs.Task;
     }
 }

--- a/Presentation/Logic/Services/IDialogService.cs
+++ b/Presentation/Logic/Services/IDialogService.cs
@@ -2,5 +2,5 @@
 
 public interface IDialogService
 {
-    Task ShowTextAsync(string title, string content, string closeButtonText);
+    Task ShowTextAsync(string title, string content, bool showTranslateButton = false, string targetLanguage = "fr");
 }

--- a/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
+++ b/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using Rok.Application.Randomizer;
+using Rok.Infrastructure.Translate;
 using Rok.Logic.Services.Player;
 using Rok.Logic.ViewModels.Albums;
 using Rok.Logic.ViewModels.Artist.Services;
+using Rok.Logic.ViewModels.Track.Services;
 using Rok.Logic.ViewModels.Tracks;
 
 namespace Rok.Logic.ViewModels.Artists;
@@ -18,6 +20,7 @@ public partial class ArtistViewModel : ObservableObject
     private readonly ILastFmClient _lastFmClient;
     private readonly IBackdropLoader _backdropLoader;
     private readonly IDialogService _dialogService;
+    private readonly IAppOptions _appOptions;
 
     private readonly ArtistDataLoader _dataLoader;
     private readonly ArtistPictureService _pictureService;
@@ -229,6 +232,7 @@ public partial class ArtistViewModel : ObservableObject
         ArtistApiService apiService,
         ArtistStatisticsService statisticsService,
         ArtistEditService editService,
+        IAppOptions appOptions,
         ILogger<ArtistViewModel> logger)
     {
         _backdropLoader = Guard.Against.Null(backdropLoader);
@@ -242,6 +246,7 @@ public partial class ArtistViewModel : ObservableObject
         _apiService = Guard.Against.Null(apiService);
         _statisticsService = Guard.Against.Null(statisticsService);
         _editService = Guard.Against.Null(editService);
+        _appOptions = Guard.Against.Null(appOptions);
         _logger = Guard.Against.Null(logger);
 
         GenreOpenCommand = new RelayCommand(() => { });
@@ -422,6 +427,11 @@ public partial class ArtistViewModel : ObservableObject
     private async Task OpenBiographyAsync()
     {
         if (!string.IsNullOrEmpty(Artist.Biography))
-            await _dialogService.ShowTextAsync(Artist.Name, Artist.Biography, _resourceLoader.GetString("Close"));
+        {
+            string? rawLanguage = Windows.Globalization.ApplicationLanguages.Languages.FirstOrDefault();
+            string language = TranslateService.NormalizeLanguageForLibreTranslate(rawLanguage, "fr");
+
+            await _dialogService.ShowTextAsync(Artist.Name, Artist.Biography, showTranslateButton: _appOptions.NovaApiEnabled, language);
+        }
     }
 }

--- a/Presentation/Logic/ViewModels/Main/MainViewModel.cs
+++ b/Presentation/Logic/ViewModels/Main/MainViewModel.cs
@@ -71,7 +71,7 @@ public partial class MainViewModel : ObservableObject
         {
             string message = _resourceLoader.GetString("NoLibraryFoldersMessage");
             string title = _resourceLoader.GetString("NoLibraryFoldersTitleMessage");
-            _dialogService.ShowTextAsync(title, message, "OK");
+            _dialogService.ShowTextAsync(title, message);
             return false;
         }
 

--- a/Presentation/Logic/ViewModels/Track/Services/TrackLyricsService.cs
+++ b/Presentation/Logic/ViewModels/Track/Services/TrackLyricsService.cs
@@ -8,6 +8,7 @@ public class TrackLyricsService(
     IMediator mediator,
     ILyricsService lyricsService,
     INovaApiService novaApiService,
+    ITranslateService translateService,
     ILogger<TrackLyricsService> logger)
 {
     public bool CheckLyricsExists(string musicFile)

--- a/Presentation/Logic/ViewModels/Track/TrackViewModel.cs
+++ b/Presentation/Logic/ViewModels/Track/TrackViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.UI.Dispatching;
 using Rok.Application.Dto.Lyrics;
 using Rok.Application.Features.Playlists.PlaylistMenu;
+using Rok.Infrastructure.Translate;
 using Rok.Logic.Services.Player;
 using Rok.Logic.ViewModels.Track.Services;
 
@@ -12,7 +13,7 @@ public partial class TrackViewModel : ObservableObject, IDisposable
     private readonly IPlayerService _playerService;
     private readonly IDialogService _dialogService;
     private readonly IBackdropLoader _backdropLoader;
-
+    private readonly IAppOptions _appOptions;
     private readonly TrackDetailDataLoader _dataLoader;
     private readonly TrackLyricsService _lyricsService;
     private readonly TrackScoreService _scoreService;
@@ -189,6 +190,7 @@ public partial class TrackViewModel : ObservableObject, IDisposable
         TrackLyricsService lyricsService,
         TrackScoreService scoreService,
         TrackNavigationService navigationService,
+        IAppOptions appOptions,
         ILogger<TrackViewModel> logger)
     {
         _backdropLoader = Guard.Against.Null(backdropLoader);
@@ -200,6 +202,7 @@ public partial class TrackViewModel : ObservableObject, IDisposable
         _lyricsService = Guard.Against.Null(lyricsService);
         _scoreService = Guard.Against.Null(scoreService);
         _navigationService = Guard.Against.Null(navigationService);
+        _appOptions = Guard.Against.Null(appOptions);
 
         ArtistOpenCommand = new RelayCommand(ArtistOpen);
         AlbumOpenCommand = new RelayCommand(AlbumOpen);
@@ -268,8 +271,15 @@ public partial class TrackViewModel : ObservableObject, IDisposable
         await LoadLyricsAsync();
 
         if (!string.IsNullOrEmpty(PlainLyrics))
-            await _dialogService.ShowTextAsync($"{ArtistName} - {Title}", PlainLyrics, _resourceLoader.GetString("Close"));
+        {
+            string? rawLanguage = Windows.Globalization.ApplicationLanguages.Languages.FirstOrDefault();
+            string language = TranslateService.NormalizeLanguageForLibreTranslate(rawLanguage, "fr");
+
+            await _dialogService.ShowTextAsync($"{ArtistName} - {Title}", PlainLyrics, showTranslateButton: _appOptions.NovaApiEnabled, language);
+        }
     }
+
+
 
     public async Task LoadLyricsAsync()
     {

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1128,4 +1128,10 @@
   <data name="smartPlaylistHeader.Text" xml:space="preserve">
     <value>Smart playlists</value>
   </data>
+  <data name="Translate" xml:space="preserve">
+    <value>Translate</value>
+  </data>
+  <data name="Original" xml:space="preserve">
+    <value>Original</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1128,4 +1128,10 @@
   <data name="smartPlaylistHeader.Text" xml:space="preserve">
     <value>Smart playlists</value>
   </data>
+  <data name="Translate" xml:space="preserve">
+    <value>Traduire</value>
+  </data>
+  <data name="Original" xml:space="preserve">
+    <value>Originale</value>
+  </data>
 </root>


### PR DESCRIPTION
Add TranslateService with external API integration and configuration. Update dependency injection to support translation. DialogService now supports "Translate" button for text dialogs. Artist and Track ViewModels offer translation for biography and lyrics. Add new resource strings for translation UI in English and French. Default debug language switched from "en" to "fr". Pass app options and translation service to relevant ViewModels. Allows users to dynamically translate displayed texts. Improves user experience for multilingual audiences.