### PR TITLE
Add auto-scroll to current listening track on page load

### DIFF
--- a/Presentation/Pages/ListeningPage.xaml
+++ b/Presentation/Pages/ListeningPage.xaml
@@ -7,6 +7,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:common="using:Rok.Commons"
       xmlns:track="using:Rok.ViewModels.Track"
+      Loaded="ListeningPage_Loaded"
       x:Name="PageRoot"
       mc:Ignorable="d">
 

--- a/Presentation/Pages/ListeningPage.xaml.cs
+++ b/Presentation/Pages/ListeningPage.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml.Controls;
 using Rok.ViewModels.Listening;
+using Rok.ViewModels.Track;
 
 
 namespace Rok.Pages;
@@ -15,6 +16,14 @@ public sealed partial class ListeningPage : Page, IDisposable
 
         ViewModel = App.ServiceProvider.GetRequiredService<ListeningViewModel>();
         DataContext = ViewModel;
+    }
+
+    private void ListeningPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        TrackViewModel? listeningTrack = ViewModel.Tracks.FirstOrDefault(track => track.Listening);
+
+        if (listeningTrack != null)
+            tracksList.ScrollIntoView(listeningTrack, ScrollIntoViewAlignment.Leading);
     }
 
 


### PR DESCRIPTION
Added a Loaded event handler to ListeningPage to automatically scroll the tracksList to the first track with Listening=true when the page loads. Implemented the ListeningPage_Loaded method in ListeningPage.xaml.cs to find and scroll to the relevant TrackViewModel using ScrollIntoView. Also imported Rok.ViewModels.Track to enable access to TrackViewModel. This improves user experience by focusing on the currently playing track when the page is displayed.