### PR TITLE
feat(statistics): add lyrics stats to statistics view

### DIFF
--- a/Core/Rok.Application/Features/Statistics/LyricsStatisticsDto.cs
+++ b/Core/Rok.Application/Features/Statistics/LyricsStatisticsDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Rok.Application.Features.Statistics;
+
+public class LyricsStatisticsDto
+{
+    public long TotalRawLyrics { get; set; }
+
+    public long TotalSyncLyrics { get; set; }
+}

--- a/Core/Rok.Application/Features/Statistics/Query/GetLyricsStatisticsQueryHandler.cs
+++ b/Core/Rok.Application/Features/Statistics/Query/GetLyricsStatisticsQueryHandler.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.Logging;
+using Rok.Application.Interfaces;
+
+namespace Rok.Application.Features.Statistics.Query;
+
+
+public class GetLyricsStatisticsQuery : IQuery<LyricsStatisticsDto>
+{
+}
+
+public class GetLyricsStatisticsQueryHandler(IFolderResolver _folderResolver, IAppOptions _options, ILogger<GetLyricsStatisticsQueryHandler> _logger) : IQueryHandler<GetLyricsStatisticsQuery, LyricsStatisticsDto>
+{
+    public async Task<LyricsStatisticsDto> HandleAsync(GetLyricsStatisticsQuery request, CancellationToken cancellationToken)
+    {
+        LyricsStatisticsDto statisticsDto = new();
+
+        foreach (string token in _options.LibraryTokens)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            try
+            {
+                List<string> folderPaths = await _folderResolver.GetPathFromTokenAsync(token).ConfigureAwait(false);
+
+                foreach (string folder in folderPaths)
+                {
+                    statisticsDto.TotalSyncLyrics += Directory.GetFiles(folder, "*.lrc", SearchOption.AllDirectories).Length;
+                    statisticsDto.TotalRawLyrics += Directory.GetFiles(folder, "*.txt", SearchOption.AllDirectories).Length;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while calculating lyrics statistics for token {Token}", token);
+            }
+        }
+
+        return statisticsDto;
+    }
+}

--- a/Presentation/Logic/ViewModels/Statistics/StatisticsViewModel.cs
+++ b/Presentation/Logic/ViewModels/Statistics/StatisticsViewModel.cs
@@ -1,10 +1,10 @@
-﻿using Rok.Application.Features.Albums.Command;
+﻿using System.Globalization;
+using Rok.Application.Features.Albums.Command;
 using Rok.Application.Features.Artists.Command;
 using Rok.Application.Features.Genres.Command;
 using Rok.Application.Features.Statistics;
 using Rok.Application.Features.Statistics.Query;
 using Rok.Application.Features.Tracks.Command;
-using System.Globalization;
 
 namespace Rok.Logic.ViewModels.Statistics;
 
@@ -58,6 +58,10 @@ public class StatisticsViewModel : ObservableObject
         }
     }
 
+    public long TotalSyncLyrics { get; set; }
+
+    public long TotalRawLyrics { get; set; }
+
     public List<RankedTopItem> TopGenres { get; set; } = [];
 
     public List<RankedTopItem> TopArtists { get; set; } = [];
@@ -98,6 +102,10 @@ public class StatisticsViewModel : ObservableObject
           .Select((t, i) => new RankedTopItem { Rank = i + 1, Id = t.Id, Name = t.Name, ListenCount = t.ListenCount })
           .ToList();
 
+        LyricsStatisticsDto lyrics = await _mediator.SendMessageAsync(new GetLyricsStatisticsQuery());
+        TotalRawLyrics = lyrics.TotalRawLyrics;
+        TotalSyncLyrics = lyrics.TotalSyncLyrics;
+
         OnPropertyChanged(nameof(Current));
         OnPropertyChanged(nameof(TopTracks));
         OnPropertyChanged(nameof(TopAlbums));
@@ -105,6 +113,8 @@ public class StatisticsViewModel : ObservableObject
         OnPropertyChanged(nameof(TopGenres));
         OnPropertyChanged(nameof(TotalDuration));
         OnPropertyChanged(nameof(TotalSize));
+        OnPropertyChanged(nameof(TotalRawLyrics));
+        OnPropertyChanged(nameof(TotalSyncLyrics));
     }
 
 

--- a/Presentation/Pages/OptionsPage.xaml
+++ b/Presentation/Pages/OptionsPage.xaml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Page
-    x:Class="Rok.Pages.OptionsPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Rok.Pages"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:enums="using:Rok.Shared.Enums" 
-    xmlns:generic="using:System.Collections.Generic"
-    xmlns:statistics="using:Rok.Logic.ViewModels.Statistics"
-    xmlns:controls="using:Rok.Commons"
-    mc:Ignorable="d"
-    x:Name="OptionsView">
+<Page x:Class="Rok.Pages.OptionsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Rok.Pages"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:enums="using:Rok.Shared.Enums"
+      xmlns:generic="using:System.Collections.Generic"
+      xmlns:statistics="using:Rok.Logic.ViewModels.Statistics"
+      xmlns:controls="using:Rok.Commons"
+      mc:Ignorable="d"
+      x:Name="OptionsView">
 
     <Grid>
 
@@ -117,8 +116,9 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
-                        <CommandBar Style="{StaticResource headerCommandBar}" HorizontalAlignment="Left">
-                            <AppBarButton x:Uid="resetListenCount"                                          
+                        <CommandBar Style="{StaticResource headerCommandBar}"
+                                    HorizontalAlignment="Left">
+                            <AppBarButton x:Uid="resetListenCount"
                                           Style="{StaticResource headerGenericButton}"
                                           Icon="Refresh"
                                           Click="ResetListenCount_Click">
@@ -129,270 +129,283 @@
                         </CommandBar>
 
                         <ScrollViewer Height="auto"
-                                  Grid.Row="1"
-                                  VerticalScrollBarVisibility="Auto">
+                                      Grid.Row="1"
+                                      VerticalScrollBarVisibility="Auto">
 
-                        <StackPanel Spacing="16"
-                                    Margin="24,18,24,18">
+                            <StackPanel Spacing="16"
+                                        Margin="24,18,24,18">
 
 
-                            <ItemsControl>
-                                <ItemsControl.Items>
-                                    <TextBlock>
+                                <ItemsControl>
+                                    <ItemsControl.Items>
+                                        <TextBlock>
                                     <Run x:Uid="StatGenres"
-                                         FontWeight="Bold" />
+                                            FontWeight="Bold" />
                                     <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TotalGenres), Mode=OneWay}" />
-                                    </TextBlock>
+                                        </TextBlock>
 
-                                    <TextBlock>
+                                        <TextBlock>
                                     <Run x:Uid="StatArtists"
-                                         FontWeight="Bold" />
+                                            FontWeight="Bold" />
                                     <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TotalArtists), Mode=OneWay}" />
-                                    </TextBlock>
+                                        </TextBlock>
 
-                                    <TextBlock>
+                                        <TextBlock>
                                     <Run x:Uid="StatAlbums"
-                                         FontWeight="Bold" />
+                                            FontWeight="Bold" />
                                     <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TotalAlbums), Mode=OneWay}" />
-                                    </TextBlock>
+                                        </TextBlock>
 
-                                    <TextBlock>
+                                        <TextBlock>
                                     <Run x:Uid="StatSongs"
-                                         FontWeight="Bold" />
+                                            FontWeight="Bold" />
                                     <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TotalTracks), Mode=OneWay}" />
-                                    </TextBlock>
+                                        </TextBlock>
 
-                                    <TextBlock>
+                                        <TextBlock>
                                     <Run x:Uid="StatListened"
-                                         FontWeight="Bold" />
+                                            FontWeight="Bold" />
                                     <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.Current.TracksListenedCount), Mode=OneWay}" />
-                                    </TextBlock>
+                                        </TextBlock>
 
-                                    <TextBlock>
+                                        <TextBlock>
                                     <Run x:Uid="StatTotalDurations"
-                                         FontWeight="Bold" />
+                                            FontWeight="Bold" />
                                     <Run Text="{x:Bind StatisticsViewModel.TotalDuration, Mode=OneWay}" />
-                                    </TextBlock>
+                                        </TextBlock>
 
-                                    <TextBlock>
+                                        <TextBlock>
                                     <Run x:Uid="StatTotalSize"
-                                         FontWeight="Bold" />
+                                            FontWeight="Bold" />
                                     <Run Text="{x:Bind StatisticsViewModel.TotalSize, Mode=OneWay}" />
-                                    </TextBlock>
-                                </ItemsControl.Items>
-                            </ItemsControl>
+                                        </TextBlock>
 
-                            <!-- Top lists: three columns side by side -->
-                            <StackPanel Orientation="Horizontal"
-                                        Spacing="12">
+                                        <TextBlock>
+                                    <Run x:Uid="StatTotalRawLyrics"
+                                            FontWeight="Bold" />
+                                            <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.TotalRawLyrics), Mode=OneWay}" />
+                                        </TextBlock>
 
-                                <!-- Top Genres -->
-                                <Border Background="{ThemeResource ContentDialogBackground}"
-                                        Padding="8"
-                                        CornerRadius="8"
-                                        Width="300">
-                                    <StackPanel>
-                                        <TextBlock x:Uid="StatTopGenres"
-                                                   FontWeight="SemiBold"
-                                                   FontSize="14" />
-                                        <ScrollViewer Height="550"
+                                        <TextBlock>
+                                    <Run x:Uid="StatTotalSyncLyrics"
+                                            FontWeight="Bold" />
+                                        <Run Text="{x:Bind StatisticsViewModel.FormatWithThousands(StatisticsViewModel.TotalSyncLyrics), Mode=OneWay}" />
+                                        </TextBlock>
+
+                                    </ItemsControl.Items>
+                                </ItemsControl>
+
+                                <!-- Top lists: three columns side by side -->
+                                <StackPanel Orientation="Horizontal"
+                                            Spacing="12">
+
+                                    <!-- Top Genres -->
+                                    <Border Background="{ThemeResource ContentDialogBackground}"
+                                            Padding="8"
+                                            CornerRadius="8"
+                                            Width="300">
+                                        <StackPanel>
+                                            <TextBlock x:Uid="StatTopGenres"
+                                                       FontWeight="SemiBold"
+                                                       FontSize="14" />
+                                            <ScrollViewer Height="550"
+                                                          VerticalScrollBarVisibility="Auto">
+                                                <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopGenres, Mode=OneWay}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate x:DataType="statistics:RankedTopItem">
+                                                            <Grid Margin="4">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="32" />
+                                                                    <ColumnDefinition Width="160" />
+                                                                    <ColumnDefinition Width="60" />
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock Grid.Column="0"
+                                                                           Text="{x:Bind Rank}"
+                                                                           HorizontalAlignment="Center"
+                                                                           VerticalAlignment="Center"
+                                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                                <TextBlock Grid.Column="1"
+                                                                           Text="{x:Bind Name}"
+                                                                           TextTrimming="CharacterEllipsis"
+                                                                           VerticalAlignment="Center" />
+                                                                <TextBlock Grid.Column="2"
+                                                                           Text="{x:Bind ListenCount}"
+                                                                           HorizontalAlignment="Right"
+                                                                           VerticalAlignment="Center" />
+                                                            </Grid>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </ScrollViewer>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <!-- Top Artists -->
+                                    <Border Background="{ThemeResource ContentDialogBackground}"
+                                            Padding="8"
+                                            CornerRadius="8"
+                                            Width="300">
+                                        <StackPanel>
+                                            <TextBlock x:Uid="StatTopArtists"
+                                                       FontWeight="SemiBold"
+                                                       FontSize="14" />
+                                            <ScrollViewer Height="550"
+                                                          VerticalScrollBarVisibility="Auto">
+                                                <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopArtists, Mode=OneWay}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate x:DataType="statistics:RankedTopItem">
+                                                            <Grid Margin="4">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="32" />
+                                                                    <ColumnDefinition Width="160" />
+                                                                    <ColumnDefinition Width="60" />
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock Grid.Column="0"
+                                                                           Text="{x:Bind Rank}"
+                                                                           HorizontalAlignment="Center"
+                                                                           VerticalAlignment="Center"
+                                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                                <TextBlock Grid.Column="1"
+                                                                           Text="{x:Bind Name}"
+                                                                           TextTrimming="CharacterEllipsis"
+                                                                           VerticalAlignment="Center" />
+                                                                <TextBlock Grid.Column="2"
+                                                                           Text="{x:Bind ListenCount}"
+                                                                           HorizontalAlignment="Right"
+                                                                           VerticalAlignment="Center" />
+                                                            </Grid>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </ScrollViewer>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <!-- Top Albums -->
+                                    <Border Background="{ThemeResource ContentDialogBackground}"
+                                            Padding="8"
+                                            CornerRadius="8"
+                                            Width="300">
+                                        <StackPanel>
+                                            <TextBlock x:Uid="StatTopAlbums"
+                                                       FontWeight="SemiBold"
+                                                       FontSize="14" />
+                                            <ScrollViewer Height="550"
+                                                          VerticalScrollBarVisibility="Auto">
+                                                <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopAlbums, Mode=OneWay}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate x:DataType="statistics:RankedTopItem">
+                                                            <Grid Margin="4">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="32" />
+                                                                    <ColumnDefinition Width="160" />
+                                                                    <ColumnDefinition Width="60" />
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock Grid.Column="0"
+                                                                           Text="{x:Bind Rank}"
+                                                                           HorizontalAlignment="Center"
+                                                                           VerticalAlignment="Center"
+                                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                                <TextBlock Grid.Column="1"
+                                                                           Text="{x:Bind Name}"
+                                                                           TextTrimming="CharacterEllipsis"
+                                                                           VerticalAlignment="Center" />
+                                                                <TextBlock Grid.Column="2"
+                                                                           HorizontalAlignment="Right"
+                                                                           Text="{x:Bind ListenCount}"
+                                                                           VerticalAlignment="Center" />
+                                                            </Grid>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </ScrollViewer>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <!-- Top Tracks -->
+                                    <Border Background="{ThemeResource ContentDialogBackground}"
+                                            Padding="8"
+                                            CornerRadius="8"
+                                            Width="300">
+                                        <StackPanel>
+                                            <TextBlock x:Uid="StatTopSongs"
+                                                       FontWeight="SemiBold"
+                                                       FontSize="14" />
+                                            <ScrollViewer Height="550"
+                                                          VerticalScrollBarVisibility="Auto">
+                                                <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopTracks, Mode=OneWay}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate x:DataType="statistics:RankedTopItem">
+                                                            <Grid Margin="4">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="32" />
+                                                                    <ColumnDefinition Width="160" />
+                                                                    <ColumnDefinition Width="60" />
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock Grid.Column="0"
+                                                                           Text="{x:Bind Rank}"
+                                                                           HorizontalAlignment="Center"
+                                                                           VerticalAlignment="Center"
+                                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                                <TextBlock Grid.Column="1"
+                                                                           Text="{x:Bind Name}"
+                                                                           TextTrimming="CharacterEllipsis"
+                                                                           VerticalAlignment="Center" />
+                                                                <TextBlock Grid.Column="2"
+                                                                           Text="{x:Bind ListenCount}"
+                                                                           HorizontalAlignment="Right"
+                                                                           VerticalAlignment="Center" />
+                                                            </Grid>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </ScrollViewer>
+                                        </StackPanel>
+                                    </Border>
+                                </StackPanel>
+
+
+                                <!-- Charts -->
+                                <StackPanel Orientation="Horizontal"
+                                            Spacing="12">
+
+                                    <Border Background="{ThemeResource ContentDialogBackground}"
+                                            Padding="8"
+                                            CornerRadius="8"
+                                            Width="300">
+                                        <ScrollViewer Height="500"
                                                       VerticalScrollBarVisibility="Auto">
-                                            <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopGenres, Mode=OneWay}">
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate x:DataType="statistics:RankedTopItem">
-                                                        <Grid Margin="4">
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="32" />
-                                                                <ColumnDefinition Width="160" />
-                                                                <ColumnDefinition Width="60" />
-                                                            </Grid.ColumnDefinitions>
-                                                            <TextBlock Grid.Column="0"
-                                                                       Text="{x:Bind Rank}"
-                                                                       HorizontalAlignment="Center"
-                                                                       VerticalAlignment="Center"
-                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                                            <TextBlock Grid.Column="1"
-                                                                       Text="{x:Bind Name}"
-                                                                       TextTrimming="CharacterEllipsis"
-                                                                       VerticalAlignment="Center" />
-                                                            <TextBlock Grid.Column="2"
-                                                                       Text="{x:Bind ListenCount}"
-                                                                       HorizontalAlignment="Right"
-                                                                       VerticalAlignment="Center" />
-                                                        </Grid>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
+                                            <controls:PieChart x:Uid="StartTracksByFileType"
+                                                               Items="{x:Bind StatisticsViewModel.Current.TracksByFileType, Mode=OneWay}" />
                                         </ScrollViewer>
-                                    </StackPanel>
-                                </Border>
+                                    </Border>
 
-                                <!-- Top Artists -->
-                                <Border Background="{ThemeResource ContentDialogBackground}"
-                                        Padding="8"
-                                        CornerRadius="8"
-                                        Width="300">
-                                    <StackPanel>
-                                        <TextBlock x:Uid="StatTopArtists"
-                                                   FontWeight="SemiBold"
-                                                   FontSize="14" />
-                                        <ScrollViewer Height="550"
+                                    <Border Background="{ThemeResource ContentDialogBackground}"
+                                            Padding="8"
+                                            CornerRadius="8"
+                                            Width="300">
+                                        <ScrollViewer Height="500"
                                                       VerticalScrollBarVisibility="Auto">
-                                            <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopArtists, Mode=OneWay}">
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate x:DataType="statistics:RankedTopItem">
-                                                        <Grid Margin="4">
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="32" />
-                                                                <ColumnDefinition Width="160" />
-                                                                <ColumnDefinition Width="60" />
-                                                            </Grid.ColumnDefinitions>
-                                                            <TextBlock Grid.Column="0"
-                                                                       Text="{x:Bind Rank}"
-                                                                       HorizontalAlignment="Center"
-                                                                       VerticalAlignment="Center"
-                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                                            <TextBlock Grid.Column="1"
-                                                                       Text="{x:Bind Name}"
-                                                                       TextTrimming="CharacterEllipsis"
-                                                                       VerticalAlignment="Center" />
-                                                            <TextBlock Grid.Column="2"
-                                                                       Text="{x:Bind ListenCount}"
-                                                                       HorizontalAlignment="Right"
-                                                                       VerticalAlignment="Center" />
-                                                        </Grid>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
+                                            <controls:PieChart x:Uid="StartAlbumsByType"
+                                                               Items="{x:Bind StatisticsViewModel.Current.AlbumsByType, Mode=OneWay}" />
                                         </ScrollViewer>
-                                    </StackPanel>
-                                </Border>
+                                    </Border>
 
-                                <!-- Top Albums -->
-                                <Border Background="{ThemeResource ContentDialogBackground}"
-                                        Padding="8"
-                                        CornerRadius="8"
-                                        Width="300">
-                                    <StackPanel>
-                                        <TextBlock x:Uid="StatTopAlbums"
-                                                   FontWeight="SemiBold"
-                                                   FontSize="14" />
-                                        <ScrollViewer Height="550"
+                                    <Border Background="{ThemeResource ContentDialogBackground}"
+                                            Padding="8"
+                                            CornerRadius="8"
+                                            Width="300">
+                                        <ScrollViewer Height="500"
                                                       VerticalScrollBarVisibility="Auto">
-                                            <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopAlbums, Mode=OneWay}">
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate x:DataType="statistics:RankedTopItem">
-                                                        <Grid Margin="4">
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="32" />
-                                                                <ColumnDefinition Width="160" />
-                                                                <ColumnDefinition Width="60" />
-                                                            </Grid.ColumnDefinitions>
-                                                            <TextBlock Grid.Column="0"
-                                                                       Text="{x:Bind Rank}"
-                                                                       HorizontalAlignment="Center"
-                                                                       VerticalAlignment="Center"
-                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                                            <TextBlock Grid.Column="1"
-                                                                       Text="{x:Bind Name}"
-                                                                       TextTrimming="CharacterEllipsis"
-                                                                       VerticalAlignment="Center" />
-                                                            <TextBlock Grid.Column="2"
-                                                                       HorizontalAlignment="Right"
-                                                                       Text="{x:Bind ListenCount}"
-                                                                       VerticalAlignment="Center" />
-                                                        </Grid>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
+                                            <controls:PieChart x:Uid="StartArtistsByGenre"
+                                                               Items="{x:Bind StatisticsViewModel.Current.ArtistsByGenre, Mode=OneWay}" />
                                         </ScrollViewer>
-                                    </StackPanel>
-                                </Border>
+                                    </Border>
+                                </StackPanel>
 
-                                <!-- Top Tracks -->
-                                <Border Background="{ThemeResource ContentDialogBackground}"
-                                        Padding="8"
-                                        CornerRadius="8"
-                                        Width="300">
-                                    <StackPanel>
-                                        <TextBlock x:Uid="StatTopSongs"
-                                                   FontWeight="SemiBold"
-                                                   FontSize="14" />
-                                        <ScrollViewer Height="550"
-                                                      VerticalScrollBarVisibility="Auto">
-                                            <ItemsControl ItemsSource="{x:Bind StatisticsViewModel.TopTracks, Mode=OneWay}">
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate x:DataType="statistics:RankedTopItem">
-                                                        <Grid Margin="4">
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="32" />
-                                                                <ColumnDefinition Width="160" />
-                                                                <ColumnDefinition Width="60" />
-                                                            </Grid.ColumnDefinitions>
-                                                            <TextBlock Grid.Column="0"
-                                                                       Text="{x:Bind Rank}"
-                                                                       HorizontalAlignment="Center"
-                                                                       VerticalAlignment="Center"
-                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                                            <TextBlock Grid.Column="1"
-                                                                       Text="{x:Bind Name}"
-                                                                       TextTrimming="CharacterEllipsis"
-                                                                       VerticalAlignment="Center" />
-                                                            <TextBlock Grid.Column="2"
-                                                                       Text="{x:Bind ListenCount}"
-                                                                       HorizontalAlignment="Right"
-                                                                       VerticalAlignment="Center" />
-                                                        </Grid>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
-                                        </ScrollViewer>
-                                    </StackPanel>
-                                </Border>
                             </StackPanel>
 
-
-                            <!-- Charts -->
-                            <StackPanel Orientation="Horizontal"
-                                        Spacing="12">
-
-                                <Border Background="{ThemeResource ContentDialogBackground}"
-                                        Padding="8"
-                                        CornerRadius="8"
-                                        Width="300">
-                                    <ScrollViewer Height="500"
-                                                  VerticalScrollBarVisibility="Auto">
-                                        <controls:PieChart x:Uid="StartTracksByFileType"
-                                                           Items="{x:Bind StatisticsViewModel.Current.TracksByFileType, Mode=OneWay}" />
-                                    </ScrollViewer>
-                                </Border>
-
-                                <Border Background="{ThemeResource ContentDialogBackground}"
-                                        Padding="8"
-                                        CornerRadius="8"
-                                        Width="300">
-                                    <ScrollViewer Height="500"
-                                                  VerticalScrollBarVisibility="Auto">
-                                        <controls:PieChart x:Uid="StartAlbumsByType"
-                                                           Items="{x:Bind StatisticsViewModel.Current.AlbumsByType, Mode=OneWay}" />
-                                    </ScrollViewer>
-                                </Border>
-
-                                <Border Background="{ThemeResource ContentDialogBackground}"
-                                        Padding="8"
-                                        CornerRadius="8"
-                                        Width="300">
-                                    <ScrollViewer Height="500"
-                                                  VerticalScrollBarVisibility="Auto">
-                                        <controls:PieChart x:Uid="StartArtistsByGenre"
-                                                           Items="{x:Bind StatisticsViewModel.Current.ArtistsByGenre, Mode=OneWay}" />
-                                    </ScrollViewer>
-                                </Border>
-                            </StackPanel>
-
-                        </StackPanel>
-
-                    </ScrollViewer>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
             </PivotItem>

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1134,4 +1134,10 @@
   <data name="compilations" xml:space="preserve">
     <value>compilations</value>
   </data>
+  <data name="StatTotalRawLyrics.Text" xml:space="preserve">
+    <value>🔹Lyrics:</value>
+  </data>
+  <data name="StatTotalSyncLyrics.Text" xml:space="preserve">
+    <value>🔹Synchronized lyrics:</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1134,4 +1134,10 @@
   <data name="compilations" xml:space="preserve">
     <value>compilations</value>
   </data>
+  <data name="StatTotalRawLyrics.Text" xml:space="preserve">
+    <value>🔹Paroles :</value>
+  </data>
+  <data name="StatTotalSyncLyrics.Text" xml:space="preserve">
+    <value>🔹Paroles synchronisées :</value>
+  </data>
 </root>


### PR DESCRIPTION
Added display of total raw and synchronized lyrics files (.txt, .lrc) in the statistics view. Introduced LyricsStatisticsDto and a query handler to count lyrics files in the library. Updated StatisticsViewModel to fetch and expose these new stats. UI (OptionsPage.xaml) now shows both values with localization support. Resource files updated for English and French.
Minor XAML refactoring for clarity and structure.
This improves user insight into lyrics coverage in their music library.