### PR TITLE
feat(playlists): add grid/list toggle view for playlists

### DIFF
--- a/Presentation/App.xaml
+++ b/Presentation/App.xaml
@@ -42,6 +42,7 @@
             <converters:BoolToInvertVisibilityConverter x:Key="BoolToInvertVisibilityConverter" />
             <converters:PlaybackStateToButtonIconConverter x:Key="PlaybackStateToButtonIconConverter" />
             <converters:VolumeToGlyphConverter x:Key="VolumeToGlyphConverter" />
+            <converters:GridListIconConverter x:Key="GridListIconConverter" />
 
             <converters:BoolToColorConverter x:Key="FavoriteToColorConverter">
                 <converters:BoolToColorConverter.TrueBrush>

--- a/Presentation/Converters/GridListIconConverter.cs
+++ b/Presentation/Converters/GridListIconConverter.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.UI.Xaml.Controls;
+
+namespace Rok.Converters;
+
+public partial class GridListIconConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is bool isGridView && isGridView)
+        {
+            return new SymbolIcon(Symbol.List);
+        }
+
+        return new SymbolIcon(Symbol.ViewAll);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Presentation/Logic/ViewModels/Playlists/PlaylistsViewModel.cs
+++ b/Presentation/Logic/ViewModels/Playlists/PlaylistsViewModel.cs
@@ -15,8 +15,23 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
 
     public RangeObservableCollection<PlaylistViewModel> SmartPlaylists { get; private set; } = [];
 
+    private bool _isGridView;
+    public bool IsGridView
+    {
+        get
+        {
+            return _isGridView;
+        }
+        private set
+        {
+            _isGridView = value;
+            OnPropertyChanged(nameof(IsGridView));
+        }
+    }
+
     public RelayCommand NewSmartPlaylistCommand { get; private set; }
     public RelayCommand NewPlaylistCommand { get; private set; }
+    public RelayCommand ToggleDisplayModeCommand { get; private set; }
 
     public PlaylistsViewModel(
         PlaylistsDataLoader dataLoader,
@@ -31,6 +46,7 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
 
         NewSmartPlaylistCommand = new RelayCommand(async () => await NewSmartPlaylistAsync());
         NewPlaylistCommand = new RelayCommand(async () => await NewPlaylistAsync());
+        ToggleDisplayModeCommand = new RelayCommand(() => IsGridView = !IsGridView);
 
         SubscribeToMessages();
         SubscribeToEvents();

--- a/Presentation/Pages/PlaylistsPage.xaml
+++ b/Presentation/Pages/PlaylistsPage.xaml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Page x:Class="Rok.Pages.PlaylistsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -10,6 +9,87 @@
       mc:Ignorable="d"
       x:Name="playlistsView">
 
+    <Page.Resources>
+
+        <ItemsPanelTemplate x:Key="GridPanel">
+            <ItemsWrapGrid Orientation="Horizontal"
+                           ItemHeight="320"
+                           ItemWidth="320"
+                           Margin="0,0,2,2" />
+        </ItemsPanelTemplate>
+
+        <ItemsPanelTemplate x:Key="ListPanel">
+            <ItemsStackPanel Orientation="Vertical" />
+        </ItemsPanelTemplate>
+
+        <DataTemplate x:Key="PlaylistGridTemplate"
+                      x:DataType="a:PlaylistViewModel">
+            <Grid Style="{StaticResource MainGridCoverStyle}">
+                <Border CornerRadius="10">
+                    <common:PictureControl Style="{StaticResource PictureCoverStyle}"
+                                           Cover="{x:Bind Picture, Mode=OneWay}"
+                                           PlayButtonVisibility="Visible"
+                                           Command="{x:Bind ListenCommand}" />
+                </Border>
+
+                <Grid Style="{StaticResource GridCoverBottomStyle}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="30" />
+                        <RowDefinition Height="30" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+
+                    <HyperlinkButton Grid.ColumnSpan="2"
+                                     Content="{x:Bind Playlist.Name}"
+                                     Command="{x:Bind PlaylistOpenCommand}"
+                                     Style="{StaticResource GridCoverBottomFirstLineStyle}" />
+                    <TextBlock Grid.Row="1"
+                               Style="{StaticResource GridCoverBottomSecondLineStyle}"
+                               Text="{x:Bind SubTitle, Mode=OneWay}" />
+                </Grid>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="PlaylistListTemplate"
+                      x:DataType="a:PlaylistViewModel">
+            <Grid Height="60"
+                  Padding="10,0"
+                  HorizontalAlignment="Stretch">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="60" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Border CornerRadius="6"
+                        Width="48"
+                        Height="48"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center">
+                    <common:PictureControl Cover="{x:Bind Picture, Mode=OneWay}"
+                                           PlayButtonVisibility="Visible"
+                                           Command="{x:Bind ListenCommand}" />
+                </Border>
+
+                <StackPanel Grid.Column="1"
+                            VerticalAlignment="Center"
+                            Margin="10,0,0,0">
+                    <HyperlinkButton Content="{x:Bind Playlist.Name}"
+                                     Command="{x:Bind PlaylistOpenCommand}"
+                                     Style="{StaticResource HyperlinkSmallButtonStyle}"
+                                     FontSize="16"
+                                     FontWeight="SemiBold"
+                                     Padding="0" />
+
+                    <TextBlock Text="{x:Bind SubTitle, Mode=OneWay}"
+                               Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+    </Page.Resources>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="50" />
@@ -19,9 +99,9 @@
         <CommandBar Grid.Row="0"
                     DefaultLabelPosition="Right"
                     Style="{StaticResource headerListCommandBar}">
-    
             <CommandBar.Content>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                <StackPanel Orientation="Horizontal"
+                            HorizontalAlignment="Left">
                     <AppBarButton x:Uid="playlistsAdd"
                                   Style="{StaticResource AppBarButtonCompactStyle}"
                                   Icon="Add"
@@ -32,11 +112,16 @@
                                   Command="{x:Bind ViewModel.NewSmartPlaylistCommand}" />
                 </StackPanel>
             </CommandBar.Content>
+
+            <AppBarSeparator />
+
+            <AppBarToggleButton Icon="{x:Bind ViewModel.IsGridView, Mode=OneWay, Converter={StaticResource GridListIconConverter}}"
+                                Command="{x:Bind ViewModel.ToggleDisplayModeCommand}"
+                                IsChecked="{x:Bind ViewModel.IsGridView, Mode=OneWay}" />
         </CommandBar>
 
         <Grid Grid.Row="1"
               Style="{StaticResource gridList}">
-
             <Grid.Background>
                 <LinearGradientBrush StartPoint="0.5,0"
                                      EndPoint="0.5,1">
@@ -49,138 +134,66 @@
 
             <ScrollViewer>
                 <StackPanel>
+                    <GridViewHeaderItem FontSize="24"
+                                        FontWeight="Bold"
+                                        HorizontalAlignment="Left">
+                        <GridViewHeaderItem.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <SymbolIcon Symbol="OutlineStar"
+                                            Margin="4,0,4,0" />
+                                <TextBlock x:Uid="smartPlaylistHeader" />
+                            </StackPanel>
+                        </GridViewHeaderItem.Content>
+                    </GridViewHeaderItem>
 
-                
-                
-                <GridViewHeaderItem FontSize="24"
-                                    FontWeight="Bold"
-                                    HorizontalAlignment="Left">
-                    <GridViewHeaderItem.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <SymbolIcon Symbol="OutlineStar"
-                                        Margin="4,0,4,0" />
-                            <TextBlock x:Uid="smartPlaylistHeader"></TextBlock>
-                        </StackPanel>
-                    </GridViewHeaderItem.Content>
-                </GridViewHeaderItem>
+                    <common:GridViewExtended x:Name="gridSmartPlaylist"
+                                             ContainerContentChanging="grid_ContainerContentChanging"
+                                             ItemsSource="{x:Bind ViewModel.SmartPlaylists}"
+                                             ItemTemplate="{StaticResource PlaylistGridTemplate}"
+                                             ItemsPanel="{StaticResource GridPanel}"
+                                             Visibility="{x:Bind ViewModel.IsGridView, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                             SelectionMode="None"
+                                             IsItemClickEnabled="True"
+                                             ScrollViewer.VerticalScrollMode="Disabled" />
 
-                <common:GridViewExtended Grid.Row="2"
-                                     x:Name="gridSmartPlaylist"
-                                     ContainerContentChanging="grid_ContainerContentChanging"
-                                     ItemsSource="{x:Bind ViewModel.SmartPlaylists}"
-                                     Margin="0"
-                                     ScrollViewer.VerticalScrollMode="Enabled"
-                                     ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListView x:Name="listSmartPlaylist"
+                              ContainerContentChanging="grid_ContainerContentChanging"
+                              ItemsSource="{x:Bind ViewModel.SmartPlaylists}"
+                              ItemTemplate="{StaticResource PlaylistListTemplate}"
+                              Visibility="{x:Bind ViewModel.IsGridView, Mode=OneWay, Converter={StaticResource BoolToInvertVisibilityConverter}}"
+                              SelectionMode="None"
+                              IsItemClickEnabled="True" />
 
-                <GridView.ItemTemplate>
-                    <DataTemplate x:DataType="a:PlaylistViewModel">
+                    <GridViewHeaderItem FontSize="24"
+                                        FontWeight="Bold"
+                                        HorizontalAlignment="Left">
+                        <GridViewHeaderItem.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <SymbolIcon Symbol="Shop"
+                                            Margin="4,0,4,0" />
+                                <TextBlock x:Uid="playlistHeader" />
+                            </StackPanel>
+                        </GridViewHeaderItem.Content>
+                    </GridViewHeaderItem>
 
-                        <Grid Style="{StaticResource MainGridCoverStyle}">
-                            <Border CornerRadius="10">
-                                <common:PictureControl Style="{StaticResource PictureCoverStyle}"
-                                                       Cover="{x:Bind Picture, Mode=OneWay}"
-                                                       PlayButtonVisibility="Visible"
-                                                       Command="{x:Bind ListenCommand}" />
-                            </Border>
-                           
-                            <Grid Style="{StaticResource GridCoverBottomStyle}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="30" />
-                                    <RowDefinition Height="30" />
-                                </Grid.RowDefinitions>
+                    <common:GridViewExtended x:Name="gridPlaylist"
+                                             ContainerContentChanging="grid_ContainerContentChanging"
+                                             ItemsSource="{x:Bind ViewModel.Playlists}"
+                                             ItemTemplate="{StaticResource PlaylistGridTemplate}"
+                                             ItemsPanel="{StaticResource GridPanel}"
+                                             Visibility="{x:Bind ViewModel.IsGridView, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                             SelectionMode="None"
+                                             IsItemClickEnabled="True"
+                                             ScrollViewer.VerticalScrollMode="Disabled" />
 
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="2*" />
-                                    <ColumnDefinition />
-                                </Grid.ColumnDefinitions>
-                              
-                                <HyperlinkButton Grid.ColumnSpan="2"
-                                                 Content="{x:Bind Playlist.Name}"
-                                                 Command="{x:Bind PlaylistOpenCommand}"
-                                                 Style="{StaticResource GridCoverBottomFirstLineStyle}" />
-                                <TextBlock Grid.Row="1"
-                                           Style="{StaticResource GridCoverBottomSecondLineStyle}"
-                                           Text="{x:Bind SubTitle, Mode=OneWay}" />
-                            </Grid>
-                        </Grid>
-                    </DataTemplate>
-                </GridView.ItemTemplate>
-
-                <GridView.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <ItemsWrapGrid Orientation="Horizontal"
-                                       ItemHeight="320"
-                                       ItemWidth="320"
-                                       Margin="0,0,2,2" />
-                    </ItemsPanelTemplate>
-                </GridView.ItemsPanel>
-            </common:GridViewExtended>
-
-                <GridViewHeaderItem FontSize="24"
-                                    FontWeight="Bold"
-                                    HorizontalAlignment="Left">
-                    <GridViewHeaderItem.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <SymbolIcon Symbol="Shop"
-                                        Margin="4,0,4,0" />
-                            <TextBlock x:Uid="playlistHeader"></TextBlock>
-                        </StackPanel>
-                    </GridViewHeaderItem.Content>
-                </GridViewHeaderItem>
-
-                <common:GridViewExtended Grid.Row="2"
-                                     x:Name="gridPlaylist"
-                                     ContainerContentChanging="grid_ContainerContentChanging"
-                                     ItemsSource="{x:Bind ViewModel.Playlists}"
-                                     Margin="0"
-                                     ScrollViewer.VerticalScrollMode="Enabled"
-                                     ScrollViewer.VerticalScrollBarVisibility="Auto">
-
-                <GridView.ItemTemplate>
-                    <DataTemplate x:DataType="a:PlaylistViewModel">
-
-                        <Grid Style="{StaticResource MainGridCoverStyle}">
-                            <Border CornerRadius="10">
-                                <common:PictureControl Style="{StaticResource PictureCoverStyle}"
-                                                       Cover="{x:Bind Picture, Mode=OneWay}"
-                                                       PlayButtonVisibility="Visible"
-                                                       Command="{x:Bind ListenCommand}" />
-                            </Border>
-
-                            <Grid Style="{StaticResource GridCoverBottomStyle}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="30" />
-                                    <RowDefinition Height="30" />
-                                </Grid.RowDefinitions>
-
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="2*" />
-                                    <ColumnDefinition />
-                                </Grid.ColumnDefinitions>
-
-                                <HyperlinkButton Grid.ColumnSpan="2"
-                                                 Content="{x:Bind Playlist.Name}"
-                                                 Command="{x:Bind PlaylistOpenCommand}"
-                                                 Style="{StaticResource GridCoverBottomFirstLineStyle}" />
-                                <TextBlock Grid.Row="1"
-                                           Style="{StaticResource GridCoverBottomSecondLineStyle}"
-                                           Text="{x:Bind SubTitle, Mode=OneWay}" />
-                            </Grid>
-                        </Grid>
-                    </DataTemplate>
-                </GridView.ItemTemplate>
-
-                <GridView.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <ItemsWrapGrid Orientation="Horizontal"
-                                       ItemHeight="320"
-                                       ItemWidth="320"
-                                       Margin="0,0,2,2" />
-                    </ItemsPanelTemplate>
-                </GridView.ItemsPanel>
-            </common:GridViewExtended>
-                
-            </StackPanel>
+                    <ListView x:Name="listPlaylist"
+                              ContainerContentChanging="grid_ContainerContentChanging"
+                              ItemsSource="{x:Bind ViewModel.Playlists}"
+                              ItemTemplate="{StaticResource PlaylistListTemplate}"
+                              Visibility="{x:Bind ViewModel.IsGridView, Mode=OneWay, Converter={StaticResource BoolToInvertVisibilityConverter}}"
+                              SelectionMode="None"
+                              IsItemClickEnabled="True" />
+                </StackPanel>
             </ScrollViewer>
         </Grid>
     </Grid>

--- a/Presentation/Pages/PlaylistsPage.xaml.cs
+++ b/Presentation/Pages/PlaylistsPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using Rok.Logic.ViewModels.Playlists;
@@ -14,19 +15,34 @@ public sealed partial class PlaylistsPage : Page, IDisposable
         InitializeComponent();
 
         ViewModel = App.ServiceProvider.GetRequiredService<PlaylistsViewModel>();
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
     }
 
 
     protected override async void OnNavigatedTo(NavigationEventArgs e)
     {
         await ViewModel.LoadDataAsync(forceReload: false);
+        UpdateVisualState();
 
         base.OnNavigatedTo(e);
     }
 
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(PlaylistsViewModel.IsGridView))
+        {
+            UpdateVisualState();
+        }
+    }
+
+    private void UpdateVisualState()
+    {
+        VisualStateManager.GoToState(this, ViewModel.IsGridView ? "GridViewState" : "ListViewState", true);
+    }
 
     public void Dispose()
     {
+        ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
     }
 
     private void grid_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)


### PR DESCRIPTION
Introduce a toggle to switch between grid and list views for playlists. Add IsGridView property and ToggleDisplayModeCommand in PlaylistsViewModel. Implement GridListIconConverter for dynamic toggle button icon. Refactor PlaylistsPage XAML: use dedicated DataTemplates for each view. Display playlists in GridView or ListView based on IsGridView. Update code-behind to handle visual state and property changes. Register/unregister PropertyChanged event for IsGridView. Add converter to App resources.
Enhances user experience with flexible playlist display options.