### PR TITLE
refactor(api): introduce interfaces for album/artist image services

### DIFF
--- a/Core/Rok.Application/DependencyInjection.cs
+++ b/Core/Rok.Application/DependencyInjection.cs
@@ -1,7 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using MiF.Mediator;
 using MiF.Mediator.DependencyInjection;
+using Rok.Application.Features.Albums.Services;
+using Rok.Application.Features.Artists.Services;
 using Rok.Application.Features.Playlists;
+using Rok.Application.Features.Tracks.Services;
 using Rok.Application.Interfaces;
 using Rok.Application.Options;
 
@@ -14,6 +17,9 @@ public static class DependencyInjection
         services.AddSingleton<IAppOptions, AppOptions>();
         services.AddScoped<IValidationService, ValidationService>();
         services.AddSingleton<IPlaylistService, PlaylistService>();
+        services.AddTransient<TrackLyricsService>();
+        services.AddTransient<AlbumApiService>();
+        services.AddTransient<ArtistApiService>();
 
         services.AddSimpleMediator();
 

--- a/Core/Rok.Application/Features/Tracks/Services/TrackLyricsService.cs
+++ b/Core/Rok.Application/Features/Tracks/Services/TrackLyricsService.cs
@@ -1,9 +1,10 @@
-﻿using Rok.Application.Dto.Lyrics;
+﻿using Microsoft.Extensions.Logging;
+using Rok.Application.Dto.Lyrics;
 using Rok.Application.Dto.MusicDataApi;
 using Rok.Application.Features.Tracks.Command;
-using Rok.Infrastructure.MusicData;
+using Rok.Application.Interfaces;
 
-namespace Rok.Logic.ViewModels.Track.Services;
+namespace Rok.Application.Features.Tracks.Services;
 
 public class TrackLyricsService(IMediator mediator, ILyricsService lyricsService, IMusicDataApiService musicDataService, ILogger<TrackLyricsService> logger)
 {
@@ -24,7 +25,7 @@ public class TrackLyricsService(IMediator mediator, ILyricsService lyricsService
         if (string.IsNullOrEmpty(track.MusicFile) || string.IsNullOrEmpty(track.ArtistName) || string.IsNullOrEmpty(track.AlbumName) || string.IsNullOrEmpty(track.Title) || track.Duration <= 0)
             return false;
 
-        if (!MusicDataApiService.IsApiRetryAllowed(track.GetLyricsLastAttempt))
+        if (!musicDataService.IsApiRetryAllowed(track.GetLyricsLastAttempt))
             return false;
 
         logger.LogTrace("Fetching lyrics for {Artist} - {Title} from API", track.ArtistName, track.Title);
@@ -35,7 +36,6 @@ public class TrackLyricsService(IMediator mediator, ILyricsService lyricsService
 
         try
         {
-
             MusicDataLyricsDto? lyrics = await musicDataService.GetLyricsAsync(track.ArtistName, track.AlbumName, track.Title, track.Duration);
             if (lyrics is null)
                 return false;

--- a/Core/Rok.Application/Interfaces/IAlbumPictureService.cs
+++ b/Core/Rok.Application/Interfaces/IAlbumPictureService.cs
@@ -1,0 +1,7 @@
+namespace Rok.Application.Interfaces;
+
+public interface IAlbumPictureService
+{
+    bool PictureExists(string albumPath);
+    string GetPictureFilePath(string albumPath);
+}

--- a/Core/Rok.Application/Interfaces/IArtistPictureService.cs
+++ b/Core/Rok.Application/Interfaces/IArtistPictureService.cs
@@ -1,0 +1,7 @@
+namespace Rok.Application.Interfaces;
+
+public interface IArtistPictureService
+{
+    bool PictureExists(string artistName);
+    string GetPictureFilePath(string artistName);
+}

--- a/Core/Rok.Application/Interfaces/IBackdropPicture.cs
+++ b/Core/Rok.Application/Interfaces/IBackdropPicture.cs
@@ -1,0 +1,7 @@
+namespace Rok.Application.Interfaces;
+
+public interface IBackdropPicture
+{
+    bool HasBackdrops(string artistName);
+    string GetArtistPictureFolder(string artistName);
+}

--- a/Core/Rok.Application/Interfaces/IMusicDataApiService.cs
+++ b/Core/Rok.Application/Interfaces/IMusicDataApiService.cs
@@ -1,6 +1,6 @@
 ﻿using Rok.Application.Dto.MusicDataApi;
 
-namespace Rok.Infrastructure.MusicData;
+namespace Rok.Application.Interfaces;
 
 public interface IMusicDataApiService
 {
@@ -15,4 +15,6 @@ public interface IMusicDataApiService
     Task DownloadArtistBackdropsAsync(MusicDataArtistDto artist, string artistFolder, CancellationToken cancellationToken);
 
     Task DownloadCoverAsync(MusicDataAlbumDto album, string coverFile, CancellationToken cancellationToken);
+
+    bool IsApiRetryAllowed(DateTime? lastAttempt);
 }

--- a/Infrastructure/Rok.Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/Rok.Infrastructure/DependencyInjection.cs
@@ -38,6 +38,7 @@ public static class DependencyInjection
         services.AddSingleton<IArtistPicture, ArtistPicture>();
         services.AddSingleton<IAlbumPicture, AlbumPicture>();
         services.AddSingleton<BackdropPicture>();
+        services.AddSingleton<IBackdropPicture, BackdropPicture>();
 
         services.AddSingleton<IPlayerEngine, WinUIMediaPlayer>();
         services.AddSingleton<ILyricsService, LyricsService>();

--- a/Infrastructure/Rok.Infrastructure/Files/BackdropPicture.cs
+++ b/Infrastructure/Rok.Infrastructure/Files/BackdropPicture.cs
@@ -4,7 +4,7 @@ using Rok.Shared.Extensions;
 
 namespace Rok.Infrastructure.Files;
 
-public class BackdropPicture
+public class BackdropPicture : IBackdropPicture
 {
     private const string KArtistFolderName = "@Artists";
 

--- a/Infrastructure/Rok.Infrastructure/MusicData/MusicDataApiService.cs
+++ b/Infrastructure/Rok.Infrastructure/MusicData/MusicDataApiService.cs
@@ -251,7 +251,7 @@ public class MusicDataApiService : IMusicDataApiService, IDisposable
     }
 
 
-    public static bool IsApiRetryAllowed(DateTime? lastAttempt)
+    public bool IsApiRetryAllowed(DateTime? lastAttempt)
     {
         if (!lastAttempt.HasValue)
             return true;

--- a/Presentation/DependencyInjection.cs
+++ b/Presentation/DependencyInjection.cs
@@ -78,7 +78,7 @@ public static class DependencyInjection
         services.AddTransient<AlbumViewModel>();
         services.AddTransient<AlbumDataLoader>();
         services.AddTransient<AlbumPictureService>();
-        services.AddTransient<AlbumApiService>();
+        services.AddTransient<IAlbumPictureService, AlbumPictureService>();
         services.AddTransient<AlbumStatisticsService>();
         services.AddTransient<AlbumEditService>();
 
@@ -118,7 +118,7 @@ public static class DependencyInjection
         services.AddTransient<ArtistViewModel>();
         services.AddTransient<ArtistDataLoader>();
         services.AddTransient<ArtistPictureService>();
-        services.AddTransient<ArtistApiService>();
+        services.AddTransient<IArtistPictureService, ArtistPictureService>();
         services.AddTransient<ArtistStatisticsService>();
         services.AddTransient<ArtistEditService>();
 
@@ -149,7 +149,6 @@ public static class DependencyInjection
         // Track detail services (for TrackViewModel - single track)
         services.AddTransient<TrackViewModel>();
         services.AddTransient<TrackDetailDataLoader>();
-        services.AddTransient<TrackLyricsService>();
         services.AddTransient<TrackScoreService>();
         services.AddTransient<TrackNavigationService>();
         // Listening ViewModel and services

--- a/Presentation/Logic/ViewModels/Album/AlbumViewModel.cs
+++ b/Presentation/Logic/ViewModels/Album/AlbumViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Rok.Application.Features.Albums.Services;
 using Rok.Application.Features.Playlists.PlaylistMenu;
 using Rok.Infrastructure.Translate;
 using Rok.Logic.Services.Player;
@@ -284,7 +285,7 @@ public partial class AlbumViewModel : ObservableObject
     [RelayCommand]
     private async Task GetDataFromApiAsync()
     {
-        bool updated = await _apiService.GetAndUpdateAlbumDataAsync(Album);
+        bool updated = await _apiService.GetAndUpdateAlbumDataAsync(Album, _pictureService);
 
         if (!updated)
             return;

--- a/Presentation/Logic/ViewModels/Album/Services/AlbumPictureService.cs
+++ b/Presentation/Logic/ViewModels/Album/Services/AlbumPictureService.cs
@@ -1,9 +1,10 @@
 ﻿using System.IO;
+using Rok.Application.Interfaces;
 using Windows.Storage;
 
 namespace Rok.Logic.ViewModels.Album.Services;
 
-public class AlbumPictureService(IAlbumPicture albumPicture, ILogger<AlbumPictureService> logger)
+public class AlbumPictureService(IAlbumPicture albumPicture, ILogger<AlbumPictureService> logger) : IAlbumPictureService
 {
     public BitmapImage? LoadPicture(string albumPath)
     {

--- a/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
+++ b/Presentation/Logic/ViewModels/Artist/ArtistViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Rok.Application.Features.Artists.Services;
 using Rok.Application.Features.Playlists.PlaylistMenu;
 using Rok.Application.Randomizer;
 using Rok.Infrastructure.Translate;
@@ -30,6 +31,7 @@ public partial class ArtistViewModel : ObservableObject
     private readonly ArtistApiService _apiService;
     private readonly ArtistStatisticsService _statisticsService;
     private readonly ArtistEditService _editService;
+    private readonly BackdropPicture _backdropPicture;
     private IEnumerable<TrackDto>? _tracks = null;
 
     public IPlaylistMenuService PlaylistMenuService { get; }
@@ -213,6 +215,7 @@ public partial class ArtistViewModel : ObservableObject
         ArtistApiService apiService,
         ArtistStatisticsService statisticsService,
         ArtistEditService editService,
+        BackdropPicture backdropPicture,
         IAppOptions appOptions,
         IPlaylistMenuService playlistMenuService,
         ILogger<ArtistViewModel> logger)
@@ -228,6 +231,7 @@ public partial class ArtistViewModel : ObservableObject
         _apiService = Guard.Against.Null(apiService);
         _statisticsService = Guard.Against.Null(statisticsService);
         _editService = Guard.Against.Null(editService);
+        _backdropPicture = Guard.Against.Null(backdropPicture);
         _appOptions = Guard.Against.Null(appOptions);
         PlaylistMenuService = Guard.Against.Null(playlistMenuService);
         _logger = Guard.Against.Null(logger);
@@ -341,7 +345,7 @@ public partial class ArtistViewModel : ObservableObject
 
     private async Task GetDataFromApiAsync()
     {
-        bool updated = await _apiService.GetAndUpdateArtistDataAsync(Artist);
+        bool updated = await _apiService.GetAndUpdateArtistDataAsync(Artist, _pictureService, _backdropPicture);
 
         if (updated)
         {

--- a/Presentation/Logic/ViewModels/Artist/Services/ArtistPictureService.cs
+++ b/Presentation/Logic/ViewModels/Artist/Services/ArtistPictureService.cs
@@ -3,7 +3,7 @@ using Windows.Storage;
 
 namespace Rok.Logic.ViewModels.Artist.Services;
 
-public class ArtistPictureService(IArtistPicture artistPicture, ILogger<ArtistPictureService> logger)
+public class ArtistPictureService(IArtistPicture artistPicture, ILogger<ArtistPictureService> logger) : IArtistPictureService
 {
     private static BitmapImage FallbackPicture => new(new Uri("ms-appx:///Assets/artistFallback.png"));
 

--- a/Presentation/Logic/ViewModels/Track/TrackViewModel.cs
+++ b/Presentation/Logic/ViewModels/Track/TrackViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Dispatching;
 using Rok.Application.Dto.Lyrics;
 using Rok.Application.Features.Playlists.PlaylistMenu;
+using Rok.Application.Features.Tracks.Services;
 using Rok.Infrastructure.Translate;
 using Rok.Logic.Services.Player;
 using Rok.Logic.ViewModels.Track.Services;


### PR DESCRIPTION
Refactored AlbumApiService and ArtistApiService to use new interfaces (IAlbumPictureService, IArtistPictureService, IBackdropPicture) for image and backdrop management. Moved these services to appropriate features namespaces. Updated DI registrations to expose interfaces and avoid duplicates. ViewModels now depend on abstractions, improving modularity and testability. Added new interfaces and adapted concrete services to implement them. Cleaned up API data retrieval logic to use these abstractions. No functional changes, only improved structure and maintainability.