### PR TITLE
feat(playlist): add drag & drop track reordering support

### DIFF
--- a/Core/Rok.Application/Features/Playlists/Command/MovePlaylistTracksCommandHandler.cs
+++ b/Core/Rok.Application/Features/Playlists/Command/MovePlaylistTracksCommandHandler.cs
@@ -1,0 +1,52 @@
+﻿using System.Transactions;
+using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Playlists.Command;
+
+public class MovePlaylistTracksCommand : ICommand<Result<bool>>
+{
+    public long PlaylistId { get; set; }
+
+    public List<long> Tracks { get; set; } = [];
+}
+
+
+public class MovePlaylistTracksCommandHandler(IPlaylistTrackRepository _repository) : ICommandHandler<MovePlaylistTracksCommand, Result<bool>>
+{
+    public async Task<Result<bool>> HandleAsync(MovePlaylistTracksCommand message, CancellationToken cancellationToken)
+    {
+        using TransactionScope scope = new(TransactionScopeAsyncFlowOption.Enabled);
+
+        try
+        {
+            IEnumerable<PlaylistTrackEntity> currentTracksEnumerable = await _repository.GetAsync(message.PlaylistId);
+            List<PlaylistTrackEntity> currentTracks = currentTracksEnumerable.ToList();
+
+            Dictionary<long, PlaylistTrackEntity> byTrackId = currentTracks.ToDictionary(t => t.TrackId);
+
+            for (int newIndex = 0; newIndex < message.Tracks.Count; newIndex++)
+            {
+                long trackId = message.Tracks[newIndex];
+
+                if (!byTrackId.TryGetValue(trackId, out PlaylistTrackEntity playlistTrack))
+                    continue;
+
+                if (playlistTrack.Position == newIndex)
+                    continue;
+
+                long rowsAffected = await _repository.UpdatePositionAsync(playlistTrack.Id, newIndex, RepositoryConnectionKind.Foreground);
+                if (rowsAffected <= 0)
+                    throw new InvalidOperationException("Failed to update track position in playlist.");
+            }
+
+            scope.Complete();
+        }
+        catch (Exception)
+        {
+            scope.Dispose();
+            return Result<bool>.Fail("Failed to move tracks in playlist due to an error.");
+        }
+
+        return Result<bool>.Success(true);
+    }
+}

--- a/Core/Rok.Application/Interfaces/IPlaylistTrackGenerateRepository.cs
+++ b/Core/Rok.Application/Interfaces/IPlaylistTrackGenerateRepository.cs
@@ -1,12 +1,8 @@
-﻿namespace Rok.Application.Interfaces;
+﻿using Rok.Application.Features.Playlists.Query;
 
-public interface IPlaylistTrackRepository
+namespace Rok.Application.Interfaces;
+
+public interface IPlaylistTrackGenerateRepository
 {
-    Task<long> AddAsync(PlaylistTrackEntity entity, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
-
-    Task<long> DeleteAsync(long playlistId, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
-
-    Task<long> DeleteAsync(long playlistId, long trackId, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
-
-    Task<long> GetAsync(long playlistId, long trackId, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+    Task<List<TrackEntity>> GenerateAsync(GeneratePlaylistTracksQuery request, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 }

--- a/Core/Rok.Application/Interfaces/IPlaylistTrackRepository.cs
+++ b/Core/Rok.Application/Interfaces/IPlaylistTrackRepository.cs
@@ -1,8 +1,16 @@
-﻿using Rok.Application.Features.Playlists.Query;
+﻿namespace Rok.Application.Interfaces;
 
-namespace Rok.Application.Interfaces;
-
-public interface IPlaylistTrackGenerateRepository
+public interface IPlaylistTrackRepository
 {
-    Task<List<TrackEntity>> GenerateAsync(GeneratePlaylistTracksQuery request, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+    Task<long> AddAsync(PlaylistTrackEntity entity, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
+    Task<long> UpdatePositionAsync(long id, int position, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
+    Task<long> DeleteAsync(long playlistId, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
+    Task<long> DeleteAsync(long playlistId, long trackId, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
+    Task<long> GetAsync(long playlistId, long trackId, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
+
+    Task<IEnumerable<PlaylistTrackEntity>> GetAsync(long playlistId, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground);
 }

--- a/Infrastructure/Rok.Infrastructure/Repositories/PlaylistTrackRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/PlaylistTrackRepository.cs
@@ -10,7 +10,8 @@ public class PlaylistTrackRepository(IDbConnection connection, [FromKeyedService
     private const string DeleteSql = "DELETE FROM playlisttracks WHERE playlistid = @playlistId";
     private const string DeleteTrackSql = "DELETE FROM playlisttracks WHERE playlistid = @playlistId AND trackid = @trackId";
     private const string SelectSql = "SELECT id FROM playlisttracks WHERE playlistid = @playlistId AND trackid = @trackId";
-
+    private const string SelectTracksSql = "SELECT * FROM playlisttracks WHERE playlistid = @playlistId";
+    private const string UpdatePositionSql = "UPDATE playlisttracks SET position = @position WHERE id = @id";
 
     public async Task<long> AddAsync(PlaylistTrackEntity entity, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
     {
@@ -34,5 +35,17 @@ public class PlaylistTrackRepository(IDbConnection connection, [FromKeyedService
     {
         IDbConnection localConnection = ResolveConnection(kind);
         return await localConnection.ExecuteScalarAsync<int>(SelectSql, new { playlistId, trackId });
+    }
+
+    public async Task<IEnumerable<PlaylistTrackEntity>> GetAsync(long playlistId, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
+    {
+        IDbConnection localConnection = ResolveConnection(kind);
+        return await localConnection.QueryAsync<PlaylistTrackEntity>(SelectTracksSql, new { playlistId });
+    }
+
+    public async Task<long> UpdatePositionAsync(long id, int position, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
+    {
+        IDbConnection localConnection = ResolveConnection(kind);
+        return await localConnection.ExecuteAsync(UpdatePositionSql, new { id, position });
     }
 }

--- a/Presentation/Logic/ViewModels/Playlist/PlaylistViewModel.cs
+++ b/Presentation/Logic/ViewModels/Playlist/PlaylistViewModel.cs
@@ -101,6 +101,8 @@ public partial class PlaylistViewModel : ObservableObject
     public AsyncRelayCommand DeleteCommand { get; private set; }
     public AsyncRelayCommand<long> RemoveFromPlaylistCommand { get; private set; }
     public AsyncRelayCommand<List<PlaylistGroupDto>> SavePlaylistCommand { get; private set; }
+    public AsyncRelayCommand MoveTrackCommand { get; private set; }
+
 
     public PlaylistViewModel(
         IBackdropLoader backdropLoader,
@@ -129,6 +131,7 @@ public partial class PlaylistViewModel : ObservableObject
         DeleteCommand = new AsyncRelayCommand(DeletePlaylistAsync);
         RemoveFromPlaylistCommand = new AsyncRelayCommand<long>(RemoveTrackAsync);
         SavePlaylistCommand = new AsyncRelayCommand<List<PlaylistGroupDto>>((c) => SavePlaylistAsync(forceUpdate: true, c));
+        MoveTrackCommand = new AsyncRelayCommand(async () => await MoveTrackAsync());
     }
 
 
@@ -211,6 +214,17 @@ public partial class PlaylistViewModel : ObservableObject
             LoadPicture();
             OnPropertyChanged();
         }
+    }
+
+    private async Task MoveTrackAsync()
+    {
+        if (Tracks.Count == 0)
+            return;
+
+        if (Playlist.Id == 0)
+            return;
+
+        await _updateService.SaveTracksPositionAsync(Playlist.Id, Tracks.Select(c => c.Track.Id).ToList());
     }
 
     private async Task ListenAsync()

--- a/Presentation/Logic/ViewModels/Playlist/Services/PlaylistUpdateService.cs
+++ b/Presentation/Logic/ViewModels/Playlist/Services/PlaylistUpdateService.cs
@@ -98,4 +98,17 @@ public class PlaylistUpdateService(
         logger.LogError("Failed to delete playlist: {Name}. Error: {Error}", playlistName, result.Error);
         return false;
     }
+
+    public async Task<bool> SaveTracksPositionAsync(long playlistId, List<long> tracks)
+    {
+        Result<bool> result = await mediator.SendMessageAsync(new MovePlaylistTracksCommand { PlaylistId = playlistId, Tracks = tracks });
+        if (result.IsSuccess)
+        {
+            Messenger.Send(new PlaylistUpdatedMessage(playlistId, ActionType.Delete));
+            return true;
+        }
+
+        logger.LogError("Failed to update playlist: {PlaylistId}. Error: {Error}", playlistId, result.Error);
+        return false;
+    }
 }

--- a/Presentation/Pages/PlaylistPage.xaml
+++ b/Presentation/Pages/PlaylistPage.xaml
@@ -102,7 +102,11 @@
                                      Grid.Row="1"
                                      Margin="6,12,0,0"
                                      ItemsSource="{x:Bind ViewModel.Tracks}"    
-                                     IsItemClickEnabled="True">
+                                     IsItemClickEnabled="True"
+                                     CanDragItems="True"
+                                     CanReorderItems="True"  
+                                     DragItemsCompleted="tracksList_DragItemsCompleted"
+                                     AllowDrop="True" >
 
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="track:TrackViewModel">
@@ -151,6 +155,7 @@
 
                             <StackPanel Grid.Column="0"
                                         Orientation="Horizontal">
+                                
                                 <HyperlinkButton Style="{StaticResource gridTracksTitleText}"
                                                  Command="{x:Bind ListenCommand}"
                                                  CommandParameter="{x:Bind}" />

--- a/Presentation/Pages/PlaylistPage.xaml.cs
+++ b/Presentation/Pages/PlaylistPage.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using Rok.Logic.ViewModels.Playlist;
 using Rok.Logic.ViewModels.Playlists;
+using Rok.Logic.ViewModels.Tracks;
 
 namespace Rok.Pages;
 
@@ -9,6 +10,8 @@ public sealed partial class PlaylistPage : Page
 {
     public PlaylistViewModel ViewModel { get; set; }
     private readonly ResourceLoader _resourceLoader;
+    private readonly TrackViewModel? _draggedItem;
+    private readonly int _draggedIndex = -1;
 
     public PlaylistPage()
     {
@@ -46,5 +49,13 @@ public sealed partial class PlaylistPage : Page
 
         if (result == ContentDialogResult.Primary && ViewModel.DeleteCommand.CanExecute(null))
             ViewModel.DeleteCommand.Execute(null);
+    }
+
+    private void tracksList_DragItemsCompleted(ListViewBase sender, DragItemsCompletedEventArgs args)
+    {
+        if (args.DropResult == Windows.ApplicationModel.DataTransfer.DataPackageOperation.Move)
+        {
+            ViewModel.MoveTrackCommand.Execute(null);
+        }
     }
 }


### PR DESCRIPTION
Backend: add MovePlaylistTracksCommand and handler to update track positions. Expose UpdatePositionAsync and playlist track retrieval in repository. Implement SaveTracksPositionAsync in service to persist order. Frontend: enable drag & drop in ListView for track reordering. Add MoveTrackCommand in ViewModel, triggered on drag completion. Refactor interfaces to separate track generation and management. Fix parameter handling for track deletion and retrieval. Add button to play track from playlist.
Allows users to reorder playlist tracks and saves changes to database.