### PR TITLE
fix(import): allow exactly MaxMessagesBeforeThrottle messages before …

### DIFF
--- a/src/Rok.Import/Services/ImportMessageThrottler.cs
+++ b/src/Rok.Import/Services/ImportMessageThrottler.cs
@@ -15,7 +15,7 @@ public class ImportMessageThrottler
 
         _albumMessagesSent++;
 
-        if (_albumMessagesSent >= MaxMessagesBeforeThrottle)
+        if (_albumMessagesSent > MaxMessagesBeforeThrottle)
         {
             _isAlbumThrottled = true;
             return false;
@@ -31,7 +31,7 @@ public class ImportMessageThrottler
 
         _artistMessagesSent++;
 
-        if (_artistMessagesSent >= MaxMessagesBeforeThrottle)
+        if (_artistMessagesSent > MaxMessagesBeforeThrottle)
         {
             _isArtistThrottled = true;
             return false;


### PR DESCRIPTION
…throttling

Replace >= with > in ShouldSendAlbumMessage and ShouldSendArtistMessage so that exactly 100 messages are sent before throttling, instead of 99.

Expose MaxMessagesBeforeThrottle as public and reference it from StartViewModel to keep both constants in sync.