### PR TITLE
Fix cbValue DisplayMemberPath to use "Value" property

### DIFF
--- a/Presentation/Commons/PlaylistGroupFilter.xaml.cs
+++ b/Presentation/Commons/PlaylistGroupFilter.xaml.cs
@@ -1,5 +1,5 @@
-using Microsoft.UI.Xaml.Controls;
 using System.Globalization;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Rok.Commons;
 
@@ -419,7 +419,7 @@ public sealed partial class PlaylistGroupFilter : UserControl
         nbValue2.Visibility = Visibility.Collapsed;
 
         cbValue.ItemsSource = LoadBoolValues();
-        cbValue.DisplayMemberPath = DisplayMemberValuePath;
+        cbValue.DisplayMemberPath = "Value";
         cbValue.SelectedValuePath = SelectedValuePath;
 
         cbValue.SelectedIndex = 0;


### PR DESCRIPTION
Corrected the DisplayMemberPath of the cbValue ComboBox to use the literal string "Value" instead of the DisplayMemberValuePath variable. This ensures that the Value property of each item is displayed correctly in the ComboBox. Previously, if DisplayMemberValuePath was not set or was incorrect, the displayed values could be wrong or empty. No other functional changes were made in this commit.