### PR TITLE
Update button icon glyph for Checked states

### DIFF
--- a/Presentation/Styles/ButtonStyles.xaml
+++ b/Presentation/Styles/ButtonStyles.xaml
@@ -103,7 +103,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="IconGlyph"
                                                                        Storyboard.TargetProperty="Glyph">
                                             <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="&#xE8E1;" />
+                                                                    Value="&#xEB52;" />
                                         </ObjectAnimationUsingKeyFrames>
                                      </Storyboard>
                                 </VisualState>
@@ -117,7 +117,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="IconGlyph"
                                                                        Storyboard.TargetProperty="Glyph">
                                             <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="&#xE8E1;" />
+                                                                    Value="&#xEB52;" />
                                         </ObjectAnimationUsingKeyFrames>
 
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LabelText"


### PR DESCRIPTION
The icon glyph used in the button's "Checked" and "CheckedPointerOver" visual states has been changed from Unicode &#xE8E1; to &#xEB52;. This update modifies the icon displayed when the button is checked or hovered while checked, ensuring better visual consistency. No other visual states or button behaviors are affected by this change. This update only impacts the XAML style definitions.