### PR TITLE
fix(import): run import on thread pool to prevent UI blocking

### DIFF
--- a/src/Rok.Import/ImportService.cs
+++ b/src/Rok.Import/ImportService.cs
@@ -80,7 +80,7 @@ ILogger<ImportService> logger) : IImport
             if (delayInSeconds > 0)
                 await Task.Delay(delayInSeconds, _cancellationToken!.Token);
 
-            await ImportAsync(_cancellationToken!.Token);
+            await Task.Run(() => ImportAsync(_cancellationToken!.Token), _cancellationToken!.Token);
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
Wrap ImportAsync call in Task.Run to offload execution to the thread pool, ensuring the UI thread is never blocked during library import.

Remove unnecessary ConfigureAwait(false) in SendMetricsAsync for consistency, as Task.Run already removes the SynchronizationContext.