### PR TITLE
feat(menu): dynamic playlist menu update & dev package name

### DIFF
--- a/Presentation/Logic/Services/PlaylistMenuService.cs
+++ b/Presentation/Logic/Services/PlaylistMenuService.cs
@@ -24,6 +24,7 @@ public partial class PlaylistMenuService : IPlaylistMenuService, IDisposable
         _resourceLoader = resourceManager;
         _logger = logger;
 
+        Messenger.Subscribe<PlaylistUpdatedMessage>(_ => OnPlaylistsChanged());
         Messenger.Subscribe<PlaylistCreatedMessage>(_ => OnPlaylistsChanged());
         Messenger.Subscribe<PlaylistNameUpdatedMessage>(_ => OnPlaylistsChanged());
         Messenger.Subscribe<PlaylistDeletedMessage>(_ => OnPlaylistsChanged());

--- a/Presentation/Package.appxmanifest
+++ b/Presentation/Package.appxmanifest
@@ -7,12 +7,12 @@
          IgnorableNamespaces="uap rescap uap3">
 
 	<Identity
-	  Name="Rokapp.Rokmusicplayer"
+	  Name="dev-Rokapp.Rokmusicplayer"
 	  Publisher="CN=C9A55691-54ED-46EA-9D4F-F3CD41C04242"
 	  Version="1.1.14.0" />
 
 	<Properties>
-		<DisplayName>Rok musicplayer</DisplayName>
+		<DisplayName>Rok musicplayer (dev)</DisplayName>
 		<PublisherDisplayName>Rok app</PublisherDisplayName>
 		<Logo>Assets\StoreLogo.png</Logo>
 	</Properties>

--- a/Presentation/Pages/SearchPage.xaml
+++ b/Presentation/Pages/SearchPage.xaml
@@ -259,7 +259,9 @@
                                     </Grid.ColumnDefinitions>
 
                                     <Grid.ContextFlyout>
-                                        <MenuFlyout ShowMode="TransientWithDismissOnPointerMoveAway">
+                                        <MenuFlyout ShowMode="TransientWithDismissOnPointerMoveAway"
+                                                    common:MenuFlyoutExtensions.PlaylistMenuService="{x:Bind PlaylistMenuService}"
+                                                    common:MenuFlyoutExtensions.TrackId="{x:Bind Track.Id, Mode=OneWay}">
                                             <MenuFlyoutItem x:Uid="trackFlyoutListen"
                                                             Icon="Play"
                                                             Command="{x:Bind ListenCommand}"

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -874,7 +874,7 @@
     <value>Annuler</value>
   </data>
   <data name="notification_playlist_track_add" xml:space="preserve">
-    <value>Chansons ajoutée à la playlist</value>
+    <value>Chanson ajoutée à la playlist</value>
   </data>
   <data name="notification_playlist_track_add_error" xml:space="preserve">
     <value>Impossible d'ajouter la chanson dans la playlist</value>


### PR DESCRIPTION
Improved dynamic update of "Add to playlist" context menu by triggering updates when TrackId, AlbumId, ArtistId, or FlattenPlaylistMenu properties change. Added OnIdChanged handler to refresh menu items as needed. Subscribed to PlaylistUpdatedMessage for better playlist sync. Updated SearchPage to bind PlaylistMenuService and TrackId to the menu. Changed package name and display name to indicate dev version. Fixed typo in French resource for playlist add notification. These changes ensure more responsive playlist menus and clarify the app's development status.