### PR TITLE
fix(sql): add trailing space to DefaultGroupBy constants

### DIFF
--- a/Infrastructure/Rok.Infrastructure/Repositories/AlbumRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/AlbumRepository.cs
@@ -13,7 +13,7 @@ public class AlbumRepository(IDbConnection connection, [FromKeyedServices("Backg
     private const string UpdateStatisticsSql = "UPDATE albums SET trackCount = @trackCount, duration = @duration WHERE id = @id";
     private const string UpdateMetadataAttemptSql = "UPDATE albums SET getMetaDataLastAttempt = @lastAttemptDate WHERE id = @id";
     private const string DeleteOrphansSql = "DELETE FROM albums WHERE id NOT IN (SELECT DISTINCT albumId FROM tracks WHERE albumId IS NOT NULL)";
-    private const string DefaultGroupBy = " GROUP BY albums.id";
+    private const string DefaultGroupBy = " GROUP BY albums.id ";
 
     public async Task<IEnumerable<IAlbumEntity>> SearchAsync(string name, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
     {

--- a/Infrastructure/Rok.Infrastructure/Repositories/ArtistRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/ArtistRepository.cs
@@ -15,7 +15,7 @@ public class ArtistRepository(IDbConnection connection, [FromKeyedServices("Back
     private const string UpdateStatisticsSql = "UPDATE artists SET trackCount = @trackCount, totalDurationSeconds = @totalDurationSeconds, albumCount = @albumCount, bestOfCount = @bestOfCount, liveCount = @liveCount, compilationCount = @compilationCount, yearMini = @yearMini, yearMaxi = @yearMaxi WHERE id = @id";
     private const string UpdateMetadataAttemptSql = "UPDATE artists SET getMetaDataLastAttempt = @lastAttemptDate WHERE id = @id";
     private const string DeleteOrphansSql = "DELETE FROM artists WHERE id NOT IN (SELECT DISTINCT artistId FROM tracks WHERE artistId IS NOT NULL)";
-    private const string DefaultGroupBy = " GROUP BY artists.id";
+    private const string DefaultGroupBy = " GROUP BY artists.id ";
 
     public async Task<IEnumerable<IArtistEntity>> SearchAsync(string name, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)
     {

--- a/Infrastructure/Rok.Infrastructure/Repositories/TrackRepository.cs
+++ b/Infrastructure/Rok.Infrastructure/Repositories/TrackRepository.cs
@@ -13,7 +13,7 @@ public class TrackRepository(IDbConnection db, [FromKeyedServices("BackgroundCon
     private const string UpdateSkipCountSql = "UPDATE tracks SET skipCount = skipCount + 1, lastSkip = @lastSkip WHERE Id = @id";
     private const string UpdateFileDateSql = "UPDATE tracks SET fileDate = @fileDate WHERE id = @id";
     private const string UpdateGetLyricsLastAttemptSql = "UPDATE tracks SET getLyricsLastAttempt = @lastAttemptDate WHERE id = @id";
-    private const string DefaultGroupBy = " GROUP BY tracks.id";
+    private const string DefaultGroupBy = " GROUP BY tracks.id ";
 
 
     public async Task<IEnumerable<TrackEntity>> SearchAsync(string name, RepositoryConnectionKind kind = RepositoryConnectionKind.Foreground)


### PR DESCRIPTION
Added a trailing space to the DefaultGroupBy SQL constants in AlbumRepository, ArtistRepository, and TrackRepository. This change prevents SQL syntax errors when concatenating additional clauses after GROUP BY, ensuring proper spacing and avoiding malformed queries. No functional logic was altered; this is a preventive fix to improve SQL string construction reliability.