### PR TITLE
feat(smart-playlist): improve track ordering & max track editing

### DIFF
--- a/Infrastructure/Rok.Infrastructure/Repositories/PlaylistTrackGenerateRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/PlaylistTrackGenerateRepository.cs
@@ -1,11 +1,10 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Rok.Application.Dto;
 using Rok.Application.Features.Playlists.Query;
 using Rok.Application.Interfaces;
 using Rok.Shared.Enums;
-using Rok.Shared.Extensions;
-using System.Text;
 
 namespace Rok.Infrastructure.Repositories;
 
@@ -42,8 +41,8 @@ public class PlaylistTrackGenerateRepository(IDbConnection db, [FromKeyedService
 
         List<TrackEntity> rows = (await ExecuteQueryAsync(query.ToString(), kind, parameters)).ToList();
 
-        if (rows.Count > 0)
-            rows.Shuffle();
+        //if (rows.Count > 0)
+        //    rows.Shuffle();
 
         return rows;
     }
@@ -281,10 +280,10 @@ public class PlaylistTrackGenerateRepository(IDbConnection db, [FromKeyedService
                 query.Append(" ORDER BY RANDOM() ");
                 break;
             case SmartPlaylistSelectBy.Newest:
-                query.Append(" ORDER BY tracks.creatdate DESC, RANDOM() ");
+                query.Append(" ORDER BY tracks.creatdate DESC ");
                 break;
             case SmartPlaylistSelectBy.Oldest:
-                query.Append(" ORDER BY tracks.creatdate ASC, RANDOM() ");
+                query.Append(" ORDER BY tracks.creatdate ASC ");
                 break;
             case SmartPlaylistSelectBy.MostPlayed:
                 query.Append(" ORDER BY tracks.listencount DESC, RANDOM() ");
@@ -299,10 +298,10 @@ public class PlaylistTrackGenerateRepository(IDbConnection db, [FromKeyedService
                 query.Append(" ORDER BY tracks.score ASC, RANDOM() ");
                 break;
             case SmartPlaylistSelectBy.MostRecent:
-                query.Append(" ORDER BY tracks.lastlisten DESC, RANDOM() ");
+                query.Append(" ORDER BY tracks.lastlisten DESC ");
                 break;
             case SmartPlaylistSelectBy.LeastRecent:
-                query.Append(" ORDER BY tracks.lastlisten ASC, RANDOM() ");
+                query.Append(" ORDER BY tracks.lastlisten ASC ");
                 break;
             default:
                 query.Append(" ORDER BY RANDOM() ");

--- a/Presentation/Commons/PlaylistGroupFilter.xaml.cs
+++ b/Presentation/Commons/PlaylistGroupFilter.xaml.cs
@@ -190,7 +190,7 @@ public sealed partial class PlaylistGroupFilter : UserControl
                 fields.Add(new FieldOption(SmartPlaylistField.IsLive, SmartPlaylistFieldType.Bool, _resourceLoader.GetString("playlistGroupFieldLive")));
                 fields.Add(new FieldOption(SmartPlaylistField.CreatDate, SmartPlaylistFieldType.Day, _resourceLoader.GetString("playlistGroupFieldAddDate")));
                 fields.Add(new FieldOption(SmartPlaylistField.Bitrate, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldBitrate")));
-                fields.Add(new FieldOption(SmartPlaylistField.LastListen, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldLastListen")));
+                fields.Add(new FieldOption(SmartPlaylistField.LastListen, SmartPlaylistFieldType.Day, _resourceLoader.GetString("playlistGroupFieldLastListen")));
                 fields.Add(new FieldOption(SmartPlaylistField.SkipCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldSkipCount")));
                 fields.Add(new FieldOption(SmartPlaylistField.Name, SmartPlaylistFieldType.String, _resourceLoader.GetString("playlistGroupFieldName")));
                 break;
@@ -203,7 +203,7 @@ public sealed partial class PlaylistGroupFilter : UserControl
                 fields.Add(new FieldOption(SmartPlaylistField.BestofCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldBestofCount")));
                 fields.Add(new FieldOption(SmartPlaylistField.CompilationCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldCompilationCount")));
                 fields.Add(new FieldOption(SmartPlaylistField.TrackCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldTrackCount")));
-                fields.Add(new FieldOption(SmartPlaylistField.LastListen, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldLastListen")));
+                fields.Add(new FieldOption(SmartPlaylistField.LastListen, SmartPlaylistFieldType.Day, _resourceLoader.GetString("playlistGroupFieldLastListen")));
                 fields.Add(new FieldOption(SmartPlaylistField.SkipCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldSkipCount")));
                 fields.Add(new FieldOption(SmartPlaylistField.Name, SmartPlaylistFieldType.String, _resourceLoader.GetString("playlistGroupFieldName")));
                 break;
@@ -213,7 +213,7 @@ public sealed partial class PlaylistGroupFilter : UserControl
                 fields.Add(new FieldOption(SmartPlaylistField.ListenCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldListenCount")));
                 fields.Add(new FieldOption(SmartPlaylistField.CreatDate, SmartPlaylistFieldType.Day, _resourceLoader.GetString("playlistGroupFieldAddDate")));
                 fields.Add(new FieldOption(SmartPlaylistField.TrackCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldTrackCount")));
-                fields.Add(new FieldOption(SmartPlaylistField.LastListen, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldLastListen")));
+                fields.Add(new FieldOption(SmartPlaylistField.LastListen, SmartPlaylistFieldType.Day, _resourceLoader.GetString("playlistGroupFieldLastListen")));
                 fields.Add(new FieldOption(SmartPlaylistField.SkipCount, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldSkipCount")));
                 fields.Add(new FieldOption(SmartPlaylistField.Year, SmartPlaylistFieldType.Int, _resourceLoader.GetString("playlistGroupFieldYear")));
                 fields.Add(new FieldOption(SmartPlaylistField.ReleaseDate, SmartPlaylistFieldType.Day, _resourceLoader.GetString("playlistGroupFieldReleaseDate")));

--- a/Presentation/Logic/ViewModels/Playlist/PlaylistViewModel.cs
+++ b/Presentation/Logic/ViewModels/Playlist/PlaylistViewModel.cs
@@ -35,7 +35,18 @@ public partial class PlaylistViewModel : ObservableObject
         }
     }
 
-    public int TrackMaximum => Playlist.TrackMaximum;
+    public int TrackMaximum
+    {
+        get
+        {
+            return Playlist.TrackMaximum;
+        }
+        set
+        {
+            Playlist.TrackMaximum = value;
+        }
+    }
+
     public int TrackCount => Playlist.TrackCount;
 
     public int ArtistCount

--- a/Presentation/Pages/SmartPlaylistPage.xaml
+++ b/Presentation/Pages/SmartPlaylistPage.xaml
@@ -75,7 +75,7 @@
                     <StackPanel Orientation="Horizontal">
                         <TextBlock x:Uid="PlaylistTrackCount" VerticalAlignment="Center" Margin="0,0,8,0" Text="Nombre de titres :"></TextBlock>
                         <NumberBox VerticalAlignment="Center"
-                                   Text="{x:Bind ViewModel.TrackMaximum, Mode=OneWay}" Width="50" HorizontalAlignment="Left"></NumberBox>
+                                   Text="{x:Bind ViewModel.TrackMaximum, Mode=TwoWay}" Width="50" HorizontalAlignment="Left"></NumberBox>
                     </StackPanel>
 
                     <StackPanel Grid.Row="1" Orientation="Horizontal" VerticalAlignment="Top">


### PR DESCRIPTION
Refactor SQL ordering for smart playlists to remove extra shuffling and ensure date-based sorting is strict for "Newest", "Oldest", "MostRecent", and "LeastRecent". Change "LastListen" field type from Int to Day for better date handling. Make TrackMaximum property editable in PlaylistViewModel and bind it two-way in the UI, allowing users to set the max track count directly. Clean up usings and dependencies in repository.
These changes improve consistency and user control in smart playlist features.