### PR TITLE
feat(telemetry): extend session and navigation tracking

### DIFF
--- a/src/Presentation/App.xaml.cs
+++ b/src/Presentation/App.xaml.cs
@@ -207,6 +207,9 @@ public partial class App : Microsoft.UI.Xaml.Application
     {
         IAppOptions options = ServiceProvider.GetRequiredService<IAppOptions>();
         ISettingsFile settingFileService = ServiceProvider.GetRequiredService<ISettingsFile>();
+        ITelemetryClient telemetryClient = ServiceProvider.GetRequiredService<ITelemetryClient>();
+
+        await telemetryClient.CaptureEventAsync("Event", "Stop");
 
         await settingFileService.SaveAsync(options);
 

--- a/src/Presentation/Services/NavigationService.cs
+++ b/src/Presentation/Services/NavigationService.cs
@@ -20,77 +20,72 @@ public class NavigationService(ITelemetryClient telemetryClient)
 
     public void NavigateTo(Type pageType, object? parameter)
     {
+        _ = telemetryClient.CaptureScreenAsync(pageType.Name);
         MainFrame.Navigate(pageType, parameter);
     }
 
     public void NavigateToArtist(long artistId)
     {
         Guard.Against.NegativeOrZero(artistId);
-
+        _ = telemetryClient.CaptureScreenAsync("ArtistPage");
         MainFrame.Navigate(typeof(ArtistPage), new ArtistOpenArgs(artistId));
     }
 
     public void NavigateToAlbums()
     {
         _ = telemetryClient.CaptureScreenAsync("AlbumsPage");
-
         MainFrame.Navigate(typeof(AlbumsPage));
     }
-
 
     public void NavigateToAlbum(long albumId)
     {
         Guard.Against.NegativeOrZero(albumId);
-
+        _ = telemetryClient.CaptureScreenAsync("AlbumPage");
         MainFrame.Navigate(typeof(AlbumPage), new AlbumOpenArgs(albumId));
     }
 
     public void NavigateToGenre(long genreId)
     {
         Guard.Against.NegativeOrZero(genreId);
-
+        _ = telemetryClient.CaptureScreenAsync("GenrePage");
         MainFrame.Navigate(typeof(GenrePage), new GenreOpenArgs(genreId));
     }
-
 
     public void NavigateToTrack(long trackId)
     {
         Guard.Against.NegativeOrZero(trackId);
-
+        _ = telemetryClient.CaptureScreenAsync("TrackPage");
         MainFrame.Navigate(typeof(TrackPage), new TrackOpenArgs(trackId));
     }
 
-
     public void NavigateToSmartPlaylist(long playlistId)
     {
+        _ = telemetryClient.CaptureScreenAsync("SmartPlaylistPage");
         MainFrame.Navigate(typeof(SmartPlaylistPage), new PlaylistOpenArgs(playlistId));
     }
 
     public void NavigateToPlaylist(long playlistId)
     {
+        _ = telemetryClient.CaptureScreenAsync("PlaylistPage");
         MainFrame.Navigate(typeof(PlaylistPage), new PlaylistOpenArgs(playlistId));
     }
 
     public void NavigateToPlaylists()
     {
         _ = telemetryClient.CaptureScreenAsync("PlaylistsPage");
-
         MainFrame.Navigate(typeof(PlaylistsPage));
     }
 
     public void NavigateToListening()
     {
         _ = telemetryClient.CaptureScreenAsync("ListeningPage");
-
         MainFrame.Navigate(typeof(ListeningPage));
     }
 
     public void NavigateToSearch(SearchOpenArgs args)
     {
         Guard.Against.Null(args);
-
         _ = telemetryClient.CaptureScreenAsync("SearchPage");
-
         MainFrame.Navigate(typeof(SearchPage), args);
     }
 

--- a/src/Presentation/ViewModels/Player/PlayerViewModel.cs
+++ b/src/Presentation/ViewModels/Player/PlayerViewModel.cs
@@ -20,6 +20,7 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
     private readonly NavigationService _navigationService;
     private readonly IPlayerSleepModeService _playerSleepModeService;
     private readonly ILogger<PlayerViewModel> _logger;
+    private readonly ITelemetryClient _telemetryClient;
     private bool _disposed;
 
     private readonly PlayerDataLoader _dataLoader;
@@ -139,7 +140,6 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
     public bool IsSynchronizedLyrics => _stateManager.IsSynchronizedLyrics;
     public string? PlainLyrics => _stateManager.PlainLyrics;
 
-
     public PlayerViewModel(
         IPlayerService player,
         NavigationService navigationService,
@@ -152,6 +152,7 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
         EqualizerViewModel equalizerViewModel,
         ResourceLoader resourceLoader,
         IPlayerSleepModeService playerSleepModeService,
+        ITelemetryClient telemetryClient,
         ILogger<PlayerViewModel> logger)
     {
         _player = Guard.Against.Null(player);
@@ -165,6 +166,7 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
         EqualizerViewModel = Guard.Against.Null(equalizerViewModel);
         _resourceLoader = Guard.Against.Null(resourceLoader);
         _playerSleepModeService = Guard.Against.Null(playerSleepModeService);
+        _telemetryClient = Guard.Against.Null(telemetryClient);
         _logger = Guard.Against.Null(logger);
 
         _stateManager.PropertyChanged += OnStateManagerPropertyChanged;
@@ -175,7 +177,6 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
 
         _timerManager.Start();
     }
-
 
     private void OnStateManagerPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -189,7 +190,6 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
     {
         _stateManager.ExecuteOnUIThread(() => OnPropertyChanged(nameof(IsSleepModeActive)));
     }
-
 
     private void SubscribeToMessages()
     {
@@ -249,7 +249,6 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
 
     #endregion
 
-
     #region Message Handlers
 
     private void OnTrackScoreUpdated(TrackScoreUpdateMessage message)
@@ -280,6 +279,8 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
     private async Task OnMediaChangedAsync(MediaChangedMessage message)
     {
         _logger.LogDebug("Player VM handle media changed: title {Title}.", message.NewTrack.Title);
+
+        await _telemetryClient.CaptureEventAsync("Player", "TrackChanged");
 
         TrackViewModel trackViewModel = _dataLoader.CreateTrackViewModel(message.NewTrack);
 
@@ -366,7 +367,6 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
 
     #endregion
 
-
     private void LoadBackdrop()
     {
         _timerManager.StopBackdropTimer();
@@ -415,7 +415,6 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(IsSynchronizedLyrics));
         OnPropertyChanged(nameof(PlainLyrics));
     }
-
 
     [RelayCommand]
     public void SetSleepTimer(int minutes)
@@ -520,8 +519,6 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
         _equalizerWindow.Closed += (_, _) => _equalizerWindow = null;
         _equalizerWindow.Activate();
     }
-
-
 
     public void Dispose()
     {


### PR DESCRIPTION
Add screen capture to all NavigationService methods that were missing it (ArtistPage, AlbumPage, GenrePage, TrackPage, SmartPlaylistPage, PlaylistPage). Also track generic NavigateTo calls using the page type name so any future page is covered automatically.

Capture a "Stop" event in MainWindow_Closed (App.xaml.cs) to mirror the existing "Start" event and enable precise session duration measurement.

Track player TrackChanged events in PlayerViewModel.OnMediaChangedAsync.