### PR TITLE
refactor(playlist-filter): update field labels for clarity

### DIFF
--- a/Presentation/Commons/PlaylistGroupFilter.xaml.cs
+++ b/Presentation/Commons/PlaylistGroupFilter.xaml.cs
@@ -217,8 +217,8 @@ public sealed partial class PlaylistGroupFilter : UserControl
                 fields.Add(new FieldOption(SmartPlaylistField.SkipCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldSkipCount")));
                 fields.Add(new FieldOption(SmartPlaylistField.Year, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldYear")));
                 fields.Add(new FieldOption(SmartPlaylistField.ReleaseDate, SmartPlaylistFieldType.Day, _resourceLoader.GetString("playlistGroupFieldReleaseDate")));
-                fields.Add(new FieldOption(SmartPlaylistField.IsBestof, SmartPlaylistFieldType.Bool, _resourceLoader.GetString("playlistGroupFieldBestof")));
-                fields.Add(new FieldOption(SmartPlaylistField.IsCompilation, SmartPlaylistFieldType.Bool, _resourceLoader.GetString("playlistGroupFieldCompilation")));
+                fields.Add(new FieldOption(SmartPlaylistField.IsBestof, SmartPlaylistFieldType.Bool, _resourceLoader.GetString("playlistGroupFieldBestofCount")));
+                fields.Add(new FieldOption(SmartPlaylistField.IsCompilation, SmartPlaylistFieldType.Bool, _resourceLoader.GetString("playlistGroupFieldCompilationCount")));
                 fields.Add(new FieldOption(SmartPlaylistField.IsLive, SmartPlaylistFieldType.Bool, _resourceLoader.GetString("playlistGroupFieldLive")));
                 fields.Add(new FieldOption(SmartPlaylistField.Name, SmartPlaylistFieldType.String, _resourceLoader.GetString("playlistGroupFieldName")));
                 break;

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -526,13 +526,13 @@
     <value>Favorite</value>
   </data>
   <data name="playlistGroupFieldAlbumCount" xml:space="preserve">
-    <value>Album count</value>
+    <value>Studio album</value>
   </data>
   <data name="playlistGroupFieldBestofCount" xml:space="preserve">
-    <value>Best of count</value>
+    <value>Best of</value>
   </data>
   <data name="playlistGroupFieldCompilationCount" xml:space="preserve">
-    <value>Compilation count</value>
+    <value>Compilation</value>
   </data>
   <data name="playlistGroupFieldTrackCount" xml:space="preserve">
     <value>Track count</value>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -526,13 +526,13 @@
     <value>Favoris</value>
   </data>
   <data name="playlistGroupFieldAlbumCount" xml:space="preserve">
-    <value>Nombre d'albums</value>
+    <value>Album studio</value>
   </data>
   <data name="playlistGroupFieldBestofCount" xml:space="preserve">
-    <value>Nombre de bestof</value>
+    <value>Best of</value>
   </data>
   <data name="playlistGroupFieldCompilationCount" xml:space="preserve">
-    <value>Nombre de compilations</value>
+    <value>Compilations</value>
   </data>
   <data name="playlistGroupFieldTrackCount" xml:space="preserve">
     <value>Nombre de titres</value>


### PR DESCRIPTION
Field labels for playlist filters have been updated for better clarity and conciseness. Resource keys for "Best of" and "Compilation" fields now use the new strings ("playlistGroupFieldBestofCount" and "playlistGroupFieldCompilationCount"). Resource values in both English and French have been simplified: "Album count" is now "Studio album", "Best of count" is now "Best of", and "Compilation count" is now "Compilation".
These changes improve the user interface by making field names clearer and more consistent across languages.