### PR TITLE
chore(manifest): remove dev suffix, bump version to 1.1.18.0

### DIFF
--- a/Presentation/Package.appxmanifest
+++ b/Presentation/Package.appxmanifest
@@ -7,12 +7,12 @@
          IgnorableNamespaces="uap rescap uap3">
 
 	<Identity
-	  Name="dev-Rokapp.Rokmusicplayer"
+	  Name="Rokapp.Rokmusicplayer"
 	  Publisher="CN=C9A55691-54ED-46EA-9D4F-F3CD41C04242"
-	  Version="1.1.17.0" />
+	  Version="1.1.18.0" />
 
 	<Properties>
-		<DisplayName>Rok musicplayer (dev)</DisplayName>
+		<DisplayName>Rok musicplayer</DisplayName>
 		<PublisherDisplayName>Rok app</PublisherDisplayName>
 		<Logo>Assets\StoreLogo.png</Logo>
 	</Properties>


### PR DESCRIPTION
Updated the app identity name by removing the "dev" prefix. Changed the DisplayName to "Rok musicplayer" (removed "(dev)"). Incremented the app version from 1.1.17.0 to 1.1.18.0. These changes prepare the app for a production release. No other functional changes were made in this commit.