### PR TITLE
feat(playlist): add album/artist to playlist support

### DIFF
--- a/Core/Rok.Application/Features/Playlists/Command/AddAlbumToPlaylistCommandHandler.cs
+++ b/Core/Rok.Application/Features/Playlists/Command/AddAlbumToPlaylistCommandHandler.cs
@@ -1,0 +1,79 @@
+﻿using System.Transactions;
+using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Playlists.Command;
+
+public class AddAlbumToPlaylistCommand : ICommand<Result<long>>
+{
+    public long PlaylistId { get; set; }
+
+    public long AlbumId { get; set; }
+}
+
+
+public class AddAlbumToPlaylistCommandHandler(IPlaylistTrackRepository _repository, IPlaylistHeaderRepository _playlistHeaderRepository, ITrackRepository _trackRepository) : ICommandHandler<AddAlbumToPlaylistCommand, Result<long>>
+{
+    public async Task<Result<long>> HandleAsync(AddAlbumToPlaylistCommand message, CancellationToken cancellationToken)
+    {
+        IEnumerable<TrackEntity> tracks = await _trackRepository.GetByAlbumIdAsync(message.AlbumId);
+        if (tracks == null)
+            return Result<long>.Fail("Track not found.");
+
+        PlaylistHeaderEntity? playlistHeader = await _playlistHeaderRepository.GetByIdAsync(message.PlaylistId);
+        if (playlistHeader == null)
+            return Result<long>.Fail("Playlist not found.");
+
+        int addCount = 0;
+
+        using TransactionScope scope = new(TransactionScopeAsyncFlowOption.Enabled);
+
+        try
+        {
+            foreach (TrackEntity track in tracks)
+            {
+                long existingId = await _repository.GetAsync(message.PlaylistId, track.Id);
+                if (existingId <= 0)
+                {
+                    await AddTrackToPlaylistAsync(message.PlaylistId, track.Id);
+                    await UpdatePlaylistHeaderAsync(playlistHeader, track);
+
+                    addCount++;
+                }
+            }
+
+            scope.Complete();
+        }
+        catch (Exception)
+        {
+            scope.Dispose();
+            return Result<long>.Fail("Failed to add track to playlist due to an error.");
+        }
+
+        if (addCount > 0)
+            return Result<long>.Success(addCount);
+        else
+            return Result<long>.Fail("Failed to add tracks to playlist.");
+    }
+
+
+    private async Task<long> AddTrackToPlaylistAsync(long playlistId, long trackId)
+    {
+        PlaylistTrackEntity playlistTrackEntity = new()
+        {
+            PlaylistId = playlistId,
+            TrackId = trackId
+        };
+
+        return await _repository.AddAsync(playlistTrackEntity);
+    }
+
+
+    private async Task UpdatePlaylistHeaderAsync(PlaylistHeaderEntity playlistHeader, TrackEntity track)
+    {
+        playlistHeader.Duration += track.Duration;
+        playlistHeader.TrackCount += 1;
+        playlistHeader.EditDate = DateTime.UtcNow;
+
+        await _playlistHeaderRepository.UpdateAsync(playlistHeader);
+    }
+}

--- a/Core/Rok.Application/Features/Playlists/Command/AddArtistToPlaylistCommandHandler.cs
+++ b/Core/Rok.Application/Features/Playlists/Command/AddArtistToPlaylistCommandHandler.cs
@@ -1,0 +1,79 @@
+﻿using System.Transactions;
+using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Playlists.Command;
+
+public class AddArtistToPlaylistCommand : ICommand<Result<long>>
+{
+    public long PlaylistId { get; set; }
+
+    public long ArtistId { get; set; }
+}
+
+
+public class AddArtistToPlaylistCommandHandler(IPlaylistTrackRepository _repository, IPlaylistHeaderRepository _playlistHeaderRepository, ITrackRepository _trackRepository) : ICommandHandler<AddArtistToPlaylistCommand, Result<long>>
+{
+    public async Task<Result<long>> HandleAsync(AddArtistToPlaylistCommand message, CancellationToken cancellationToken)
+    {
+        IEnumerable<TrackEntity> tracks = await _trackRepository.GetByArtistIdAsync(message.ArtistId);
+        if (tracks == null)
+            return Result<long>.Fail("Track not found.");
+
+        PlaylistHeaderEntity? playlistHeader = await _playlistHeaderRepository.GetByIdAsync(message.PlaylistId);
+        if (playlistHeader == null)
+            return Result<long>.Fail("Playlist not found.");
+
+        int addCount = 0;
+
+        using TransactionScope scope = new(TransactionScopeAsyncFlowOption.Enabled);
+
+        try
+        {
+            foreach (TrackEntity track in tracks)
+            {
+                long existingId = await _repository.GetAsync(message.PlaylistId, track.Id);
+                if (existingId <= 0)
+                {
+                    await AddTrackToPlaylistAsync(message.PlaylistId, track.Id);
+                    await UpdatePlaylistHeaderAsync(playlistHeader, track);
+
+                    addCount++;
+                }
+            }
+
+            scope.Complete();
+        }
+        catch (Exception)
+        {
+            scope.Dispose();
+            return Result<long>.Fail("Failed to add track to playlist due to an error.");
+        }
+
+        if (addCount > 0)
+            return Result<long>.Success(addCount);
+        else
+            return Result<long>.Fail("Failed to add tracks to playlist.");
+    }
+
+
+    private async Task<long> AddTrackToPlaylistAsync(long playlistId, long trackId)
+    {
+        PlaylistTrackEntity playlistTrackEntity = new()
+        {
+            PlaylistId = playlistId,
+            TrackId = trackId
+        };
+
+        return await _repository.AddAsync(playlistTrackEntity);
+    }
+
+
+    private async Task UpdatePlaylistHeaderAsync(PlaylistHeaderEntity playlistHeader, TrackEntity track)
+    {
+        playlistHeader.Duration += track.Duration;
+        playlistHeader.TrackCount += 1;
+        playlistHeader.EditDate = DateTime.UtcNow;
+
+        await _playlistHeaderRepository.UpdateAsync(playlistHeader);
+    }
+}

--- a/Core/Rok.Application/Features/Playlists/PlaylistMenu/IPlaylistMenuService.cs
+++ b/Core/Rok.Application/Features/Playlists/PlaylistMenu/IPlaylistMenuService.cs
@@ -8,5 +8,13 @@ public interface IPlaylistMenuService
 
     Task AddTrackToPlaylistAsync(long playlistId, long trackId);
 
+    Task AddAlbumToPlaylistAsync(long playlistId, long albumId);
+
+    Task AddArtistToPlaylistAsync(long playlistId, long artistId);
+
     Task CreateNewPlaylistWithTrackAsync(string playlistName, long trackId);
+
+    Task CreateNewPlaylistWithAlbumAsync(string playlistName, long albumId);
+
+    Task CreateNewPlaylistWithArtistAsync(string playlistName, long artistId);
 }

--- a/Presentation/Commons/FullScreenControl.xaml.cs
+++ b/Presentation/Commons/FullScreenControl.xaml.cs
@@ -1,7 +1,7 @@
+using System.Threading;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
 using Rok.Logic.ViewModels.Player;
-using System.Threading;
 
 namespace Rok.Commons;
 

--- a/Presentation/Logic/ViewModels/Album/AlbumViewModel.cs
+++ b/Presentation/Logic/ViewModels/Album/AlbumViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Rok.Infrastructure.Translate;
+﻿using Rok.Application.Features.Playlists.PlaylistMenu;
+using Rok.Infrastructure.Translate;
 using Rok.Logic.Services.Player;
 using Rok.Logic.ViewModels.Album.Services;
 using Rok.Logic.ViewModels.Tracks;
@@ -11,7 +12,6 @@ public partial class AlbumViewModel : ObservableObject
     private readonly ResourceLoader _resourceLoader;
     private readonly IPlayerService _playerService;
     private readonly ILogger<AlbumViewModel> _logger;
-    private readonly ILastFmClient _lastFmClient;
     private readonly IBackdropLoader _backdropLoader;
     private readonly IDialogService _dialogService;
     private readonly IAppOptions _appOptions;
@@ -27,7 +27,7 @@ public partial class AlbumViewModel : ObservableObject
 
     private IEnumerable<TrackDto>? _tracks = null;
 
-    public bool LastFmPageAvailable { get => !string.IsNullOrWhiteSpace(Album.LastFmUrl); }
+    public IPlaylistMenuService PlaylistMenuService { get; }
 
     public bool IsFavorite
     {
@@ -154,10 +154,10 @@ public partial class AlbumViewModel : ObservableObject
         AlbumEditService editService,
         IAppOptions appOptions,
         IDialogService dialogService,
+        IPlaylistMenuService playlistMenuService,
         ILogger<AlbumViewModel> logger)
     {
         _backdropLoader = Guard.Against.Null(backdropLoader);
-        _lastFmClient = Guard.Against.Null(lastFmClient);
         _navigationService = Guard.Against.Null(navigationService);
         _playerService = Guard.Against.Null(playerService);
         _resourceLoader = Guard.Against.Null(resourceLoader);
@@ -168,6 +168,7 @@ public partial class AlbumViewModel : ObservableObject
         _editService = Guard.Against.Null(editService);
         _appOptions = Guard.Against.Null(appOptions);
         _dialogService = Guard.Against.Null(dialogService);
+        PlaylistMenuService = Guard.Against.Null(playlistMenuService);
         _logger = Guard.Against.Null(logger);
 
         ListenCommand = new AsyncRelayCommand(ListenAsync);

--- a/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
+++ b/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Rok.Application.Randomizer;
+﻿using Rok.Application.Features.Playlists.PlaylistMenu;
+using Rok.Application.Randomizer;
 using Rok.Infrastructure.Translate;
 using Rok.Logic.Services.Player;
 using Rok.Logic.ViewModels.Albums;
@@ -32,8 +33,7 @@ public partial class ArtistViewModel : ObservableObject
 
     private IEnumerable<TrackDto>? _tracks = null;
 
-    public bool LastFmPageAvailable { get => !string.IsNullOrWhiteSpace(Artist.LastFmUrl); }
-
+    public IPlaylistMenuService PlaylistMenuService { get; }
     public bool IsFavorite
     {
         get => Artist.IsFavorite;
@@ -230,6 +230,7 @@ public partial class ArtistViewModel : ObservableObject
         ArtistStatisticsService statisticsService,
         ArtistEditService editService,
         IAppOptions appOptions,
+        IPlaylistMenuService playlistMenuService,
         ILogger<ArtistViewModel> logger)
     {
         _backdropLoader = Guard.Against.Null(backdropLoader);
@@ -243,6 +244,7 @@ public partial class ArtistViewModel : ObservableObject
         _statisticsService = Guard.Against.Null(statisticsService);
         _editService = Guard.Against.Null(editService);
         _appOptions = Guard.Against.Null(appOptions);
+        PlaylistMenuService = Guard.Against.Null(playlistMenuService);
         _logger = Guard.Against.Null(logger);
 
         GenreOpenCommand = new RelayCommand(() => { });

--- a/Presentation/Package.appxmanifest
+++ b/Presentation/Package.appxmanifest
@@ -7,12 +7,12 @@
          IgnorableNamespaces="uap rescap uap3">
 
 	<Identity
-	  Name="Rokapp.Rokmusicplayer"
+	  Name="dev-Rokapp.Rokmusicplayer"
 	  Publisher="CN=C9A55691-54ED-46EA-9D4F-F3CD41C04242"
 	  Version="1.1.10.0" />
 
 	<Properties>
-		<DisplayName>Rok musicplayer</DisplayName>
+		<DisplayName>Rok musicplayer (dev)</DisplayName>
 		<PublisherDisplayName>Rok app</PublisherDisplayName>
 		<Logo>Assets\StoreLogo.png</Logo>
 	</Properties>

--- a/Presentation/Pages/AlbumPage.xaml
+++ b/Presentation/Pages/AlbumPage.xaml
@@ -185,11 +185,17 @@
                                   Icon="Library"
                                   Command="{x:Bind ViewModel.OpenBiographyCommand}"
                                   Visibility="{x:Bind ViewModel.Album.Biography, Converter={StaticResource StringToVisibilityConverter}}" />
-
+                                        
                     <AppBarButton x:Uid="albumViewPlaylist"
                                   Style="{StaticResource headerGenericButton}"
-                                  Icon="Add"
-                                  Visibility="Collapsed" />
+                                  Icon="Add">
+                        <AppBarButton.Flyout>
+                            <MenuFlyout x:Name="albumPlaylistFlyout"
+                                        common:MenuFlyoutExtensions.PlaylistMenuService="{x:Bind ViewModel.PlaylistMenuService}"
+                                        common:MenuFlyoutExtensions.AlbumId="{x:Bind ViewModel.Album.Id}"
+                                        common:MenuFlyoutExtensions.FlattenPlaylistMenu="True" />
+                        </AppBarButton.Flyout>
+                    </AppBarButton>
 
                     <AppBarButton x:Uid="albumViewEdit"
                                   Style="{StaticResource headerGenericButton}"

--- a/Presentation/Pages/ArtistPage.xaml
+++ b/Presentation/Pages/ArtistPage.xaml
@@ -269,6 +269,18 @@
                                   Visibility="Collapsed"                                    
                                   IsEnabled="False"/>
 
+                    <AppBarButton x:Uid="albumViewPlaylist"
+                                  Style="{StaticResource headerGenericButton}"
+                                  Icon="Add">
+                        <AppBarButton.Flyout>
+                            <MenuFlyout x:Name="albumPlaylistFlyout"
+                                        common:MenuFlyoutExtensions.PlaylistMenuService="{x:Bind ViewModel.PlaylistMenuService}"
+                                        common:MenuFlyoutExtensions.ArtistId="{x:Bind ViewModel.Artist.Id}"
+                                        common:MenuFlyoutExtensions.FlattenPlaylistMenu="True" />
+                        </AppBarButton.Flyout>
+                    </AppBarButton>
+
+
                     <AppBarButton x:Uid="artistViewEdit"
                                   Style="{StaticResource headerGenericButton}"
                                   Icon="Edit"

--- a/Presentation/Pages/ListeningPage.xaml
+++ b/Presentation/Pages/ListeningPage.xaml
@@ -305,18 +305,6 @@
                               Command="{x:Bind ViewModel.ShufflePlaylistCommand}" />
 
                 <AppBarSeparator />
-
-                <!--<AppBarButton x:Uid="artistViewWebSite"
-                              Style="{StaticResource headerGenericButton}"
-                              Icon="World"
-                              Command="{x:Bind ViewModel.Artist.OpenOfficielSiteCommand}"
-                              Visibility="{x:Bind ViewModel.Artist.Artist.OfficialSiteUrl, Converter={StaticResource StringToVisibilityConverter}}" />-->
-
-                <!--<AppBarButton x:Uid="artistViewLastFm"
-                              Style="{StaticResource headerGenericButton}"
-                              Icon="MusicInfo"
-                              Command="{x:Bind ViewModel.Artist.OpenLastFmPageCommand, Mode=OneWay}"
-                              Visibility="{x:Bind ViewModel.Artist.LastFmPageAvailable, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />-->
             </CommandBar>
         </RelativePanel>
 


### PR DESCRIPTION
Add ability to add an entire album or artist to a playlist, in addition to single tracks. Extend IPlaylistMenuService and PlaylistMenuService with async methods for albums/artists. Implement AddAlbumToPlaylistCommand and AddArtistToPlaylistCommand handlers. Update MenuFlyoutExtensions to support AlbumId, ArtistId, and menu flattening. Expose playlist menu in AlbumPage and ArtistPage with new "Add to playlist" button. Inject IPlaylistMenuService into AlbumViewModel and ArtistViewModel. Improve menu handler cleanup and robustness.
Update app manifest to indicate dev version.
No functional changes to ListeningPage.xaml (comments only). Enables quick addition of all tracks from an album or artist to playlists via UI.