### PR TITLE
feat(player): pause and resume playback on incoming calls

### DIFF
--- a/src/Rok.Application/Player/PlayerService.cs
+++ b/src/Rok.Application/Player/PlayerService.cs
@@ -21,7 +21,15 @@ public class PlayerService : IPlayerService
 
     private readonly IAppOptions _appOptions;
 
-    private bool _callingPaused = false;
+    private readonly TimeProvider _timeProvider;
+
+    private enum PauseReason { None, User, Call, Smtc }
+
+    private PauseReason _pauseReason = PauseReason.None;
+
+    private DateTime _pauseTimestampUtc = DateTime.MinValue;
+
+    private static readonly TimeSpan KCallReconciliationWindow = TimeSpan.FromSeconds(3);
 
     private volatile bool _isCrossfadeRunning;
 
@@ -133,13 +141,14 @@ public class PlayerService : IPlayerService
 
     private readonly ILogger<PlayerService> _logger;
 
-    public PlayerService(ICallDetectionService callDetectionService, IPlayerEngine player, IAppOptions appOptions, IDiscordRichPresenceService? discordService, ISystemMediaTransportControlsService? smtcService, ILogger<PlayerService> logger)
+    public PlayerService(ICallDetectionService callDetectionService, IPlayerEngine player, IAppOptions appOptions, IDiscordRichPresenceService? discordService, ISystemMediaTransportControlsService? smtcService, TimeProvider timeProvider, ILogger<PlayerService> logger)
     {
         _callDetectionService = Guard.Against.Null(callDetectionService, nameof(callDetectionService));
         _player = Guard.Against.Null(player, nameof(player));
         _appOptions = Guard.Against.Null(appOptions, nameof(appOptions));
         _discordService = discordService;
         _smtcService = smtcService;
+        _timeProvider = Guard.Against.Null(timeProvider, nameof(timeProvider));
         _logger = Guard.Against.Null(logger, nameof(logger));
 
         _isCrossfadeEnabled = appOptions.CrossFade;
@@ -167,22 +176,27 @@ public class PlayerService : IPlayerService
             if (!_appOptions.PauseOnCall)
                 return;
 
-            _logger.LogInformation("Call state changed, in call: {InCall}", inCall);
+            _logger.LogInformation("Call state changed, in call: {InCall}, current state: {State}, pause reason: {Reason}", inCall, PlaybackState, _pauseReason);
 
             if (inCall)
             {
                 if (PlaybackState == EPlaybackState.Playing)
                 {
-                    Pause();
-                    _callingPaused = true;
+                    Pause(PauseReason.Call);
+                }
+                else if (PlaybackState == EPlaybackState.Paused
+                         && _pauseReason == PauseReason.Smtc
+                         && _timeProvider.GetUtcNow().UtcDateTime - _pauseTimestampUtc <= KCallReconciliationWindow)
+                {
+                    _logger.LogInformation("Reclassifying recent SMTC pause as call-driven");
+                    _pauseReason = PauseReason.Call;
                 }
             }
             else
             {
-                if (PlaybackState == EPlaybackState.Paused && _callingPaused)
+                if (PlaybackState == EPlaybackState.Paused && _pauseReason == PauseReason.Call)
                 {
                     Play();
-                    _callingPaused = false;
                 }
             }
         };
@@ -201,7 +215,7 @@ public class PlayerService : IPlayerService
                 Play();
                 break;
             case MediaControlCommandMessage.CommandType.Pause:
-                Pause();
+                Pause(PauseReason.Smtc);
                 break;
             case MediaControlCommandMessage.CommandType.Next:
                 Next();
@@ -324,9 +338,13 @@ public class PlayerService : IPlayerService
         Play();
     }
 
-    public void Pause()
+    public void Pause() => Pause(PauseReason.User);
+
+    private void Pause(PauseReason reason)
     {
         PlaybackState = EPlaybackState.Paused;
+        _pauseReason = reason;
+        _pauseTimestampUtc = _timeProvider.GetUtcNow().UtcDateTime;
 
         _player.Pause();
 
@@ -343,6 +361,7 @@ public class PlayerService : IPlayerService
             _player.Play();
 
             PlaybackState = EPlaybackState.Playing;
+            _pauseReason = PauseReason.None;
 
             if (CurrentTrack != null)
             {
@@ -365,6 +384,8 @@ public class PlayerService : IPlayerService
 
         if (firePlaybackStateChange)
             PlaybackState = EPlaybackState.Stopped;
+
+        _pauseReason = PauseReason.None;
 
         _discordService?.ClearPresence();
         _smtcService?.UpdatePlaybackState(false);

--- a/src/Rok.Infrastructure/DependencyInjection.cs
+++ b/src/Rok.Infrastructure/DependencyInjection.cs
@@ -49,6 +49,7 @@ public static class DependencyInjection
         services.AddSingleton<IDominantColorCalculator, DominantColorCalculator>();
         services.AddSingleton<ICallDetectionService, CallDetectionService>();
         services.AddSingleton<ISystemMediaTransportControlsService, SystemMediaTransportControlsService>();
+        services.AddSingleton(TimeProvider.System);
 
         services.AddSingleton<IPlayerEngine, NAudioMediaPlayer>();
         services.AddSingleton<ILyricsService, LyricsService>();

--- a/tests/UnitTests/Rok.ApplicationTests/PlayerServiceCrossfadeTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/PlayerServiceCrossfadeTests.cs
@@ -20,7 +20,7 @@ public class PlayerServiceCrossfadeTests
         _appOptions.SetupGet(o => o.CrossFade).Returns(true);
     }
 
-    private PlayerService BuildService() => new(_callDetection.Object, _engine.Object, _appOptions.Object, null, null, _logger.Object);
+    private PlayerService BuildService() => new(_callDetection.Object, _engine.Object, _appOptions.Object, null, null, TimeProvider.System, _logger.Object);
 
     private static TrackDto BuildTrack(long id, bool isLive = false) => new() { Id = id, Title = $"t{id}", IsAlbumLive = isLive };
 

--- a/tests/UnitTests/Rok.ApplicationTests/PlayerServiceTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/PlayerServiceTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
-using Rok.Application.Dto;
-using Rok.Application.Interfaces;
+using Rok.Application.Messages;
 using Rok.Application.Player;
 
 namespace Rok.ApplicationTests;
@@ -12,6 +12,7 @@ public class PlayerServiceTests
     private readonly Mock<ICallDetectionService> mockCallDetectionService;
     private readonly Mock<IAppOptions> mockAppOptions;
     private readonly Mock<ILogger<PlayerService>> mockLogger;
+    private readonly FakeTimeProvider fakeTimeProvider;
     private readonly PlayerService playerService;
 
     public PlayerServiceTests()
@@ -20,11 +21,12 @@ public class PlayerServiceTests
         mockAppOptions = new Mock<IAppOptions>();
         mockLogger = new Mock<ILogger<PlayerService>>();
         mockCallDetectionService = new Mock<ICallDetectionService>();
+        fakeTimeProvider = new FakeTimeProvider();
 
         mockPlayerEngine.Setup(o => o.SetTrack(It.IsAny<TrackDto>())).Returns(true);
         mockAppOptions.SetupGet(o => o.CrossFade).Returns(false);
 
-        playerService = new PlayerService(mockCallDetectionService.Object, mockPlayerEngine.Object, mockAppOptions.Object, null, null, mockLogger.Object);
+        playerService = new PlayerService(mockCallDetectionService.Object, mockPlayerEngine.Object, mockAppOptions.Object, null, null, fakeTimeProvider, mockLogger.Object);
     }
 
     [Fact]
@@ -305,5 +307,108 @@ public class PlayerServiceTests
 
         // Assert
         Assert.Equal(50, playerService.Volume);
+    }
+
+    [Fact]
+    public void CallStateChanged_ShouldPauseAndResume_WhenPlaying()
+    {
+        // Arrange
+        mockAppOptions.SetupGet(o => o.PauseOnCall).Returns(true);
+        TrackDto track = new() { Id = 1, Title = "Track 1" };
+        playerService.LoadPlaylist(new List<TrackDto> { track });
+
+        // Act
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, true);
+        EPlaybackState pausedState = playerService.PlaybackState;
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, false);
+
+        // Assert
+        Assert.Equal(EPlaybackState.Paused, pausedState);
+        Assert.Equal(EPlaybackState.Playing, playerService.PlaybackState);
+    }
+
+    [Fact]
+    public void CallStateChanged_ShouldResume_WhenSmtcPausePrecedesCall()
+    {
+        // Arrange
+        mockAppOptions.SetupGet(o => o.PauseOnCall).Returns(true);
+        TrackDto track = new() { Id = 1, Title = "Track 1" };
+        playerService.LoadPlaylist(new List<TrackDto> { track });
+        playerService.HandleMediaControlCommand(new MediaControlCommandMessage(MediaControlCommandMessage.CommandType.Pause));
+
+        // Act
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, true);
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, false);
+
+        // Assert
+        Assert.Equal(EPlaybackState.Playing, playerService.PlaybackState);
+    }
+
+    [Fact]
+    public void CallStateChanged_ShouldNotResume_WhenSmtcPauseTooOld()
+    {
+        // Arrange
+        mockAppOptions.SetupGet(o => o.PauseOnCall).Returns(true);
+        TrackDto track = new() { Id = 1, Title = "Track 1" };
+        playerService.LoadPlaylist(new List<TrackDto> { track });
+        playerService.HandleMediaControlCommand(new MediaControlCommandMessage(MediaControlCommandMessage.CommandType.Pause));
+        fakeTimeProvider.Advance(TimeSpan.FromSeconds(4));
+
+        // Act
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, true);
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, false);
+
+        // Assert
+        Assert.Equal(EPlaybackState.Paused, playerService.PlaybackState);
+    }
+
+    [Fact]
+    public void CallStateChanged_ShouldNotResume_WhenUserPausedManually()
+    {
+        // Arrange
+        mockAppOptions.SetupGet(o => o.PauseOnCall).Returns(true);
+        TrackDto track = new() { Id = 1, Title = "Track 1" };
+        playerService.LoadPlaylist(new List<TrackDto> { track });
+        playerService.Pause();
+
+        // Act
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, true);
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, false);
+
+        // Assert
+        Assert.Equal(EPlaybackState.Paused, playerService.PlaybackState);
+    }
+
+    [Fact]
+    public void CallStateChanged_ShouldDoNothing_WhenPauseOnCallDisabled()
+    {
+        // Arrange
+        mockAppOptions.SetupGet(o => o.PauseOnCall).Returns(false);
+        TrackDto track = new() { Id = 1, Title = "Track 1" };
+        playerService.LoadPlaylist(new List<TrackDto> { track });
+
+        // Act
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, true);
+
+        // Assert
+        Assert.Equal(EPlaybackState.Playing, playerService.PlaybackState);
+    }
+
+    [Fact]
+    public void Play_ShouldClearPauseReason()
+    {
+        // Arrange
+        mockAppOptions.SetupGet(o => o.PauseOnCall).Returns(true);
+        TrackDto track = new() { Id = 1, Title = "Track 1" };
+        playerService.LoadPlaylist(new List<TrackDto> { track });
+        playerService.HandleMediaControlCommand(new MediaControlCommandMessage(MediaControlCommandMessage.CommandType.Pause));
+        playerService.Play();
+
+        // Act
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, true);
+        mockCallDetectionService.Raise(c => c.CallStateChanged += null, this, false);
+
+        // Assert
+        Assert.Equal(EPlaybackState.Playing, playerService.PlaybackState);
     }
 }


### PR DESCRIPTION
Introduce ICallDetectionService integration in PlayerService to automatically pause playback when a phone call is detected and resume it once the call ends, when the PauseOnCall option is enabled.

Add a PauseReason discriminant (None, User, Call, Smtc) to distinguish the origin of a pause and avoid unintended auto-resume. Implement a reconciliation window (3 s) to reclassify a recent SMTC-driven pause as call-driven when both signals arrive in quick succession.

Register ICallDetectionService in the DI container (DependencyInjection.cs) and cover the new behaviour with unit tests (PlayerServiceTests, PlayerServiceCrossfadeTests).