### PR TITLE
Refactor IsFavorite binding & DI for album/artist/genre handlers

### DIFF
--- a/Presentation/DependencyInjection.cs
+++ b/Presentation/DependencyInjection.cs
@@ -52,8 +52,8 @@ public static class DependencyInjection
         services.AddTransient<AlbumsSelectionManager>();
         services.AddTransient<AlbumsStateManager>();
         services.AddTransient<AlbumsPlaybackService>();
-        services.AddSingleton<AlbumUpdateMessageHandler>();
-        services.AddSingleton<AlbumImportedMessageHandler>();
+        services.AddTransient<AlbumUpdateMessageHandler>();
+        services.AddTransient<AlbumImportedMessageHandler>();
         services.AddTransient<IAlbumProvider, AlbumProvider>();
         services.AddTransient<IAlbumLibraryMonitor, AlbumLibraryMonitor>();
         services.AddTransient<AlbumsGroupCategory>();

--- a/Presentation/Logic/ViewModels/Album/AlbumViewModel.cs
+++ b/Presentation/Logic/ViewModels/Album/AlbumViewModel.cs
@@ -30,11 +30,10 @@ public partial class AlbumViewModel : ObservableObject
     public IPlaylistMenuService PlaylistMenuService { get; }
 
 
-    [ObservableProperty]
-    public partial bool IsFavorite { get; set; }
-    partial void OnIsFavoriteChanged(bool value)
+    public bool IsFavorite
     {
-        Album.IsFavorite = value;
+        get => Album.IsFavorite;
+        set => SetProperty(Album.IsFavorite, value, Album, (album, val) => album.IsFavorite = val);
     }
 
     [ObservableProperty]

--- a/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
+++ b/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
@@ -36,11 +36,10 @@ public partial class ArtistViewModel : ObservableObject
     public RangeObservableCollection<AlbumViewModel> Albums { get; set; } = [];
 
 
-    [ObservableProperty]
-    public partial bool IsFavorite { get; set; }
-    partial void OnIsFavoriteChanged(bool value)
+    public bool IsFavorite
     {
-        Artist.IsFavorite = value;
+        get => Artist.IsFavorite;
+        set => SetProperty(Artist.IsFavorite, value, Artist, (artist, val) => artist.IsFavorite = val);
     }
 
     [ObservableProperty]

--- a/Presentation/Logic/ViewModels/Genre/GenreViewModel.cs
+++ b/Presentation/Logic/ViewModels/Genre/GenreViewModel.cs
@@ -24,11 +24,10 @@ public partial class GenreViewModel : ObservableObject
     public RangeObservableCollection<AlbumViewModel> Albums { get; set; } = [];
     public GenreDto Genre { get; private set; } = new();
 
-    [ObservableProperty]
-    public partial bool IsFavorite { get; set; }
-    partial void OnIsFavoriteChanged(bool value)
+    public bool IsFavorite
     {
-        Genre.IsFavorite = value;
+        get => Genre.IsFavorite;
+        set => SetProperty(Genre.IsFavorite, value, Genre, (genre, val) => genre.IsFavorite = val);
     }
 
     [ObservableProperty]


### PR DESCRIPTION
Refactored IsFavorite property in AlbumViewModel, ArtistViewModel, and GenreViewModel to delegate directly to the underlying DTO and use SetProperty for change notification. Removed [ObservableProperty] and partial methods for IsFavorite. Changed AlbumUpdateMessageHandler and AlbumImportedMessageHandler registration from singleton to transient in DependencyInjection for better instance management. These changes improve data synchronization and service lifecycle handling. Aucune modification fonctionnelle attendue côté UI.