### PR TITLE
feat(ui): display group item count in album, artist, track pages

### DIFF
--- a/Presentation/Pages/AlbumsPage.xaml
+++ b/Presentation/Pages/AlbumsPage.xaml
@@ -421,6 +421,18 @@
                                         <StackPanel Orientation="Horizontal">
                                             <HyperlinkButton Content="{x:Bind Title}"
                                                              Style="{StaticResource HyperlinkGroupButtonStyle}" />
+
+                                            <Border Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"
+                                                    CornerRadius="10"
+                                                    Padding="8,2"
+                                                    VerticalAlignment="Center"
+                                                    Margin="0,0,10,0">
+                                                <TextBlock Text="{x:Bind Count}"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           VerticalAlignment="Center"
+                                                           Opacity="0.7" />
+                                            </Border>
+
                                             <Button Margin="10,0,0,0"
                                                     Command="{Binding ElementName=albumsView, Path=DataContext.ListenGroupCommand}"
                                                     CommandParameter="{x:Bind}"

--- a/Presentation/Pages/ArtistsPage.xaml
+++ b/Presentation/Pages/ArtistsPage.xaml
@@ -338,6 +338,18 @@
                                                     Visibility="Visible">
                                             <HyperlinkButton Content="{x:Bind Title}"
                                                              Style="{StaticResource HyperlinkGroupButtonStyle}" />
+
+                                            <Border Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"
+                                                    CornerRadius="10"
+                                                    Padding="8,2"
+                                                    VerticalAlignment="Center"
+                                                    Margin="0,0,10,0">
+                                                <TextBlock Text="{x:Bind Count}"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           VerticalAlignment="Center"
+                                                           Opacity="0.7" />
+                                            </Border>
+                                            
                                             <Button Margin="10,0,0,0"
                                                     Command="{Binding ElementName=artistsView, Path=DataContext.ListenGroupCommand}"
                                                     CommandParameter="{x:Bind}"

--- a/Presentation/Pages/TracksPage.xaml
+++ b/Presentation/Pages/TracksPage.xaml
@@ -291,6 +291,18 @@
                                                     Visibility="Visible">
                                             <HyperlinkButton Content="{x:Bind Title}"
                                                              Style="{StaticResource HyperlinkGroupButtonStyle}" />
+
+                                            <Border Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"
+                                                    CornerRadius="10"
+                                                    Padding="8,2"
+                                                    VerticalAlignment="Center"
+                                                    Margin="0,0,10,0">
+                                                <TextBlock Text="{x:Bind Count}"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           VerticalAlignment="Center"
+                                                           Opacity="0.7" />
+                                            </Border>
+
                                             <Button Margin="10,0,0,0"
                                                     Command="{Binding ElementName=tracksView, Path=DataContext.ListenGroupCommand}"
                                                     CommandParameter="{x:Bind}"

--- a/Presentation/ViewModels/Albums/AlbumsGroupCategoryViewModel.cs
+++ b/Presentation/ViewModels/Albums/AlbumsGroupCategoryViewModel.cs
@@ -10,5 +10,7 @@ public class AlbumsGroupCategoryViewModel : IGroupCategory<AlbumViewModel>
 
     public List<AlbumViewModel> Items { get; set; } = [];
 
+    public int Count => Items.Count;
+
     public override string ToString() => Title;
 }

--- a/Presentation/ViewModels/Artists/ArtistsGroupCategoryViewModel.cs
+++ b/Presentation/ViewModels/Artists/ArtistsGroupCategoryViewModel.cs
@@ -9,5 +9,7 @@ public class ArtistsGroupCategoryViewModel : IGroupCategory<ArtistViewModel>
 
     public List<ArtistViewModel> Items { get; set; } = [];
 
+    public int Count => Items.Count;
+
     public override string ToString() => Title;
 }

--- a/Presentation/ViewModels/Tracks/TracksGroupCategoryViewModel.cs
+++ b/Presentation/ViewModels/Tracks/TracksGroupCategoryViewModel.cs
@@ -9,5 +9,7 @@ public class TracksGroupCategoryViewModel : IGroupCategory<TrackViewModel>
 
     public List<TrackViewModel> Items { get; set; } = [];
 
+    public int Count => Items.Count;
+
     public override string ToString() => Title;
 }


### PR DESCRIPTION
Added Count property to group ViewModels (Albums, Artists, Tracks). Updated XAML to show item count next to group title using a styled Border and TextBlock. Improves visibility of group sizes for users.
Count is dynamically calculated from Items list.
Visual style uses neutral background and caption text style. No breaking changes, only UI enhancements.
Tested on all relevant pages for correct display.
Refactoring limited to ViewModel and XAML files.
No impact on existing commands or navigation.
Ready for review and integration.