### PR TITLE
Update ListenCommand binding and playlist start track support

### DIFF
--- a/Presentation/Pages/AlbumPage.xaml
+++ b/Presentation/Pages/AlbumPage.xaml
@@ -314,8 +314,8 @@
                                            Style="{StaticResource gridTracksRowIndexText}" />
 
                                 <HyperlinkButton Style="{StaticResource gridTracksTitleText}"
-                                                 Command="{x:Bind ListenCommand}"
-                                                 CommandParameter="{x:Bind}" />
+                                                 Command="{Binding DataContext.ListenCommand, ElementName=albumPage}"
+                                                 CommandParameter="{Binding}" />
 
                                 <HyperlinkButton x:Uid="lyricsTag"
                                                  Visibility="{x:Bind LyricsExists, Converter={StaticResource BoolToVisibilityConverter}}"

--- a/Presentation/ViewModels/Album/AlbumViewModel.cs
+++ b/Presentation/ViewModels/Album/AlbumViewModel.cs
@@ -283,13 +283,13 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum
     }
 
     [RelayCommand]
-    private async Task ListenAsync()
+    private async Task ListenAsync(TrackViewModel? startTrack = null)
     {
         if (_tracks == null)
             await LoadTracksAsync(Album.Id);
 
         if (_tracks?.Any() == true)
-            _playerService.LoadPlaylist(_tracks.ToList());
+            _playerService.LoadPlaylist(_tracks.ToList(), startTrack?.Track);
     }
 
     [RelayCommand]


### PR DESCRIPTION
Refactored ListenCommand binding in AlbumPage.xaml to use DataContext and standard Binding, ensuring correct ViewModel context. ListenAsync in AlbumViewModel now accepts an optional startTrack parameter, allowing playlist playback to start from a specific track. PlayerService.LoadPlaylist updated to handle startTrack. Improves flexibility and reliability of playback initiation from the UI. Fixes command parameter binding issues and enables targeted track listening.