### PR TITLE
feat(options): add project stats & support button to Options page

### DIFF
--- a/Presentation/Pages/OptionsPage.xaml
+++ b/Presentation/Pages/OptionsPage.xaml
@@ -448,9 +448,37 @@
                                        Text="Developed by Mickaël FRANCOIS" />
                         </StackPanel>
 
+                        <StackPanel Spacing="4"
+                                    Margin="0,8,0,0">
+                            <TextBlock Text="Project stats:"
+                                       FontWeight="SemiBold"
+                                       FontSize="12" />
+                            <TextBlock Text="✅ 1000+ active users"
+                                       FontSize="11" />
+                            <TextBlock Text="✅ Updated regularly"
+                                       FontSize="11" />
+                            <TextBlock Text="✅ 100% free &amp; open-source"
+                                       FontSize="11" />
+                            <TextBlock Text="❤️ Maintained by one developer"
+                                       FontSize="11"
+                                       Foreground="{ThemeResource AccentFillColorDefaultBrush}" />
+                        </StackPanel>
+
                         <StackPanel Orientation="Horizontal"
                                     Spacing="16"
                                     Margin="0,0,0,8">
+
+                            <Button x:Uid="SupportProjectButton"
+                                    Click="SupportButton_Click">
+                                <Button.Content>
+                                    <StackPanel Orientation="Horizontal"
+                                                Spacing="6">
+                                        <FontIcon Glyph="&#xE006;"></FontIcon>
+                                        <TextBlock x:Uid="SupportProjectButtonText"
+                                                   Text="Support the project"></TextBlock>
+                                    </StackPanel>
+                                </Button.Content>
+                            </Button>
 
                             <Button Click="StorePageButton_Click">
                                 <Button.Content>

--- a/Presentation/Pages/OptionsPage.xaml.cs
+++ b/Presentation/Pages/OptionsPage.xaml.cs
@@ -184,6 +184,12 @@ public sealed partial class OptionsPage : Page
         if (result == ContentDialogResult.Primary && StatisticsViewModel.ResetListenCountCommand.CanExecute(null))
             StatisticsViewModel.ResetListenCountCommand.Execute(null);
     }
+
+    private void SupportButton_Click(object sender, RoutedEventArgs e)
+    {
+        Uri uri = new("https://www.buymeacoffee.com/mickaelfrancois");
+        _ = Windows.System.Launcher.LaunchUriAsync(uri);
+    }
 }
 
 public class PathItem(string key, string value)

--- a/Presentation/Strings/en-US/Resources.resw
+++ b/Presentation/Strings/en-US/Resources.resw
@@ -1146,4 +1146,7 @@
   <data name="MenuFlyout_CurrentListening_Text" xml:space="preserve">
     <value>Current listening</value>
   </data>
+  <data name="SupportProjectButtonText.Text" xml:space="preserve">
+    <value>Support the project, buy me a coffee</value>
+  </data>
 </root>

--- a/Presentation/Strings/fr-FR/Resources.resw
+++ b/Presentation/Strings/fr-FR/Resources.resw
@@ -1146,4 +1146,7 @@
   <data name="MenuFlyout_CurrentListening_Text" xml:space="preserve">
     <value>Ecoute en cours</value>
   </data>
+  <data name="SupportProjectButtonText.Text" xml:space="preserve">
+    <value>Soutenez le projet, offrez-moi un café</value>
+  </data>
 </root>


### PR DESCRIPTION
Added a new "Project stats" section on the Options page, displaying key project information such as active users, update frequency, open-source status, and maintenance by a single developer. Introduced a "Support the project" button that opens the Buy Me a Coffee page to allow users to support the developer. Implemented the click event handler for this button in the code-behind. Localized the support button text in both English and French resource files.