### PR TITLE
feat(playlists): enable track-specific playback and fix binding

### DIFF
--- a/Presentation/Pages/PlaylistPage.xaml
+++ b/Presentation/Pages/PlaylistPage.xaml
@@ -236,8 +236,8 @@
                                         Orientation="Horizontal">
                                 
                                 <HyperlinkButton Style="{StaticResource gridTracksTitleText}"
-                                                 Command="{x:Bind ListenCommand}"
-                                                 CommandParameter="{x:Bind}" />
+                                                 Command="{Binding DataContext.ListenCommand, ElementName=playlistPage}"
+                                                 CommandParameter="{Binding}" />
 
                                 <HyperlinkButton x:Uid="lyricsTag"
                                                  Visibility="{x:Bind LyricsExists, Converter={StaticResource BoolToVisibilityConverter}}"

--- a/Presentation/Pages/SmartPlaylistPage.xaml
+++ b/Presentation/Pages/SmartPlaylistPage.xaml
@@ -266,8 +266,8 @@
                                                 Orientation="Horizontal">
                                         
                                         <HyperlinkButton Style="{StaticResource gridTracksTitleText}"
-                                                         Command="{x:Bind ListenCommand}"
-                                                         CommandParameter="{x:Bind}" />
+                                                         Command="{Binding DataContext.ListenCommand, ElementName=smartPlaylistPage}"
+                                                         CommandParameter="{Binding}" />
 
                                         <HyperlinkButton x:Uid="lyricsTag"
                                                          Visibility="{x:Bind LyricsExists, Converter={StaticResource BoolToVisibilityConverter}}"

--- a/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
+++ b/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
@@ -222,7 +222,7 @@ public partial class PlaylistViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task ListenAsync()
+    private async Task ListenAsync(TrackViewModel? track)
     {
         if (_tracks == null)
         {
@@ -233,7 +233,7 @@ public partial class PlaylistViewModel : ObservableObject
         }
 
         if (_tracks?.Any() == true)
-            _playerService.LoadPlaylist(Tracks.Select(t => t.Track).ToList());
+            _playerService.LoadPlaylist(_tracks.ToList(), track?.Track);
     }
 
     [RelayCommand]


### PR DESCRIPTION
Updated "Listen" buttons in PlaylistPage.xaml and SmartPlaylistPage.xaml to use classic {Binding} syntax, referencing ListenCommand from the page DataContext. CommandParameter now uses the current binding context.

ListenAsync in PlaylistViewModel now accepts an optional TrackViewModel parameter, allowing playback to start from a specific track.

_playerService.LoadPlaylist is updated to receive both the track list and the selected track, improving user experience by starting playback at the chosen track instead of always the first.