### PR TITLE
feat: Refactor track info layout: align rating next to title

### DIFF
--- a/Presentation/Commons/FullScreenControl.xaml
+++ b/Presentation/Commons/FullScreenControl.xaml
@@ -406,16 +406,29 @@
 
             <Grid x:Name="trackInfo">
 
-                <TextBlock x:Name="title"
-                           Text="{x:Bind PlayerViewModel.CurrentTrack.Title, Mode=OneWay}"
-                           VerticalAlignment="Bottom"
-                           Margin="340,0,0,80"
-                           FontSize="30"
-                           Foreground="White"
-                           HorizontalAlignment="Left"
-                           TextWrapping="NoWrap"
-                           Width="auto"
-                           FontWeight="Bold" />
+                <RelativePanel VerticalAlignment="Bottom">
+
+                    <TextBlock x:Name="title"
+                               Text="{x:Bind PlayerViewModel.CurrentTrack.Title, Mode=OneWay}"
+                               VerticalAlignment="Bottom"
+                               Margin="340,0,0,80"
+                               FontSize="30"
+                               Foreground="White"
+                               HorizontalAlignment="Left"
+                               TextWrapping="NoWrap"
+                               Width="auto"
+                               FontWeight="Bold" />
+
+                    <local:RatingControlDarkControl x:Name="score"
+                                                    Value="{x:Bind PlayerViewModel.CurrentTrack.Score, Mode=TwoWay}"
+                                                    RelativePanel.AlignVerticalCenterWith="title"
+                                                    RelativePanel.RightOf="title"
+                                                    Margin="10,0,20,80"
+                                                    Height="30"
+                                                    BorderThickness="0"
+                                                    HorizontalAlignment="Left" />
+                </RelativePanel>
+
                 <TextBlock x:Name="artist"
                            Text="{x:Bind PlayerViewModel.CurrentTrack.ArtistName, Mode=OneWay}"
                            VerticalAlignment="Bottom"
@@ -424,15 +437,8 @@
                            Foreground="White"
                            HorizontalAlignment="Left"
                            TextWrapping="NoWrap"
-                           Width="600"
+                           MaxWidth="600"
                            FontWeight="Bold" />
-                <local:RatingControlDarkControl x:Name="score"
-                                                Value="{x:Bind PlayerViewModel.CurrentTrack.Score, Mode=TwoWay}"
-                                                VerticalAlignment="Bottom"
-                                                Margin="0,0,20,50"
-                                                Height="30"
-                                                BorderThickness="0"
-                                                HorizontalAlignment="Right" />
             </Grid>
         </Grid>
     </Grid>


### PR DESCRIPTION
Reorganized the title and rating controls into a RelativePanel for better alignment. The rating control is now placed to the right of the title and vertically centered. Removed the old rating control previously aligned bottom right. Changed artist TextBlock from fixed Width to MaxWidth for better text wrapping. Improves readability and visual consistency of the track info section. No changes to underlying data bindings or logic.
Ajusted margins for improved spacing between elements. No impact on other UI components.
Tested for layout correctness in fullscreen mode.
Pas de modifications fonctionnelles côté ViewModel.