### PR TITLE
Add IF NOT EXISTS to table and index creation in SqlBuilder

### DIFF
--- a/Infrastructure/Rok.Infrastructure/Migration/SqlBuilder.cs
+++ b/Infrastructure/Rok.Infrastructure/Migration/SqlBuilder.cs
@@ -26,7 +26,7 @@ public class SqlBuilder
 
         _keyPart = new StringBuilder();
         _sql = new StringBuilder();
-        _sql.Append($"CREATE TABLE `{tableName}` (");
+        _sql.Append($"CREATE TABLE IF NOT EXISTS `{tableName}` (");
 
 
         return this;
@@ -111,14 +111,14 @@ public class SqlBuilder
 
     public SqlBuilder AsKey()
     {
-        _keyPart.Append($"CREATE INDEX Idx_{_currentTableName}_{_currentColumnName} ON {_currentTableName} ({_currentColumnName});");
+        _keyPart.Append($"CREATE INDEX IF NOT EXISTS Idx_{_currentTableName}_{_currentColumnName} ON {_currentTableName} ({_currentColumnName});");
         return this;
     }
 
 
     public SqlBuilder AsUniqueKey()
     {
-        _keyPart.Append($"CREATE UNIQUE INDEX {_currentTableName}_{_currentColumnName} ON {_currentTableName} ({_currentColumnName});");
+        _keyPart.Append($"CREATE UNIQUE INDEX IF NOT EXISTS {_currentTableName}_{_currentColumnName} ON {_currentTableName} ({_currentColumnName});");
         return this;
     }
 


### PR DESCRIPTION
Added IF NOT EXISTS clause to SQL statements generated by SqlBuilder for table creation (CREATE TABLE) and index creation (CREATE INDEX, CREATE UNIQUE INDEX). This prevents errors when attempting to create tables or indexes that already exist in the database. Improves robustness and idempotency of schema generation. No changes to method signatures or public API.
Only affects the generated SQL statements.
Tested for backward compatibility.