### PR TITLE
Refactor playlist loading to use Track objects only

### DIFF
--- a/Presentation/Logic/ViewModels/Playlist/PlaylistViewModel.cs
+++ b/Presentation/Logic/ViewModels/Playlist/PlaylistViewModel.cs
@@ -261,7 +261,7 @@ public partial class PlaylistViewModel : ObservableObject
 
         if (_tracks?.Any() == true)
         {
-            _playerService.LoadPlaylist(_tracks.ToList());
+            _playerService.LoadPlaylist(Tracks.Select(t => t.Track).ToList());
         }
     }
 


### PR DESCRIPTION
Replaced _playerService.LoadPlaylist(_tracks.ToList()) with _playerService.LoadPlaylist(Tracks.Select(t => t.Track).ToList()). This change ensures that only Track objects are passed to the player service, instead of wrapper or container objects. This should improve type safety and prevent potential issues with unexpected object types. No changes were made to the logic for loading or generating tracks. This refactor clarifies the data flow between the view model and the player service.