### PR TITLE
Update genre filter menu to use FilterByGenreCommand

### DIFF
--- a/Presentation/Pages/AlbumsFilterMenuBuilder.cs
+++ b/Presentation/Pages/AlbumsFilterMenuBuilder.cs
@@ -65,7 +65,7 @@ internal class AlbumsFilterMenuBuilder
         MenuFlyoutItem genreAllMenu = new()
         {
             Text = _manager.MainResourceMap.GetValue("Resources/filtergenreall").ValueAsString,
-            Command = viewModel.FilterByCommand,
+            Command = viewModel.FilterByGenreCommand,
         };
         genreSubItem.Items.Add(genreAllMenu);
 

--- a/Presentation/Pages/ArtistsFilterMenuBuilder.cs
+++ b/Presentation/Pages/ArtistsFilterMenuBuilder.cs
@@ -54,7 +54,7 @@ internal class ArtistsFilterMenuBuilder
         MenuFlyoutItem genreAllMenu = new()
         {
             Text = _manager.MainResourceMap.GetValue("Resources/filtergenreall").ValueAsString,
-            Command = viewModel.FilterByCommand,
+            Command = viewModel.FilterByGenreCommand,
         };
         genreSubItem.Items.Add(genreAllMenu);
 

--- a/Presentation/Pages/TracksFilterMenuBuilder.cs
+++ b/Presentation/Pages/TracksFilterMenuBuilder.cs
@@ -60,7 +60,7 @@ internal class TracksFilterMenuBuilder
         MenuFlyoutItem genreAllMenu = new()
         {
             Text = _manager.MainResourceMap.GetValue("Resources/filtergenreall").ValueAsString,
-            Command = viewModel.FilterByCommand,
+            Command = viewModel.FilterByGenreCommand,
         };
         genreSubItem.Items.Add(genreAllMenu);
 


### PR DESCRIPTION
Replaced FilterByCommand with FilterByGenreCommand for the "All genres" menu item in AlbumsFilterMenuBuilder, ArtistsFilterMenuBuilder, and TracksFilterMenuBuilder. This change ensures that filtering by genre uses the appropriate command, improving the accuracy and consistency of genre-based filtering when selecting the "All genres" option in the filter menu.
No other logic or UI changes were introduced.