### PR TITLE
Add unit label for day fields in PlaylistGroupFilter

### DIFF
--- a/Presentation/Commons/PlaylistGroupFilter.xaml
+++ b/Presentation/Commons/PlaylistGroupFilter.xaml
@@ -1,30 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<UserControl
-    x:Class="Rok.Commons.PlaylistGroupFilter"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Rok.Commons"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    d:DesignHeight="300"
-    d:DesignWidth="400"
-    mc:Ignorable="d">
+<UserControl x:Class="Rok.Commons.PlaylistGroupFilter"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:Rok.Commons"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             d:DesignHeight="300"
+             d:DesignWidth="400"
+             mc:Ignorable="d">
 
     <Grid>
-        <StackPanel  Orientation="Horizontal" VerticalAlignment="Top">
-            <ComboBox x:Name="cbEntities" SelectionChanged="EntitiesSelectionChanged" Margin="0,0,10,0"></ComboBox>
-            <ComboBox x:Name="cbFields" SelectionChanged="FieldsSelectionChanged" Margin="0,0,10,0"></ComboBox>
-            <ComboBox x:Name="cbOperators" SelectionChanged="OperatorsSelectionChanged" Margin="0,0,10,0"></ComboBox>
+        <StackPanel  Orientation="Horizontal"
+                     VerticalAlignment="Top">
+            <ComboBox x:Name="cbEntities"
+                      SelectionChanged="EntitiesSelectionChanged"
+                      Margin="0,0,10,0"></ComboBox>
+            <ComboBox x:Name="cbFields"
+                      SelectionChanged="FieldsSelectionChanged"
+                      Margin="0,0,10,0"></ComboBox>
+            <ComboBox x:Name="cbOperators"
+                      SelectionChanged="OperatorsSelectionChanged"
+                      Margin="0,0,10,0"></ComboBox>
 
-            <ComboBox x:Name="cbValue" Visibility="Collapsed"></ComboBox>
-            <TextBox x:Name="tbValue" Visibility="Collapsed"></TextBox>
-            <NumberBox x:Name="nbValue" Visibility="Collapsed"></NumberBox>
-            <NumberBox x:Name="nbValue2" Visibility="Collapsed"></NumberBox>
+            <ComboBox x:Name="cbValue"
+                      Visibility="Collapsed"></ComboBox>
+            <TextBox x:Name="tbValue"
+                     Visibility="Collapsed"></TextBox>
+            <NumberBox x:Name="nbValue"
+                       Visibility="Collapsed"></NumberBox>
+            <NumberBox x:Name="nbValue2"
+                       Visibility="Collapsed"></NumberBox>
 
-            <Button x:Name="filterNew" Click="FilterNew_Click" Margin="10,0,10,0">
+            <TextBlock x:Name="lbUnit"
+                       VerticalAlignment="Center"
+                       Margin="6,0,0,0"
+                       Visibility="Collapsed" />
+
+            <AppBarSeparator Margin="10,0,10,0"></AppBarSeparator>
+            
+            <Button x:Name="filterNew"
+                    Click="FilterNew_Click"
+                    Margin="0,0,10,0">
                 <SymbolIcon Symbol="Add"></SymbolIcon>
             </Button>
-            <Button x:Name="filterRemove" Click="FilterRemove_Click">
+            <Button x:Name="filterRemove"
+                    Click="FilterRemove_Click">
                 <SymbolIcon Symbol="Delete"></SymbolIcon>
             </Button>
         </StackPanel>

--- a/Presentation/Commons/PlaylistGroupFilter.xaml.cs
+++ b/Presentation/Commons/PlaylistGroupFilter.xaml.cs
@@ -42,10 +42,14 @@ public sealed partial class PlaylistGroupFilter : UserControl
             cbEntities.SelectedItem = ((IEnumerable<EntityOption>)cbEntities.ItemsSource).FirstOrDefault(f => f.Key == value.Entity);
 
             LoadFieldsList(value.Entity);
-            cbFields.SelectedItem = ((IEnumerable<FieldOption>)cbFields.ItemsSource).FirstOrDefault(f => f.Key == value.Field);
+            FieldOption field = ((IEnumerable<FieldOption>)cbFields.ItemsSource).FirstOrDefault(f => f.Key == value.Field)!;
+            cbFields.SelectedItem = field;
+            SetUnit(field);
 
             LoadOperatorList(value.Field);
             cbOperators.SelectedItem = ((IEnumerable<OperatorOption>)cbOperators.ItemsSource).FirstOrDefault(f => f.Key == value.Operator);
+
+
 
             Value = value.Value ?? string.Empty;
             Value2 = value.Value2 ?? string.Empty;
@@ -235,7 +239,6 @@ public sealed partial class PlaylistGroupFilter : UserControl
                 break;
 
             case SmartPlaylistEntity.Countries:
-                fields.Add(new FieldOption(SmartPlaylistField.Code, SmartPlaylistFieldType.String, _resourceLoader.GetString("playlistGroupFieldCode")));
                 fields.Add(new FieldOption(SmartPlaylistField.Name, SmartPlaylistFieldType.String, _resourceLoader.GetString("playlistGroupFieldName")));
                 break;
         }
@@ -258,9 +261,10 @@ public sealed partial class PlaylistGroupFilter : UserControl
         if (e.AddedItems.Count == 1 && e.RemovedItems.Count == 1 && ((FieldOption)e.AddedItems[0]).Key == ((FieldOption)e.RemovedItems[0]).Key)
             return;
 
-        SmartPlaylistField field = ((FieldOption)cbFields.SelectedItem).Key;
+        FieldOption fieldOption = (FieldOption)cbFields.SelectedItem;
 
-        LoadOperatorList(field);
+        LoadOperatorList(fieldOption.Key);
+        SetUnit(fieldOption);
     }
 
 
@@ -314,6 +318,22 @@ public sealed partial class PlaylistGroupFilter : UserControl
         cbOperators.DisplayMemberPath = DisplayMemberValuePath;
 
         cbOperators.SelectedIndex = 0;
+    }
+
+
+    private void SetUnit(FieldOption field)
+    {
+        switch (field.FieldType)
+        {
+            case SmartPlaylistFieldType.Day:
+                lbUnit.Text = _resourceLoader.GetString("playlistGroupFieldUnitDays");
+                lbUnit.Visibility = Visibility.Visible;
+                break;
+
+            default:
+                lbUnit.Visibility = Visibility.Collapsed;
+                break;
+        }
     }
 
 

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1125,4 +1125,7 @@
   <data name="Original" xml:space="preserve">
     <value>Original</value>
   </data>
+  <data name="playlistGroupFieldUnitDays" xml:space="preserve">
+    <value>days</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1125,4 +1125,7 @@
   <data name="Original" xml:space="preserve">
     <value>Originale</value>
   </data>
+  <data name="playlistGroupFieldUnitDays" xml:space="preserve">
+    <value>jours</value>
+  </data>
 </root>


### PR DESCRIPTION
Added a unit label ("days"/"jours") next to the value input when filtering on fields of type Day in PlaylistGroupFilter. Introduced SetUnit method to manage the label's visibility and content based on the selected field. Updated XAML to include a hidden TextBlock for the unit. Added localized resources for the unit label in English and French. Improved XAML formatting for readability. Also, removed the "Code" field from the Countries entity field list.