### PR TITLE
feat(api): make API key configurable in MusicDataApiOptions

### DIFF
--- a/Core/Rok.Application/Options/MusicDataApiOptions.cs
+++ b/Core/Rok.Application/Options/MusicDataApiOptions.cs
@@ -3,4 +3,6 @@
 public sealed class MusicDataApiOptions
 {
     public string? BaseAddress { get; set; }
+
+    public string? ApiKey { get; set; }
 }

--- a/Infrastructure/Rok.Infrastructure/MusicData/MusicDataApiService.cs
+++ b/Infrastructure/Rok.Infrastructure/MusicData/MusicDataApiService.cs
@@ -62,7 +62,7 @@ public class MusicDataApiService : IMusicDataApiService, IDisposable
 
     private void ConfigureHttpClient()
     {
-        if (!_appOptions.NovaApiEnabled || _musicDataApiOptions.BaseAddress is null)
+        if (!_appOptions.NovaApiEnabled || _musicDataApiOptions.BaseAddress is null || _musicDataApiOptions.ApiKey is null)
         {
             _logger.LogInformation("RoK Music API is disabled.");
 
@@ -77,7 +77,7 @@ public class MusicDataApiService : IMusicDataApiService, IDisposable
         _httpClient.BaseAddress = new Uri(_musicDataApiOptions.BaseAddress);
         _httpClient.DefaultRequestHeaders.Add("User-Agent", $"Rok/{appVersion}");
         _httpClient.Timeout = TimeSpan.FromSeconds(10);
-        _httpClient.DefaultRequestHeaders.Add("X-Api-Key", "73407c42-ba4d-54da-8131-1b8ce0b1e6f1");
+        _httpClient.DefaultRequestHeaders.Add("X-Api-Key", _musicDataApiOptions.ApiKey);
     }
 
 


### PR DESCRIPTION
Added an ApiKey property to MusicDataApiOptions to allow API key configuration. Updated MusicDataApiService to check that ApiKey is not null before enabling the API client. Replaced the hardcoded API key in HTTP headers with the value from MusicDataApiOptions. This improves security and flexibility by allowing the API key to be set via configuration rather than code. Also ensures the service is only enabled when both BaseAddress and ApiKey are provided. No breaking changes to existing consumers.