### PR TITLE
feat(db): add country name column and enhance country filters

### DIFF
--- a/Infrastructure/Rok.Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/Rok.Infrastructure/DependencyInjection.cs
@@ -48,6 +48,7 @@ public static class DependencyInjection
         services.AddSingleton<IMigrationService, MigrationService>();
         services.AddSingleton<IMigration, Migration2>();
         services.AddSingleton<IMigration, Migration3>();
+        services.AddSingleton<IMigration, Migration4>();
 
         services.AddScoped<IArtistRepository, ArtistRepository>();
         services.AddScoped<IAlbumRepository, AlbumRepository>();

--- a/Infrastructure/Rok.Infrastructure/Migration/Migration4.cs
+++ b/Infrastructure/Rok.Infrastructure/Migration/Migration4.cs
@@ -1,0 +1,13 @@
+﻿namespace Rok.Infrastructure.Migration;
+
+public class Migration4 : IMigration
+{
+    public int TargetVersion => 4;
+
+    public void Apply(IDbConnection connection)
+    {
+        connection.Execute("ALTER TABLE Countries ADD COLUMN name TEXT NULL;");
+
+        connection.Execute("UPDATE Countries SET name = english;");
+    }
+}

--- a/Infrastructure/Rok.Infrastructure/Repositories/PlaylistTrackGenerateRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/PlaylistTrackGenerateRepository.cs
@@ -22,7 +22,7 @@ public class PlaylistTrackGenerateRepository(IDbConnection db, [FromKeyedService
         HandleNameFilter(group.Filters.Where(c => c.Entity == SmartPlaylistEntity.Genres && c.Field == SmartPlaylistField.Name && !string.IsNullOrEmpty(c.Value)), query, parameters);
         HandleNameFilter(group.Filters.Where(c => c.Entity == SmartPlaylistEntity.Artists && c.Field == SmartPlaylistField.Name && !string.IsNullOrEmpty(c.Value)), query, parameters);
         HandleNameFilter(group.Filters.Where(c => c.Entity == SmartPlaylistEntity.Albums && c.Field == SmartPlaylistField.Name && !string.IsNullOrEmpty(c.Value)), query, parameters);
-        HandleNameFilter(group.Filters.Where(c => c.Entity == SmartPlaylistEntity.Countries && c.Field == SmartPlaylistField.Code && !string.IsNullOrEmpty(c.Value)), query, parameters);
+        HandleNameFilter(group.Filters.Where(c => c.Entity == SmartPlaylistEntity.Countries && (c.Field == SmartPlaylistField.Code || c.Field == SmartPlaylistField.Name) && !string.IsNullOrEmpty(c.Value)), query, parameters);
 
         HandleIntFilter(group.Filters.Where(c => c.FieldType == SmartPlaylistFieldType.Int && c.Operator != SmartPlaylistOperator.Between), query, parameters);
         HandleBoolFilter(group.Filters.Where(c => c.FieldType == SmartPlaylistFieldType.Bool && c.Operator != SmartPlaylistOperator.Between), query, parameters);

--- a/Presentation/Commons/PlaylistGroupFilter.xaml.cs
+++ b/Presentation/Commons/PlaylistGroupFilter.xaml.cs
@@ -235,6 +235,7 @@ public sealed partial class PlaylistGroupFilter : UserControl
                 break;
 
             case SmartPlaylistEntity.Countries:
+                fields.Add(new FieldOption(SmartPlaylistField.Code, SmartPlaylistFieldType.String, _resourceLoader.GetString("playlistGroupFieldCode")));
                 fields.Add(new FieldOption(SmartPlaylistField.Name, SmartPlaylistFieldType.String, _resourceLoader.GetString("playlistGroupFieldName")));
                 break;
         }


### PR DESCRIPTION
Added Migration4 to introduce a nullable 'name' column in the Countries table, populated from the existing 'english' column. Registered Migration4 in DI for automatic migration handling. Updated smart playlist filters to allow filtering countries by both 'Code' and 'Name' fields. The 'Code' field is now available as a filter option for countries in the playlist group filter UI. This improves flexibility and usability when filtering tracks by country attributes.