### PR TITLE
feat: add genre page, navigation and favorite support

### DIFF
--- a/Core/Rok.Application/Features/Albums/Query/GetAlbumsByGenreIdQueryHandler.cs
+++ b/Core/Rok.Application/Features/Albums/Query/GetAlbumsByGenreIdQueryHandler.cs
@@ -3,10 +3,10 @@ using Rok.Domain.Interfaces.Entities;
 
 namespace Rok.Application.Features.Albums.Query;
 
-public class GetAlbumsByGenreIdQuery(int genreId) : IQuery<IEnumerable<AlbumDto>>
+public class GetAlbumsByGenreIdQuery(long genreId) : IQuery<IEnumerable<AlbumDto>>
 {
     [RequiredGreaterThanZero]
-    public int GenreId { get; } = genreId;
+    public long GenreId { get; } = genreId;
 }
 
 

--- a/Core/Rok.Application/Features/Genres/Command/UpdateGenreFavoriteCommandHandler.cs
+++ b/Core/Rok.Application/Features/Genres/Command/UpdateGenreFavoriteCommandHandler.cs
@@ -1,0 +1,24 @@
+﻿using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Genres.Command;
+
+public class UpdateGenreFavoriteCommand(long id, bool isFavorite) : ICommand<Result<bool>>
+{
+    [RequiredGreaterThanZero]
+    public long Id { get; init; } = id;
+
+    public bool IsFavorite { get; init; } = isFavorite;
+}
+
+public class UpdateGenreFavoriteCommandHandler(IGenreRepository _genreRepository) : ICommandHandler<UpdateGenreFavoriteCommand, Result<bool>>
+{
+    public async Task<Result<bool>> HandleAsync(UpdateGenreFavoriteCommand message, CancellationToken cancellationToken)
+    {
+        bool result = await _genreRepository.UpdateFavoriteAsync(message.Id, message.IsFavorite);
+
+        if (result)
+            return Result<bool>.Success(result);
+        else
+            return Result<bool>.Fail("Failed to update genre favorite status.");
+    }
+}

--- a/Core/Rok.Application/Features/Tracks/Query/GetTracksByGenreIdQueryHandler.cs
+++ b/Core/Rok.Application/Features/Tracks/Query/GetTracksByGenreIdQueryHandler.cs
@@ -2,10 +2,10 @@
 
 namespace Rok.Application.Features.Tracks.Query;
 
-public class GetTracksByGenreIdQuery(int genreId) : IQuery<IEnumerable<TrackDto>>
+public class GetTracksByGenreIdQuery(long genreId) : IQuery<IEnumerable<TrackDto>>
 {
     [RequiredGreaterThanZero]
-    public int GenreId { get; } = genreId;
+    public long GenreId { get; } = genreId;
 }
 
 

--- a/Presentation/DependencyInjection.cs
+++ b/Presentation/DependencyInjection.cs
@@ -9,6 +9,8 @@ using Rok.Logic.ViewModels.Artist.Services;
 using Rok.Logic.ViewModels.Artists;
 using Rok.Logic.ViewModels.Artists.Handlers;
 using Rok.Logic.ViewModels.Artists.Services;
+using Rok.Logic.ViewModels.Genre;
+using Rok.Logic.ViewModels.Genre.Services;
 using Rok.Logic.ViewModels.Listening;
 using Rok.Logic.ViewModels.Listening.Services;
 using Rok.Logic.ViewModels.Main;
@@ -75,6 +77,11 @@ public static class DependencyInjection
         services.AddTransient<AlbumApiService>();
         services.AddTransient<AlbumStatisticsService>();
         services.AddTransient<AlbumEditService>();
+
+        // Genre ViewModel and services
+        services.AddTransient<GenreViewModel>();
+        services.AddTransient<GenreDataLoader>();
+        services.AddTransient<GenreEditService>();
 
         // Artists ViewModel, services and handlers
         services.AddSingleton<ArtistsViewModel>();

--- a/Presentation/Logic/Services/NavigationService.cs
+++ b/Presentation/Logic/Services/NavigationService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.UI.Xaml.Controls;
 using Rok.Logic.ViewModels.Album;
 using Rok.Logic.ViewModels.Artist;
+using Rok.Logic.ViewModels.Genre;
 using Rok.Logic.ViewModels.Playlist;
 using Rok.Logic.ViewModels.Search;
 using Rok.Logic.ViewModels.Track;
@@ -48,6 +49,15 @@ public class NavigationService(ITelemetryClient telemetryClient)
         _ = telemetryClient.CaptureScreenAsync("AlbumPage");
 
         MainFrame.Navigate(typeof(AlbumPage), new AlbumOpenArgs(albumId));
+    }
+
+    public void NavigateToGenre(long genreId)
+    {
+        Guard.Against.NegativeOrZero(genreId);
+
+        _ = telemetryClient.CaptureScreenAsync("GenrePage");
+
+        MainFrame.Navigate(typeof(GenrePage), new GenreOpenArgs(genreId));
     }
 
 

--- a/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
+++ b/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
@@ -101,7 +101,7 @@ public partial class ArtistViewModel : ObservableObject
                 if (Artist.CompilationCount > 1)
                     label += _resourceLoader.GetString("compilations");
                 else
-                    label += _resourceLoader.GetString("live");
+                    label += _resourceLoader.GetString("compilation");
                 separator = ", ";
             }
 
@@ -247,7 +247,7 @@ public partial class ArtistViewModel : ObservableObject
         PlaylistMenuService = Guard.Against.Null(playlistMenuService);
         _logger = Guard.Against.Null(logger);
 
-        GenreOpenCommand = new RelayCommand(() => { });
+        GenreOpenCommand = new RelayCommand(GenreOpen);
         ListenCommand = new AsyncRelayCommand(ListenAsync);
         ArtistsByCountryOpenCommand = new RelayCommand(() => { });
         ArtistFavoriteCommand = new AsyncRelayCommand(UpdateFavoriteStateAsync);
@@ -339,6 +339,12 @@ public partial class ArtistViewModel : ObservableObject
     private void ArtistOpen()
     {
         _navigationService.NavigateToArtist(Artist.Id);
+    }
+
+    private void GenreOpen()
+    {
+        if (Artist.GenreId.HasValue)
+            _navigationService.NavigateToGenre(Artist.GenreId.Value);
     }
 
     private async Task ListenAsync()

--- a/Presentation/Logic/ViewModels/Genre/GenreOpenArgs.cs
+++ b/Presentation/Logic/ViewModels/Genre/GenreOpenArgs.cs
@@ -1,0 +1,6 @@
+﻿namespace Rok.Logic.ViewModels.Genre;
+
+internal class GenreOpenArgs(long genreId)
+{
+    public long GenreId { get; } = genreId;
+}

--- a/Presentation/Logic/ViewModels/Genre/GenreViewModel.cs
+++ b/Presentation/Logic/ViewModels/Genre/GenreViewModel.cs
@@ -1,0 +1,255 @@
+﻿using Rok.Application.Randomizer;
+using Rok.Logic.Services.Player;
+using Rok.Logic.ViewModels.Albums;
+using Rok.Logic.ViewModels.Artist.Services;
+using Rok.Logic.ViewModels.Genre.Services;
+
+namespace Rok.Logic.ViewModels.Genre;
+
+public class GenreViewModel : ObservableObject
+{
+    private static string FallbackPictureUri => App.Current.Resources["ArtistFallbackPictureUri"] as string ?? "ms-appx:///Assets/artistFallback.png";
+    private static BitmapImage FallbackPicture => new(new Uri(FallbackPictureUri));
+
+    private readonly NavigationService _navigationService;
+    private readonly ResourceLoader _resourceLoader;
+    private readonly IPlayerService _playerService;
+    private readonly GenreDataLoader _dataLoader;
+    private readonly ILogger<GenreViewModel> _logger;
+    private readonly IBackdropLoader _backdropLoader;
+    private readonly ArtistPictureService _pictureService;
+    private readonly GenreEditService _editService;
+
+    public RangeObservableCollection<AlbumViewModel> Albums { get; set; } = [];
+
+    public GenreDto Genre { get; private set; } = new();
+
+    public bool IsFavorite
+    {
+        get => Genre.IsFavorite;
+        set
+        {
+            if (Genre.IsFavorite != value)
+            {
+                Genre.IsFavorite = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private BitmapImage? _picture = null;
+    public BitmapImage Picture
+    {
+        get
+        {
+            return _picture ?? FallbackPicture;
+        }
+        set
+        {
+            _picture = value;
+            OnPropertyChanged(nameof(Picture));
+            OnPropertyChanged(nameof(IsPictureAvailable));
+        }
+    }
+
+    public bool IsPictureAvailable
+    {
+        get
+        {
+            return _picture != null && _picture.UriSource != FallbackPicture.UriSource;
+        }
+    }
+
+    private BitmapImage? _backdrop = null;
+    public BitmapImage? Backdrop
+    {
+        get => _backdrop;
+        set
+        {
+            _backdrop = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string SubTitle
+    {
+        get
+        {
+            string label = "";
+            string separator = "";
+
+            if (Genre.TrackCount > 0)
+            {
+                label += $"{Genre.TrackCount} ";
+
+                if (Genre.TrackCount > 1)
+                    label += _resourceLoader.GetString("tracks");
+                else
+                    label += _resourceLoader.GetString("track");
+                separator = ", ";
+            }
+
+            if (Genre.AlbumCount > 0)
+            {
+                label += $"{separator}{Genre.AlbumCount} ";
+                if (Genre.AlbumCount > 1)
+                    label += _resourceLoader.GetString("albums");
+                else
+                    label += _resourceLoader.GetString("album");
+                separator = ", ";
+            }
+
+            if (Genre.BestofCount > 0)
+            {
+                label += $"{separator}{Genre.BestofCount} ";
+                if (Genre.BestofCount > 1)
+                    label += _resourceLoader.GetString("bestOf");
+                else
+                    label += _resourceLoader.GetString("bestOf");
+                separator = ", ";
+            }
+
+            if (Genre.LiveCount > 0)
+            {
+                label += $"{separator}{Genre.LiveCount} ";
+                if (Genre.LiveCount > 1)
+                    label += _resourceLoader.GetString("live");
+                else
+                    label += _resourceLoader.GetString("live");
+                separator = ", ";
+            }
+
+            if (Genre.CompilationCount > 0)
+            {
+                label += $"{separator}{Genre.CompilationCount} ";
+                if (Genre.CompilationCount > 1)
+                    label += _resourceLoader.GetString("compilations");
+                else
+                    label += _resourceLoader.GetString("compilation");
+            }
+
+            return label;
+        }
+    }
+
+    public string ListenStats
+    {
+        get
+        {
+            string label = "";
+
+            if (Genre.ListenCount > 0)
+            {
+                label += _resourceLoader.GetString("listenCount") + " "
+                                + Genre.ListenCount + " "
+                                + _resourceLoader.GetString("listenCountTimes") + ", "
+                                + _resourceLoader.GetString("lastListen") + " "
+                               + Genre.LastListen?.ToString("g");
+            }
+
+            return label;
+        }
+    }
+
+    public AsyncRelayCommand GenreFavoriteCommand { get; private set; }
+    public AsyncRelayCommand ListenCommand { get; private set; }
+
+
+    public GenreViewModel(NavigationService navigationService,
+                          IPlayerService playerService,
+                          ResourceLoader resourceLoader,
+                          GenreDataLoader dataLoader,
+                          ArtistPictureService pictureService,
+                          IBackdropLoader backdropLoader,
+                          GenreEditService editService,
+                          ILogger<GenreViewModel> logger)
+    {
+        _navigationService = navigationService;
+        _playerService = playerService;
+        _dataLoader = dataLoader;
+        _pictureService = pictureService;
+        _backdropLoader = backdropLoader;
+        _resourceLoader = resourceLoader;
+        _editService = editService;
+        _logger = logger;
+
+        ListenCommand = new AsyncRelayCommand(ListenAsync);
+        GenreFavoriteCommand = new AsyncRelayCommand(UpdateFavoriteStateAsync);
+    }
+
+
+    public async Task LoadDataAsync(long genreId, bool loadAlbums = true, bool loadTracks = true)
+    {
+        Stopwatch stopwatch = new();
+        stopwatch.Start();
+
+        await LoadGenreAsync(genreId);
+        await LoadAlbumsAsync(genreId);
+
+        stopwatch.Stop();
+
+        _logger.LogInformation("Genre {GenreId} loaded in {ElapsedMilliseconds} ms (albums: {LoadAlbums}, tracks: {LoadTracks})",
+                                genreId, stopwatch.ElapsedMilliseconds, loadAlbums, loadTracks);
+    }
+
+
+    private async Task LoadGenreAsync(long genreId)
+    {
+        GenreDto? genre = await _dataLoader.LoadGenreAsync(genreId);
+
+        if (genre != null)
+            Genre = genre;
+    }
+
+
+    private async Task LoadAlbumsAsync(long genreId)
+    {
+        List<AlbumViewModel> albums = await _dataLoader.LoadAlbumsAsync(genreId);
+
+        if (albums.Count > 0)
+        {
+            Albums.AddRange(albums);
+
+            List<AlbumViewModel> albumsWithArtist = albums.Where(a => !string.IsNullOrEmpty(a.Album.ArtistName)).ToList();
+            int index = Random.Shared.Next(albumsWithArtist.Count);
+            AlbumViewModel randomAlbum = albumsWithArtist[index];
+
+            LoadPicture(randomAlbum.Album.ArtistName);
+            LoadBackdrop(randomAlbum.Album.ArtistName);
+        }
+    }
+
+
+    public void LoadPicture(string artistName)
+    {
+        Picture = _pictureService.LoadPicture(artistName);
+    }
+
+
+    public void LoadBackdrop(string artistName)
+    {
+        _backdropLoader.LoadBackdrop(artistName, (BitmapImage? backdropImage) =>
+        {
+            Backdrop = backdropImage;
+        });
+    }
+
+    private async Task ListenAsync()
+    {
+        IEnumerable<TrackDto> tracks = await _dataLoader.LoadTracksAsync(Genre.Id);
+
+        if (tracks?.Any() == true)
+        {
+            List<TrackDto> randomizedTracks = TracksRandomizer.Randomize(tracks);
+            _playerService.LoadPlaylist(randomizedTracks);
+        }
+    }
+
+    private async Task UpdateFavoriteStateAsync()
+    {
+        bool newFavoriteState = !Genre.IsFavorite;
+        await _editService.UpdateFavoriteAsync(Genre, newFavoriteState);
+
+        OnPropertyChanged(nameof(IsFavorite));
+    }
+}

--- a/Presentation/Logic/ViewModels/Genre/Services/GenreDataLoader.cs
+++ b/Presentation/Logic/ViewModels/Genre/Services/GenreDataLoader.cs
@@ -1,0 +1,32 @@
+﻿using Rok.Application.Features.Albums.Query;
+using Rok.Application.Features.Genres.Query;
+using Rok.Application.Features.Tracks.Query;
+using Rok.Logic.ViewModels.Albums;
+
+namespace Rok.Logic.ViewModels.Genre.Services;
+
+public class GenreDataLoader(IMediator mediator, ILogger<GenreDataLoader> logger)
+{
+    public async Task<GenreDto?> LoadGenreAsync(long genreId)
+    {
+        Result<GenreDto> result = await mediator.SendMessageAsync(new GetGenreByIdQuery(genreId));
+
+        if (result.IsSuccess)
+            return result.Value!;
+
+        logger.LogError("Failed to load genre {GenreId}", genreId);
+        return null;
+    }
+
+    public async Task<List<AlbumViewModel>> LoadAlbumsAsync(long genreId)
+    {
+        IEnumerable<AlbumDto> albums = await mediator.SendMessageAsync(new GetAlbumsByGenreIdQuery(genreId));
+        return AlbumViewModelMap.CreateViewModels(albums.ToList());
+    }
+
+
+    public async Task<IEnumerable<TrackDto>> LoadTracksAsync(long genreId)
+    {
+        return await mediator.SendMessageAsync(new GetTracksByGenreIdQuery(genreId));
+    }
+}

--- a/Presentation/Logic/ViewModels/Genre/Services/GenreEditService.cs
+++ b/Presentation/Logic/ViewModels/Genre/Services/GenreEditService.cs
@@ -1,0 +1,12 @@
+﻿using Rok.Application.Features.Genres.Command;
+
+namespace Rok.Logic.ViewModels.Genre.Services;
+
+public class GenreEditService(IMediator mediator, ILogger<GenreEditService> logger)
+{
+    public async Task UpdateFavoriteAsync(GenreDto genre, bool isFavorite)
+    {
+        await mediator.SendMessageAsync(new UpdateGenreFavoriteCommand(genre.Id, isFavorite));
+        genre.IsFavorite = isFavorite;
+    }
+}

--- a/Presentation/Logic/ViewModels/Track/Services/TrackNavigationService.cs
+++ b/Presentation/Logic/ViewModels/Track/Services/TrackNavigationService.cs
@@ -14,6 +14,12 @@ public class TrackNavigationService(NavigationService navigationService)
             navigationService.NavigateToAlbum(albumId.Value);
     }
 
+    public void NavigateToGenre(long? genreId)
+    {
+        if (genreId.HasValue)
+            navigationService.NavigateToGenre(genreId.Value);
+    }
+
     public void NavigateToTrack(long trackId)
     {
         if (trackId > 0)

--- a/Presentation/Logic/ViewModels/Track/TrackViewModel.cs
+++ b/Presentation/Logic/ViewModels/Track/TrackViewModel.cs
@@ -175,6 +175,7 @@ public partial class TrackViewModel : ObservableObject, IDisposable
     public bool Listened { get; set; }
 
     public RelayCommand AlbumOpenCommand { get; private set; }
+    public RelayCommand GenreOpenCommand { get; private set; }
     public RelayCommand ArtistOpenCommand { get; private set; }
     public RelayCommand TrackOpenCommand { get; private set; }
     public AsyncRelayCommand LyricsOpenCommand { get; private set; }
@@ -209,6 +210,7 @@ public partial class TrackViewModel : ObservableObject, IDisposable
         TrackOpenCommand = new RelayCommand(TrackOpen);
         LyricsOpenCommand = new AsyncRelayCommand(LyricsOpenAsync);
         ListenCommand = new RelayCommand(Listen);
+        GenreOpenCommand = new RelayCommand(GenreOpen);
 
         SubscribeToMessages();
     }
@@ -259,6 +261,12 @@ public partial class TrackViewModel : ObservableObject, IDisposable
     {
         if (Track.AlbumId.HasValue)
             _navigationService.NavigateToAlbum(Track.AlbumId);
+    }
+
+    private void GenreOpen()
+    {
+        if (Track.GenreId.HasValue)
+            _navigationService.NavigateToGenre(Track.GenreId);
     }
 
     private void TrackOpen()

--- a/Presentation/Pages/AlbumPage.xaml.cs
+++ b/Presentation/Pages/AlbumPage.xaml.cs
@@ -3,13 +3,8 @@ using Microsoft.UI.Xaml.Navigation;
 using Rok.Logic.ViewModels.Album;
 using Rok.Logic.ViewModels.Albums;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Rok.Pages;
-/// <summary>
-/// An empty page that can be used on its own or navigated to within a Frame.
-/// </summary>
+
 public sealed partial class AlbumPage : Page
 {
     public AlbumViewModel ViewModel { get; set; }

--- a/Presentation/Pages/ArtistPage.xaml
+++ b/Presentation/Pages/ArtistPage.xaml
@@ -67,11 +67,12 @@
                            Margin="10,-1,0,0" 
                            VerticalAlignment="Center"/>
 
-                <TextBlock x:Name="genreName"
-                           Text="{x:Bind ViewModel.Artist.GenreName}"
-                           RelativePanel.Below="artistName"
-                           FontSize="16"
-                           Style="{StaticResource headerText}" />
+                <HyperlinkButton x:Name="genreName"
+                                 Content="{x:Bind ViewModel.Artist.GenreName}"
+                                 RelativePanel.Below="artistName"
+                                 FontSize="16"
+                                 Command="{x:Bind ViewModel.GenreOpenCommand}"
+                                 Style="{StaticResource headerGenreHyperlink}" />
 
                 <TextBlock x:Name="panelExtendedInfo"
                            RelativePanel.Below="genreName"

--- a/Presentation/Pages/GenrePage.xaml
+++ b/Presentation/Pages/GenrePage.xaml
@@ -6,10 +6,161 @@
     xmlns:local="using:Rok.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+      xmlns:common="using:Rok.Commons"
+      xmlns:albums="using:Rok.Logic.ViewModels.Albums"
+      mc:Ignorable="d"
+    x:Name="genrePage"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition x:Name="headerRow"
+                           Height="{ThemeResource headerRowHeight}" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
+        <Grid.Background>
+            <SolidColorBrush Color="{ThemeResource CardBackgroundFillColorDefault}"
+                             Opacity="{StaticResource headerBackgroundOpacity}" />
+        </Grid.Background>
+
+        <Image x:Name="backdrop"
+               Grid.RowSpan="2"
+               Source="{x:Bind ViewModel.Backdrop,Mode=OneWay}"
+               Opacity="{StaticResource headerBackdropOpacity}"
+               Style="{StaticResource headerBackdrop}"
+               Stretch="UniformToFill"
+               IsHitTestVisible="False" />
+
+
+        <!-- Header -->
+        <Grid Padding="2">
+
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="pictureColumn"
+                                  Width="{ThemeResource headerPictureColumnWidth}" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Grid Style="{StaticResource headerPictureGrid}">
+                <common:PictureControl x:Name="artistPicture"
+                                       Cover="{x:Bind ViewModel.Picture, Mode=OneWay}"
+                                       Style="{StaticResource headerPicture}" />
+            </Grid>
+
+            <RelativePanel Grid.Column="1"
+                           Margin="6,0,0,0">
+                <TextBlock x:Name="genreName"
+                           Text="{x:Bind ViewModel.Genre.Name, Mode=OneWay}"
+                           Style="{StaticResource headerTitleText}" />
+
+                <TextBlock x:Name="panelExtendedInfo"
+                           RelativePanel.Below="genreName"
+                           Style="{StaticResource headerText}"
+                           Text="{x:Bind ViewModel.SubTitle}" />
+
+                <StackPanel x:Name="panelStatsInfo"
+                            RelativePanel.Below="panelExtendedInfo"
+                            Orientation="Horizontal"
+                            Visibility="{x:Bind ViewModel.Genre.ListenCount, Converter={StaticResource IntToVisibilityConverter}}">
+                    <TextBlock x:Uid="AlbumViewListenCount"
+                               Margin="0,0,4,0"
+                               FontSize="12"></TextBlock>
+                    <TextBlock Text="{x:Bind ViewModel.Genre.ListenCount}"
+                               FontSize="12"></TextBlock>
+                    <TextBlock x:Uid="AlbumViewListenCountTimes"
+                               Margin="2,0,0,0"
+                               FontSize="12"></TextBlock>
+
+                    <TextBlock x:Uid="AlbumViewLastListen"
+                               Margin="0,0,2,0"
+                               FontSize="12"></TextBlock>
+                    <TextBlock Text="{x:Bind ViewModel.Genre.LastListen}"
+                               FontSize="12"></TextBlock>
+                </StackPanel>
+
+
+                <CommandBar  RelativePanel.AlignBottomWithPanel="True"
+                             Style="{StaticResource headerCommandBar}">
+
+                    <AppBarButton x:Uid="albumViewListen"
+                                  Style="{StaticResource listenAppBarButtonStyle}"
+                                  Command="{x:Bind ViewModel.ListenCommand}" />
+
+                    <AppBarToggleButton x:Uid="albumViewLike"
+                                        x:Name="genreAppBarLike"
+                                        Style="{StaticResource headerLikeButton}"
+                                        IsChecked="{x:Bind ViewModel.IsFavorite, Mode=OneWay}"
+                                        Command="{x:Bind ViewModel.GenreFavoriteCommand}" />
+                </CommandBar>
+            </RelativePanel>
+
+        </Grid>
+
+        <!-- Content -->
+        <Border Grid.Row="1"
+                CornerRadius="12,12,0,0"
+                Background="{ThemeResource CardBackgroundFillColorDefault}"
+                Margin="4,0,4,4">
+            <common:GridViewExtended x:Name="grid"
+                                     ItemsSource="{x:Bind ViewModel.Albums}"
+                                     ContainerContentChanging="grid_ContainerContentChanging"
+                                     Margin="0"
+                                     ScrollViewer.VerticalScrollMode="Enabled"
+                                     ScrollViewer.VerticalScrollBarVisibility="Auto">
+                <GridView.ItemTemplate>
+                    <DataTemplate x:DataType="albums:AlbumViewModel">
+                        <Grid Style="{StaticResource MainGridCoverStyle}">
+                            <Border CornerRadius="10">
+                                <common:PictureControl Style="{StaticResource PictureCoverStyle}"
+                                                       Cover="{x:Bind Picture, Mode=OneWay}"
+                                                       x:Phase="2"
+                                                       PlayButtonVisibility="Visible"
+                                                       Command="{x:Bind ListenCommand}" />
+                            </Border>
+
+                            <Grid Style="{StaticResource GridCoverBottomStyle}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="30"></RowDefinition>
+                                    <RowDefinition Height="30"></RowDefinition>
+                                </Grid.RowDefinitions>
+
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition></ColumnDefinition>
+                                    <ColumnDefinition Width="50"></ColumnDefinition>
+                                </Grid.ColumnDefinitions>
+
+                                <HyperlinkButton Grid.ColumnSpan="2"
+                                                 Content="{x:Bind Album.Name}"
+                                                 x:Phase="0"
+                                                 Command="{x:Bind AlbumOpenCommand}"
+                                                 Style="{StaticResource GridCoverBottomFirstLineStyle}" />
+
+                                <TextBlock Grid.Row="1"
+                                           Style="{StaticResource GridCoverBottomSecondLineStyle}"
+                                           Text="{x:Bind SubTitle, Mode=OneWay}"
+                                           x:Phase="1" />
+
+                                <common:AnimatedButton Grid.Row="1"
+                                                       Grid.Column="1"
+                                                       HorizontalAlignment="Right"
+                                                       VerticalAlignment="Stretch"
+                                                       Margin="-15,0,0,0"
+                                                       Icon="{StaticResource HeartPath}"
+                                                       Color="{x:Bind IsFavorite, Converter={StaticResource FavoriteToColorConverter}, Mode=OneWay}"
+                                                       Command="{x:Bind AlbumFavoriteCommand}"
+                                                       CommandParameter="{x:Bind IsFavorite, Converter={StaticResource BoolToInvertBoolConverter}, Mode=OneWay}" />
+                            </Grid>
+                        </Grid>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+
+                <GridView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <ItemsWrapGrid Style="{StaticResource gridAlbumsWrapGrid}" />
+                    </ItemsPanelTemplate>
+                </GridView.ItemsPanel>
+            </common:GridViewExtended>
+        </Border>
     </Grid>
 </Page>

--- a/Presentation/Pages/GenrePage.xaml.cs
+++ b/Presentation/Pages/GenrePage.xaml.cs
@@ -1,18 +1,39 @@
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using Rok.Logic.ViewModels.Albums;
+using Rok.Logic.ViewModels.Genre;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace Rok.Pages
+namespace Rok.Pages;
+
+public sealed partial class GenrePage : Page
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class GenrePage : Page
+    public GenreViewModel ViewModel { get; set; }
+
+    public GenrePage()
     {
-        public GenrePage()
+        this.InitializeComponent();
+
+        ViewModel = App.ServiceProvider.GetRequiredService<GenreViewModel>();
+        DataContext = ViewModel;
+    }
+
+
+    protected override async void OnNavigatedTo(NavigationEventArgs e)
+    {
+        if (e.Parameter is not GenreOpenArgs options)
+            throw new ArgumentNullException(nameof(options), "GenreOpenArgs cannot be null");
+
+        await ViewModel.LoadDataAsync(options.GenreId);
+
+        base.OnNavigatedTo(e);
+    }
+
+    private void grid_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.Item is AlbumViewModel item && item.Picture == null)
         {
-            this.InitializeComponent();
+            item.LoadPicture();
         }
     }
 }

--- a/Presentation/Pages/ListeningPage.xaml
+++ b/Presentation/Pages/ListeningPage.xaml
@@ -132,9 +132,14 @@
                            Margin="10,-1,0,0"
                            VerticalAlignment="Center" />
 
+                <HyperlinkButton x:Name="genreName"
+                                 Content="{x:Bind ViewModel.Artist.Artist.GenreName}"
+                                 RelativePanel.Below="artistName"                                 
+                                 Command="{x:Bind ViewModel.Artist.GenreOpenCommand}"
+                                 Style="{StaticResource headerGenreHyperlink}" />
 
                 <CommandBar x:Name="panelNetwork"
-                            RelativePanel.Below="artistName"
+                            RelativePanel.Below="genreName"
                             Margin="-5,-5,0,0"
                             Style="{StaticResource headerCommandBar}">
 
@@ -330,6 +335,8 @@
                                       x:Name="trackArtist" />
                     <ColumnDefinition Width="{ThemeResource gridHeaderTracksAlbumColumnWidth}"
                                       x:Name="trackAlbum" />
+                    <ColumnDefinition Width="{ThemeResource gridHeaderTracksGenreColumnWidth}"
+                                      x:Name="trackGenre" />
                     <ColumnDefinition Width="{ThemeResource gridHeaderTracksScoreColumnWidth}"
                                       x:Name="trackScore" />
                 </Grid.ColumnDefinitions>
@@ -343,8 +350,11 @@
                 <TextBlock x:Uid="gridHeaderAlbum"
                            Grid.Column="3"
                            Style="{StaticResource gridHeaderTracksText}" />
-                <TextBlock x:Uid="gridHeaderScore"
+                <TextBlock x:Uid="gridHeaderGenre"
                            Grid.Column="4"
+                           Style="{StaticResource gridHeaderTracksText}" />
+                <TextBlock x:Uid="gridHeaderScore"
+                           Grid.Column="5"
                            Style="{StaticResource gridHeaderTracksText}" />
             </Grid>
 
@@ -368,6 +378,7 @@
                                 <ColumnDefinition Width="{ThemeResource gridHeaderTracksTitleColumnWidth}" />
                                 <ColumnDefinition Width="{ThemeResource gridHeaderTracksArtistColumnWidth}" />
                                 <ColumnDefinition Width="{ThemeResource gridHeaderTracksAlbumColumnWidth}" />
+                                <ColumnDefinition Width="{ThemeResource gridHeaderTracksGenreColumnWidth}" />
                                 <ColumnDefinition Width="{ThemeResource gridHeaderTracksScoreColumnWidth}" />
                             </Grid.ColumnDefinitions>
 
@@ -453,7 +464,11 @@
                                              Command="{x:Bind AlbumOpenCommand}"
                                              VerticalAlignment="Center" />
 
-                            <common:RatingControlLightControl Grid.Column="4"
+                            <HyperlinkButton Grid.Column="4"
+                                             Style="{StaticResource gridTracksGenreText}"
+                                             Command="{x:Bind GenreOpenCommand}" />
+
+                            <common:RatingControlLightControl Grid.Column="5"
                                                               Style="{StaticResource gridTracksScore}"
                                                               RatingValue="{x:Bind Score, Mode=TwoWay}"
                                                               VerticalAlignment="Center" />

--- a/Presentation/Pages/TracksPage.xaml
+++ b/Presentation/Pages/TracksPage.xaml
@@ -133,6 +133,8 @@
                                       x:Name="trackArtist" />
                     <ColumnDefinition Width="{ThemeResource gridHeaderTracksAlbumColumnWidth}"
                                       x:Name="trackAlbum" />
+                    <ColumnDefinition Width="{ThemeResource gridHeaderTracksGenreColumnWidth}"
+                                      x:Name="trackGenre" />
                     <ColumnDefinition Width="{ThemeResource gridHeaderTracksScoreColumnWidth}"
                                       x:Name="trackScore" />
                 </Grid.ColumnDefinitions>
@@ -146,8 +148,11 @@
                 <TextBlock x:Uid="gridHeaderAlbum"
                            Grid.Column="2"
                            Style="{StaticResource gridHeaderTracksText}" />
-                <TextBlock x:Uid="gridHeaderScore"
+                <TextBlock x:Uid="gridHeaderGenre"
                            Grid.Column="3"
+                           Style="{StaticResource gridHeaderTracksText}" />
+                <TextBlock x:Uid="gridHeaderScore"
+                           Grid.Column="4"
                            Style="{StaticResource gridHeaderTracksText}" />
             </Grid>
 
@@ -177,6 +182,7 @@
                                         <ColumnDefinition Width="{ThemeResource gridHeaderTracksTitleColumnWidth}" />
                                         <ColumnDefinition Width="{ThemeResource gridHeaderTracksArtistColumnWidth}" />
                                         <ColumnDefinition Width="{ThemeResource gridHeaderTracksAlbumColumnWidth}" />
+                                        <ColumnDefinition Width="{ThemeResource gridHeaderTracksGenreColumnWidth}" />
                                         <ColumnDefinition Width="{ThemeResource gridHeaderTracksScoreColumnWidth}" />
                                     </Grid.ColumnDefinitions>
 
@@ -232,7 +238,11 @@
                                                      Style="{StaticResource gridTracksAlbumText}"
                                                      Command="{x:Bind AlbumOpenCommand}" />
 
-                                    <common:RatingControlLightControl Grid.Column="3"
+                                    <HyperlinkButton Grid.Column="3"
+                                                     Style="{StaticResource gridTracksGenreText}"
+                                                     Command="{x:Bind GenreOpenCommand}" />
+
+                                    <common:RatingControlLightControl Grid.Column="4"
                                                                       Style="{StaticResource gridTracksScore}"
                                                                       RatingValue="{x:Bind Score, Mode=TwoWay}" />
                                 </Grid>

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1128,4 +1128,10 @@
   <data name="playlistGroupFieldUnitDays" xml:space="preserve">
     <value>days</value>
   </data>
+  <data name="gridHeaderGenre.Text" xml:space="preserve">
+    <value>Style</value>
+  </data>
+  <data name="compilations" xml:space="preserve">
+    <value>compilations</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1128,4 +1128,10 @@
   <data name="playlistGroupFieldUnitDays" xml:space="preserve">
     <value>jours</value>
   </data>
+  <data name="gridHeaderGenre.Text" xml:space="preserve">
+    <value>Genre</value>
+  </data>
+  <data name="compilations" xml:space="preserve">
+    <value>compilations</value>
+  </data>
 </root>

--- a/Presentation/Styles/ControlsStyles.xaml
+++ b/Presentation/Styles/ControlsStyles.xaml
@@ -107,6 +107,7 @@
     <x:Double x:Key="gridHeaderTracksTitleColumnWidth">350</x:Double>
     <x:Double x:Key="gridHeaderTracksAlbumColumnWidth">250</x:Double>
     <x:Double x:Key="gridHeaderTracksArtistColumnWidth">350</x:Double>
+    <x:Double x:Key="gridHeaderTracksGenreColumnWidth">250</x:Double>
     <x:Double x:Key="gridHeaderTracksScoreColumnWidth">150</x:Double>
 
     <x:Double x:Key="gridHeaderTracksHeight">25</x:Double>
@@ -158,6 +159,21 @@
                     <TextBlock Text="{Binding Track.AlbumName}"
                         TextTrimming="CharacterEllipsis"
                         ToolTipService.ToolTip="{Binding Track.AlbumName}"/>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="gridTracksGenreText"
+           TargetType="HyperlinkButton">
+        <Setter Property="Padding"
+                Value="0" />
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Track.GenreName}"
+                               TextTrimming="CharacterEllipsis"
+                               ToolTipService.ToolTip="{Binding Track.GenreName}" />
                 </DataTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
Ajout de la page Genre avec son ViewModel, services de chargement et édition. Navigation vers la page d’un genre depuis les pages Artiste, Track et Listening. Affichage des albums, statistiques et image du genre sur la nouvelle page. Ajout de la gestion du favori pour les genres (commandes et backend). Affichage du genre dans les listes de morceaux, avec navigation possible. Ajout de styles et ressources pour l’affichage du genre. Corrections de libellés et traductions ("compilations", "Genre"). Refactorisation des types d’identifiants de genre (int → long). Intégration complète dans la DI et le service de navigation. Amélioration de l’expérience utilisateur autour des genres musicaux.