### PR TITLE
feat(menu): add "Current Listening" option to context menu

### DIFF
--- a/Core/Rok.Application/Features/Playlists/PlaylistMenu/IPlaylistMenuService.cs
+++ b/Core/Rok.Application/Features/Playlists/PlaylistMenu/IPlaylistMenuService.cs
@@ -12,6 +12,12 @@ public interface IPlaylistMenuService
 
     Task AddArtistToPlaylistAsync(long playlistId, long artistId);
 
+    Task AddArtistToCurrentListeningAsync(long artistId);
+
+    Task AddAlbumToCurrentListeningAsync(long albumId);
+
+    Task AddTrackToCurrentListeningAsync(long trackId);
+
     Task CreateNewPlaylistWithTrackAsync(string playlistName, long trackId);
 
     Task CreateNewPlaylistWithAlbumAsync(string playlistName, long albumId);

--- a/Presentation/Logic/Services/Player/PlayerService.cs
+++ b/Presentation/Logic/Services/Player/PlayerService.cs
@@ -1,6 +1,6 @@
-﻿using Rok.Application.Player;
+﻿using System.Threading;
+using Rok.Application.Player;
 using Rok.Infrastructure.Social;
-using System.Threading;
 
 namespace Rok.Logic.Services.Player;
 
@@ -224,7 +224,12 @@ public class PlayerService : IPlayerService
     {
         Guard.Against.Null(tracks);
 
+        bool hasTracks = Playlist.Count > 0;
+
         tracks.ForEach(c => Playlist.Add(c));
+
+        if (!hasTracks)
+            Start();
 
         Messenger.Send(new PlaylistChanged(Playlist));
     }

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1143,4 +1143,7 @@
   <data name="TagsBox.PlaceholderText" xml:space="preserve">
     <value>+ add tag</value>
   </data>
+  <data name="MenuFlyout_CurrentListening_Text" xml:space="preserve">
+    <value>Current listening</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1143,4 +1143,7 @@
   <data name="TagsBox.PlaceholderText" xml:space="preserve">
     <value>+ ajouter tag</value>
   </data>
+  <data name="MenuFlyout_CurrentListening_Text" xml:space="preserve">
+    <value>Ecoute en cours</value>
+  </data>
 </root>


### PR DESCRIPTION
Adds the ability to add a track, album, or artist to the current listening queue directly from the context menu. Updates IPlaylistMenuService with async methods for this feature and implements them in PlaylistMenuService. Injects IPlayerService to handle playlist updates and playback start if the queue was empty. Adds a new localized menu item ("Current listening" / "Ecoute en cours") with appropriate event handling. Improves user feedback with error notifications on failure. Resources updated for EN/FR support.