### PR TITLE
Remove previous lyric display, update manifest for dev build

### DIFF
--- a/Presentation/Commons/FullScreenControl.xaml
+++ b/Presentation/Commons/FullScreenControl.xaml
@@ -352,32 +352,6 @@
                             Width="Auto"
                             MaxWidth="1200">
 
-                    <!-- Previous lyric (smaller, italic, subtle) -->
-                    <ContentControl x:Name="PrevLyricControl"
-                                    Visibility="{x:Bind PlayerViewModel.PreviousLyric, Mode=OneWay, Converter={StaticResource StringToVisibilityConverter}}"
-                                    Content="{x:Bind PlayerViewModel.PreviousLyric, Mode=OneWay}"
-                                    HorizontalAlignment="Center"
-                                    Margin="0,0,0,12">
-                        <ContentControl.Transitions>
-                            <TransitionCollection>
-                                <ContentThemeTransition />
-                                <EntranceThemeTransition FromVerticalOffset="-12" />
-                            </TransitionCollection>
-                        </ContentControl.Transitions>
-                        <ContentControl.ContentTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding}"
-                                           Foreground="#CCFFFFFF"
-                                           FontSize="28"
-                                           FontStyle="Italic"
-                                           FontWeight="Normal"
-                                           TextAlignment="Center"
-                                           TextWrapping="Wrap"
-                                           MaxWidth="1100" />
-                            </DataTemplate>
-                        </ContentControl.ContentTemplate>
-                    </ContentControl>
-
                     <!-- Current centered lyric (large, bold) -->
                     <ContentControl x:Name="CenteredLyricContent"
                                     Visibility="{x:Bind PlayerViewModel.CurrentLyric.Lyric, Mode=OneWay, Converter={StaticResource StringToVisibilityConverter}}"

--- a/Presentation/Package.appxmanifest
+++ b/Presentation/Package.appxmanifest
@@ -7,12 +7,12 @@
          IgnorableNamespaces="uap rescap uap3">
 
 	<Identity
-	  Name="Rokapp.Rokmusicplayer"
+	  Name="dev-Rokapp.Rokmusicplayer"
 	  Publisher="CN=C9A55691-54ED-46EA-9D4F-F3CD41C04242"
 	  Version="1.1.13.0" />
 
 	<Properties>
-		<DisplayName>Rok musicplayer</DisplayName>
+		<DisplayName>Rok musicplayer (dev)</DisplayName>
 		<PublisherDisplayName>Rok app</PublisherDisplayName>
 		<Logo>Assets\StoreLogo.png</Logo>
 	</Properties>


### PR DESCRIPTION
Removed the PreviousLyric ContentControl from FullScreenControl.xaml, so only the current lyric is shown in fullscreen mode. Updated Package.appxmanifest to set the package name to "dev-Rokapp.Rokmusicplayer" and display name to "Rok musicplayer (dev)" for development builds. These changes clarify the app's environment and simplify the fullscreen lyric view.