### PR TITLE
Bump app version to 1.1.17.0 in Package.appxmanifest

### DIFF
--- a/Presentation/Package.appxmanifest
+++ b/Presentation/Package.appxmanifest
@@ -9,7 +9,7 @@
 	<Identity
 	  Name="dev-Rokapp.Rokmusicplayer"
 	  Publisher="CN=C9A55691-54ED-46EA-9D4F-F3CD41C04242"
-	  Version="1.1.16.0" />
+	  Version="1.1.17.0" />
 
 	<Properties>
 		<DisplayName>Rok musicplayer (dev)</DisplayName>


### PR DESCRIPTION
The application version in Package.appxmanifest has been incremented from 1.1.16.0 to 1.1.17.0.
No other changes were made in this commit.
This update prepares the app for a new release cycle. No functional or code changes are included.
Only the manifest metadata has been updated.