### PR TITLE
Limit playlist loading to 100 shuffled tracks

### DIFF
--- a/Presentation/ViewModels/Genre/GenreViewModel.cs
+++ b/Presentation/ViewModels/Genre/GenreViewModel.cs
@@ -220,7 +220,7 @@ public partial class GenreViewModel : ObservableObject
         {
             List<TrackDto> shuffledTracks = tracks.ToList();
             TracksRandomizer.Randomize(shuffledTracks);
-            _playerService.LoadPlaylist(shuffledTracks);
+            _playerService.LoadPlaylist(shuffledTracks.Take(100).ToList());
         }
     }
 


### PR DESCRIPTION
The player service now loads only the first 100 tracks from the shuffled list, instead of loading all available tracks. This change improves performance and prevents excessively large playlists from being loaded. The randomization logic remains unchanged, but only a subset is passed to LoadPlaylist. No other functionalities are affected.