### PR TITLE
feat(import): add throttling & UI progress for import

### DIFF
--- a/Core/Rok.Import/DependencyInjection.cs
+++ b/Core/Rok.Import/DependencyInjection.cs
@@ -18,6 +18,7 @@ public static class DependencyInjection
         services.AddSingleton<TrackImport>();
 
         services.AddSingleton<CountryCache>();
+        services.AddSingleton<ImportMessageThrottler>();
 
         services.AddScoped<ImportProgressService>();
         services.AddScoped<ImportTrackingService>();

--- a/Core/Rok.Import/Services/ImportMessageThrottler.cs
+++ b/Core/Rok.Import/Services/ImportMessageThrottler.cs
@@ -1,0 +1,53 @@
+namespace Rok.Import.Services;
+
+public class ImportMessageThrottler
+{
+    private const int MaxMessagesBeforeThrottle = 40;
+    private int _albumMessagesSent = 0;
+    private bool _isAlbumThrottled = false;
+    private int _artistMessagesSent = 0;
+    private bool _isArtistThrottled = false;
+
+    public bool ShouldSendAlbumMessage()
+    {
+        if (_isAlbumThrottled)
+            return false;
+
+        _albumMessagesSent++;
+
+        if (_albumMessagesSent >= MaxMessagesBeforeThrottle)
+        {
+            _isAlbumThrottled = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    public bool ShouldSendArtistMessage()
+    {
+        if (_isArtistThrottled)
+            return false;
+
+        _artistMessagesSent++;
+
+        if (_artistMessagesSent >= MaxMessagesBeforeThrottle)
+        {
+            _isArtistThrottled = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    public void Reset()
+    {
+        _albumMessagesSent = 0;
+        _isAlbumThrottled = false;
+        _artistMessagesSent = 0;
+        _isArtistThrottled = false;
+    }
+
+    public bool IsAlbumThrottled => _isAlbumThrottled;
+    public bool IsArtistThrottled => _isArtistThrottled;
+}

--- a/Presentation/Logic/ViewModels/Albums/AlbumsViewModel.cs
+++ b/Presentation/Logic/ViewModels/Albums/AlbumsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Dispatching;
 using Rok.Logic.ViewModels.Albums.Interfaces;
 using Rok.Logic.ViewModels.Albums.Services;
 
@@ -15,6 +16,7 @@ public partial class AlbumsViewModel : ObservableObject, IDisposable
     private readonly AlbumsSelectionManager _selectionManager;
     private readonly AlbumsStateManager _stateManager;
     private readonly AlbumsPlaybackService _playbackService;
+    private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
     private bool _stateLoaded = false;
     private bool _libraryUpdated = false;
     private List<AlbumViewModel> _filteredAlbums = [];
@@ -74,7 +76,7 @@ public partial class AlbumsViewModel : ObservableObject, IDisposable
     private void OnLibraryChanged(object? sender, EventArgs e)
     {
         _libraryUpdated = true;
-        FilterAndSort();
+        _dispatcherQueue.TryEnqueue(() => FilterAndSort());
     }
 
 

--- a/Presentation/Logic/ViewModels/Artists/ArtistsViewModel.cs
+++ b/Presentation/Logic/ViewModels/Artists/ArtistsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Dispatching;
 using Rok.Logic.ViewModels.Artists.Interfaces;
 using Rok.Logic.ViewModels.Artists.Services;
 
@@ -15,6 +16,7 @@ public partial class ArtistsViewModel : ObservableObject, IDisposable
     private readonly ArtistsSelectionManager _selectionManager;
     private readonly ArtistsStateManager _stateManager;
     private readonly ArtistsPlaybackService _playbackService;
+    private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
     private bool _stateLoaded = false;
     private bool _libraryUpdated = false;
     private List<ArtistViewModel> _filteredArtists = [];
@@ -75,7 +77,7 @@ public partial class ArtistsViewModel : ObservableObject, IDisposable
     private void OnLibraryChanged(object? sender, EventArgs e)
     {
         _libraryUpdated = true;
-        FilterAndSort();
+        _dispatcherQueue.TryEnqueue(() => FilterAndSort());
     }
 
 

--- a/Presentation/Logic/ViewModels/Start/StartViewModel.cs
+++ b/Presentation/Logic/ViewModels/Start/StartViewModel.cs
@@ -31,6 +31,12 @@ public partial class StartViewModel : ObservableObject
     [ObservableProperty]
     public partial bool ErrorOccurred { get; set; } = false;
 
+    [ObservableProperty]
+    private string _importProgressText = string.Empty;
+
+    [ObservableProperty]
+    private double _importProgress = 0;
+
 
 
     public StartViewModel(IAlbumPicture albumPicture, ISettingsFile settingsFile, NavigationService navigationService, IMediator mediator, IImport importService, IAppOptions appOptions)
@@ -112,7 +118,10 @@ public partial class StartViewModel : ObservableObject
                     Picture = cover
                 });
 
-                if (AlbumsImported.Count > KAlbumMinimumBeforeUse)
+                ImportProgressText = $"{AlbumsImported.Count} albums discovered";
+                ImportProgress = Math.Min((AlbumsImported.Count * 100.0) / KAlbumMinimumBeforeUse, 100);
+
+                if (AlbumsImported.Count >= KAlbumMinimumBeforeUse)
                 {
                     UnregisterEvents();
                     _navigationService.NavigateToAlbums();

--- a/Presentation/Logic/ViewModels/Tracks/TracksViewModel.cs
+++ b/Presentation/Logic/ViewModels/Tracks/TracksViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Dispatching;
 using Rok.Logic.ViewModels.Tracks.Interfaces;
 using Rok.Logic.ViewModels.Tracks.Services;
 
@@ -13,6 +14,7 @@ public partial class TracksViewModel : ObservableObject, IDisposable
     private readonly TracksSelectionManager _selectionManager;
     private readonly TracksStateManager _stateManager;
     private readonly TracksPlaybackService _playbackService;
+    private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
     private bool _stateLoaded = false;
     private bool _libraryUpdated = false;
     private List<TrackViewModel> _filteredTracks = [];
@@ -62,7 +64,7 @@ public partial class TracksViewModel : ObservableObject, IDisposable
     private void OnLibraryChanged(object? sender, EventArgs e)
     {
         _libraryUpdated = true;
-        FilterAndSort();
+        _dispatcherQueue.TryEnqueue(() => FilterAndSort());
     }
 
 

--- a/Presentation/MainWindow.xaml.cs
+++ b/Presentation/MainWindow.xaml.cs
@@ -220,6 +220,11 @@ public sealed partial class MainWindow : Window
                 IconRotation.Begin();
                 libraryRefreshButton.Content = msg.ProcessMessage;
             }
+            else if (msg.ProcessState == LibraryRefreshMessage.EState.Unchanged)
+            {
+                if (!string.IsNullOrWhiteSpace(msg.ProcessMessage))
+                    libraryRefreshButton.Content = msg.ProcessMessage;
+            }
             else if (msg.ProcessState == LibraryRefreshMessage.EState.CleanData)
             {
                 libraryRefreshButton.Content = _resourceLoader.GetString("genCleanData");
@@ -235,10 +240,6 @@ public sealed partial class MainWindow : Window
                     IconRotation.Stop();
                     libraryRefreshButton.Content = _resourceLoader.GetString("genRefreshLibrary");
                 }
-            }
-            else
-            {
-                libraryRefreshButton.Content = msg.ProcessMessage;
             }
         });
     }

--- a/Presentation/Pages/WelcomePage.xaml
+++ b/Presentation/Pages/WelcomePage.xaml
@@ -5,8 +5,23 @@
       xmlns:local="using:Rok.Pages"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:common="using:Rok.Commons"      
+      xmlns:common="using:Rok.Commons"
+      xmlns:media="using:Microsoft.UI.Xaml.Media"
       mc:Ignorable="d">
+
+    <Page.Resources>
+        <Storyboard x:Name="FadeInStoryboard">
+            <DoubleAnimation Storyboard.TargetName="mainContent"
+                             Storyboard.TargetProperty="Opacity"
+                             From="0"
+                             To="1"
+                             Duration="0:0:0.8">
+                <DoubleAnimation.EasingFunction>
+                    <CubicEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+            </DoubleAnimation>
+        </Storyboard>
+    </Page.Resources>
 
     <Grid Loaded="Grid_Loaded">
         <Grid.Background>
@@ -14,113 +29,157 @@
                         Stretch="UniformToFill" />
         </Grid.Background>
 
-        <StackPanel Orientation="Vertical">
-            <RelativePanel Background="#99000000"
-                           Height="100"
-                           VerticalAlignment="Top">
+        <Grid x:Name="mainContent" Opacity="0">
+            <StackPanel Orientation="Vertical" Spacing="20">
+                <Grid Background="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
+                      CornerRadius="8"
+                      Margin="20,20,20,0"
+                      Padding="24"
+                      MaxWidth="800"
+                      HorizontalAlignment="Center">
+                    
+                    <StackPanel x:Name="panelWaiting" Spacing="16">
+                        <TextBlock Text="Welcome to Rok"
+                                   FontSize="32"
+                                   FontWeight="SemiBold"
+                                   Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                   HorizontalAlignment="Center" />
 
-                <StackPanel x:Name="panelWaiting"
-                            Orientation="Horizontal"
-                            Margin="10,20,0,0">
+                        <StackPanel Orientation="Horizontal"
+                                    HorizontalAlignment="Center"
+                                    Spacing="12"
+                                    Visibility="{x:Bind ViewModel.LibraryRefreshRunning, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">
+                            <ProgressRing IsActive="{x:Bind ViewModel.LibraryRefreshRunning, Mode=OneWay}"
+                                          Width="24"
+                                          Height="24" />
+                            <StackPanel Spacing="4">
+                                <TextBlock x:Uid="welcomeWaiting"
+                                           FontSize="16"
+                                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                           TextWrapping="Wrap" />
+                                <TextBlock Text="{x:Bind ViewModel.ImportProgressText, Mode=OneWay}"
+                                           FontSize="14"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Opacity="0.8" />
+                            </StackPanel>
+                        </StackPanel>
 
-                    <ProgressRing x:Name="libraryRefresh"
-                                  IsActive="{x:Bind ViewModel.LibraryRefreshRunning,Mode=OneWay}"
-                                  Visibility="{x:Bind ViewModel.LibraryRefreshRunning, Converter={StaticResource BoolToVisibilityConverter},Mode=OneWay}"
-                                  Margin="10,0,10,0" />
+                        <ProgressBar IsIndeterminate="False"
+                                     Value="{x:Bind ViewModel.ImportProgress, Mode=OneWay}"
+                                     Maximum="100"
+                                     Visibility="{x:Bind ViewModel.LibraryRefreshRunning, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
+                                     Margin="0,8,0,0" />
+                    </StackPanel>
+                </Grid>
 
-                    <TextBlock x:Uid="welcomeWaiting"
-                               x:Name="welcomeWaiting"
-                               Height="50"
-                               Width="500"
-                               TextWrapping="Wrap"
-                               Foreground="White" />
-                </StackPanel>
-            </RelativePanel>
-
-            <Grid Margin="4,10,4,10">
-                <GridView x:Name="listAlbums"
-                          Height="300"
-                          ItemsSource="{x:Bind ViewModel.AlbumsImported}"
-                          ScrollViewer.HorizontalScrollBarVisibility="Hidden"
-                          ScrollViewer.VerticalScrollBarVisibility="Hidden"
-                          ScrollViewer.HorizontalScrollMode="Disabled"
-                          ScrollViewer.VerticalScrollMode="Disabled">
+                <ScrollViewer MaxHeight="600"
+                              VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled">
+                    <GridView x:Name="listAlbums"
+                              ItemsSource="{x:Bind ViewModel.AlbumsImported}"
+                              MaxWidth="1400"
+                              Padding="20,0"
+                              SelectionMode="None"
+                              IsItemClickEnabled="False">
+                    <GridView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <ItemsWrapGrid Orientation="Horizontal"
+                                           MaximumRowsOrColumns="4" />
+                        </ItemsPanelTemplate>
+                    </GridView.ItemsPanel>
+                    
                     <GridView.ItemTemplate>
                         <DataTemplate>
-                            <Grid HorizontalAlignment="Left"
-                                  Width="300"
-                                  Height="300"
-                                  Margin="4"
-                                  BorderBrush="Gray"
-                                  BorderThickness="0">
-                                <Border>
-                                    <common:PictureControl Padding="0"
-                                                           Margin="0"
-                                                           Cover="{Binding Picture, Mode=OneWay}"
+                            <Grid Width="280"
+                                  Height="280"
+                                  Margin="8"
+                                  CornerRadius="8"
+                                  Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                  BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                  BorderThickness="1">
+                                <Grid.Shadow>
+                                    <ThemeShadow />
+                                </Grid.Shadow>
+
+                                <Grid CornerRadius="8">
+                                    <common:PictureControl Cover="{Binding Picture, Mode=OneWay}"
                                                            VerticalAlignment="Center"
                                                            HorizontalAlignment="Center"
                                                            PlayButtonVisibility="Collapsed" />
-                                </Border>
 
-                                <Grid VerticalAlignment="Bottom"
-                                      Background="#CC000000"
-                                      Height="60"
-                                      Margin="2,0,2,2">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="30"></RowDefinition>
-                                        <RowDefinition Height="30"></RowDefinition>
-                                    </Grid.RowDefinitions>
-
-                                    <TextBlock Margin="4,0,0,0"
-                                               FontSize="18"
-                                               Width="300"
-                                               Text="{Binding Name}"
-                                               Foreground="LightGreen"
-                                               HorizontalAlignment="Left" />
-                                    <TextBlock Grid.Row="1"
-                                               Margin="4,0,0,0"
-                                               FontSize="18"
-                                               Width="300"
-                                               Text="{Binding ArtistName}"
-                                               Foreground="White"
-                                               HorizontalAlignment="Left" />
+                                    <Grid VerticalAlignment="Bottom"
+                                          CornerRadius="0,0,8,8">
+                                        <Grid.Background>
+                                            <media:AcrylicBrush TintColor="Black"
+                                                                TintOpacity="0.7"
+                                                                TintLuminosityOpacity="0.1" />
+                                        </Grid.Background>
+                                        
+                                        <StackPanel Padding="12,8" Spacing="4">
+                                            <TextBlock Text="{Binding Name}"
+                                                       FontSize="16"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       MaxLines="1" />
+                                            <TextBlock Text="{Binding ArtistName}"
+                                                       FontSize="14"
+                                                       Foreground="White"
+                                                       Opacity="0.9"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       MaxLines="1" />
+                                        </StackPanel>
+                                    </Grid>
                                 </Grid>
                             </Grid>
                         </DataTemplate>
                     </GridView.ItemTemplate>
-                    <GridView.Transitions>
+                    
+                    <GridView.ItemContainerTransitions>
                         <TransitionCollection>
-                            <AddDeleteThemeTransition></AddDeleteThemeTransition>
+                            <AddDeleteThemeTransition />
+                            <ContentThemeTransition />
+                            <ReorderThemeTransition />
+                            <EntranceThemeTransition IsStaggeringEnabled="True" />
                         </TransitionCollection>
-                    </GridView.Transitions>
-                </GridView>
+                    </GridView.ItemContainerTransitions>
+                    </GridView>
+                </ScrollViewer>
 
-                <StackPanel x:Name="errorPanel"
-                            Visibility="{x:Bind ViewModel.ErrorOccurred, Converter={StaticResource BoolToVisibilityConverter},Mode=OneWay}"
-                            Orientation="Vertical"
-                            Background="#99000000">
-                    <TextBlock HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               FontSize="72"
-                               Foreground="White"
-                               FontWeight="Bold">:(</TextBlock>
-                    <TextBlock x:Uid="startViewErrorMessage"
-                               HorizontalAlignment="Center"
-                               Foreground="White" />
-                    <Button Click="Button_Click"
-                            HorizontalAlignment="Center"
-                            Margin="0,20,0,20"
-                            BorderBrush="White">
-                        <StackPanel Orientation="Horizontal">
-                            <SymbolIcon Symbol="Add"
-                                        Foreground="White"></SymbolIcon>
-                            <TextBlock x:Uid="startViewAddFolder"
-                                       Margin="6,0,6,0"
-                                       Foreground="White" />
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Grid>
-        </StackPanel>
+                <Grid x:Name="errorPanel"
+                      Visibility="{x:Bind ViewModel.ErrorOccurred, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
+                      Background="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
+                      CornerRadius="8"
+                      Padding="40"
+                      MaxWidth="600"
+                      HorizontalAlignment="Center"
+                      Margin="20">
+                    <Grid.Shadow>
+                        <ThemeShadow />
+                    </Grid.Shadow>
+                    
+                    <StackPanel Spacing="20">
+                        <FontIcon Glyph="&#xE7BA;"
+                                  FontSize="72"
+                                  Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                  HorizontalAlignment="Center" />
+                        <TextBlock x:Uid="startViewErrorMessage"
+                                   FontSize="18"
+                                   HorizontalAlignment="Center"
+                                   TextAlignment="Center"
+                                   TextWrapping="Wrap"
+                                   Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                        <Button Click="Button_Click"
+                                HorizontalAlignment="Center"
+                                Style="{StaticResource AccentButtonStyle}">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <SymbolIcon Symbol="Add" />
+                                <TextBlock x:Uid="startViewAddFolder" />
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </StackPanel>
+        </Grid>
     </Grid>
 </Page>

--- a/Presentation/Pages/WelcomePage.xaml.cs
+++ b/Presentation/Pages/WelcomePage.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Rok.Logic.ViewModels.Main;
 using Rok.Logic.ViewModels.Start;
@@ -41,12 +42,12 @@ public sealed partial class WelcomePage : Page
         }
         catch
         {
-            // Ignore
         }
     }
 
     private void Grid_Loaded(object sender, RoutedEventArgs e)
     {
+        FadeInStoryboard.Begin();
         MainViewModel.RefreshLibraryCommand.Execute(this);
     }
 }


### PR DESCRIPTION
Introduced ImportMessageThrottler to limit album/artist import messages to 40 each, preventing UI overload during large imports. Albums, Artists, and Tracks ViewModels now use DispatcherQueue to ensure UI thread safety for filtering/sorting. WelcomePage UI modernized: fade-in animation, progress bar, and dynamic import progress text. StartViewModel now displays import progress and album count. Improved error panel styling and feedback. Minor adjustments to library refresh button state handling. Overall, enhances user experience and feedback during initial library import.