### PR TITLE
fix(player): guard against FindIndex returning -1 in Start

### DIFF
--- a/src/Rok.Application/Player/PlayerService.cs
+++ b/src/Rok.Application/Player/PlayerService.cs
@@ -316,6 +316,9 @@ public class PlayerService : IPlayerService
         else
             _currentIndex = Playlist.FindIndex(c => c.Id == startTrack.Id);
 
+        if (_currentIndex < 0)
+            return;
+
         LoadFile(Playlist[_currentIndex]);
 
         Play();


### PR DESCRIPTION
When the requested track is not found in the playlist, FindIndex returns -1. Accessing Playlist[-1] caused an IndexOutOfRangeException and crashed playback. Added an early return when _currentIndex < 0.