### PR TITLE
fix(artist): update artist data and pictures from API

### DIFF
--- a/src/Presentation/ViewModels/Album/AlbumViewModel.cs
+++ b/src/Presentation/ViewModels/Album/AlbumViewModel.cs
@@ -419,19 +419,25 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
     {
         CancellationToken token = _navigationCts.Token;
 
-        bool updated = await _apiService.GetAndUpdateAlbumDataAsync(Album, _pictureService);
+        AlbumApiUpdateResult result = await _apiService.GetAndUpdateAlbumDataAsync(Album, _pictureService);
 
-        if (!updated || token.IsCancellationRequested)
+        if (token.IsCancellationRequested)
             return;
 
-        if (_pictureService.PictureExists(Album.AlbumPath))
+        if (result.PictureDownloaded)
+        {
             LoadPicture();
+            Messenger.Send(new AlbumUpdateMessage(Album.Id, ActionType.Picture));
+        }
 
-        AlbumDto? refreshedAlbum = await _dataLoader.ReloadAlbumAsync(Album.Id);
-        if (refreshedAlbum != null)
-            Album = refreshedAlbum;
+        if (result.DataUpdated)
+        {
+            AlbumDto? refreshedAlbum = await _dataLoader.ReloadAlbumAsync(Album.Id);
+            if (refreshedAlbum != null)
+                Album = refreshedAlbum;
 
-        Messenger.Send(new AlbumUpdateMessage(Album.Id, ActionType.Update));
+            Messenger.Send(new AlbumUpdateMessage(Album.Id, ActionType.Update));
+        }
     }
 
     [RelayCommand]

--- a/src/Presentation/ViewModels/Albums/Handlers/AlbumUpdateMessageHandler.cs
+++ b/src/Presentation/ViewModels/Albums/Handlers/AlbumUpdateMessageHandler.cs
@@ -51,6 +51,11 @@ public class AlbumUpdateMessageHandler(AlbumsDataLoader dataLoader, ILogger<Albu
                 dataLoader.RemoveAlbum(message.Id);
                 logger.LogTrace("Album {Id} viewmodel removed.", message.Id);
                 break;
+
+            case ActionType.Picture:
+                dataLoader.RefreshAlbumPicture(message.Id);
+                logger.LogTrace("Album {Id} picture updated.", message.Id);
+                break;
         }
 
         DataChanged?.Invoke(this, EventArgs.Empty);

--- a/src/Presentation/ViewModels/Albums/Services/AlbumsDataLoader.cs
+++ b/src/Presentation/ViewModels/Albums/Services/AlbumsDataLoader.cs
@@ -81,6 +81,20 @@ public class AlbumsDataLoader(IMediator mediator, IAlbumViewModelFactory albumVi
         }
     }
 
+    public void RefreshAlbumPicture(long id)
+    {
+        AlbumViewModel? albumToUpdate = ViewModels.FirstOrDefault(c => c.Album.Id == id);
+
+        if (albumToUpdate != null)
+        {
+            albumToUpdate.LoadPicture();
+        }
+        else
+        {
+            logger.LogWarning("Album {Id} not found for picture refresh.", id);
+        }
+    }
+
     public void RemoveAlbum(long id)
     {
         ViewModels.RemoveAll(c => c.Album.Id == id);

--- a/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
+++ b/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
@@ -456,19 +456,28 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
     {
         CancellationToken token = _navigationCts.Token;
 
-        bool updated = await _apiService.GetAndUpdateArtistDataAsync(Artist, _pictureService, _backdropPicture);
+        ArtistApiUpdateResult result = await _apiService.GetAndUpdateArtistDataAsync(Artist, _pictureService, _backdropPicture);
 
-        if (!updated || token.IsCancellationRequested)
+        if (token.IsCancellationRequested)
             return;
 
-        if (_pictureService.PictureExists(Artist.Name))
+        if (result.PictureDownloaded)
+        {
             LoadPicture();
+            Messenger.Send(new ArtistUpdateMessage(Artist.Id, ActionType.Picture));
+        }
 
-        ArtistDto? refreshedArtist = await _dataLoader.ReloadArtistAsync(Artist.Id);
-        if (refreshedArtist != null)
-            Artist = refreshedArtist;
+        if (result.BackdropsDownloaded)
+            LoadBackdrop();
 
-        Messenger.Send(new ArtistUpdateMessage(Artist.Id, ActionType.Update));
+        if (result.DataUpdated)
+        {
+            ArtistDto? refreshedArtist = await _dataLoader.ReloadArtistAsync(Artist.Id);
+            if (refreshedArtist != null)
+                Artist = refreshedArtist;
+
+            Messenger.Send(new ArtistUpdateMessage(Artist.Id, ActionType.Update));
+        }
     }
 
 

--- a/src/Rok.Application/Features/Albums/Services/AlbumApiService.cs
+++ b/src/Rok.Application/Features/Albums/Services/AlbumApiService.cs
@@ -12,42 +12,45 @@ public class AlbumApiService(
     IMusicDataApiService musicDataApiService,
     ILogger<AlbumApiService> logger)
 {
-    public async Task<bool> GetAndUpdateAlbumDataAsync(AlbumDto album, IAlbumPictureService pictureService)
+    public async Task<AlbumApiUpdateResult> GetAndUpdateAlbumDataAsync(AlbumDto album, IAlbumPictureService pictureService)
     {
         if (string.IsNullOrEmpty(album.Name) || string.IsNullOrEmpty(album.ArtistName))
-            return false;
+            return AlbumApiUpdateResult.None;
 
         if (!musicDataApiService.IsApiRetryAllowed(album.GetMetaDataLastAttempt))
-            return false;
+            return AlbumApiUpdateResult.None;
 
         await mediator.SendMessageAsync(new UpdateAlbumGetMetaDataLastAttemptCommand(album.Id));
         album.GetMetaDataLastAttempt = DateTime.UtcNow;
 
         MusicDataAlbumDto? albumApi = await musicDataApiService.GetAlbumAsync(album.Name, album.ArtistName, album.MusicBrainzID, album.ArtistMusicBrainzID);
         if (albumApi == null)
-            return false;
-
-        if (!string.IsNullOrEmpty(albumApi.MusicBrainzID))
-        {
-            await DownloadPictureIfNeededAsync(album, albumApi, pictureService, CancellationToken.None);
-
-            if (CompareAlbumFromApi(album, albumApi))
-                return await UpdateAlbumDataIfNeededAsync(album, albumApi);
-        }
-
-        return false;
-    }
-
-    private async Task DownloadPictureIfNeededAsync(AlbumDto album, MusicDataAlbumDto albumApi, IAlbumPictureService pictureService, CancellationToken cancellationToken)
-    {
-        if (pictureService.PictureExists(album.AlbumPath))
-            return;
+            return AlbumApiUpdateResult.None;
 
         if (string.IsNullOrEmpty(albumApi.MusicBrainzID))
-            return;
+            return AlbumApiUpdateResult.None;
+
+        bool pictureDownloaded = await DownloadPictureIfNeededAsync(album, albumApi, pictureService, CancellationToken.None);
+
+        bool dataUpdated = false;
+        if (CompareAlbumFromApi(album, albumApi))
+            dataUpdated = await UpdateAlbumDataIfNeededAsync(album, albumApi);
+
+        return new AlbumApiUpdateResult(dataUpdated, pictureDownloaded);
+    }
+
+    private async Task<bool> DownloadPictureIfNeededAsync(AlbumDto album, MusicDataAlbumDto albumApi, IAlbumPictureService pictureService, CancellationToken cancellationToken)
+    {
+        if (pictureService.PictureExists(album.AlbumPath))
+            return false;
+
+        if (string.IsNullOrEmpty(albumApi.MusicBrainzID))
+            return false;
 
         string picturePath = pictureService.GetPictureFilePath(album.AlbumPath);
         await musicDataApiService.DownloadCoverAsync(albumApi, picturePath, cancellationToken);
+
+        return pictureService.PictureExists(album.AlbumPath);
     }
 
     private async Task<bool> UpdateAlbumDataIfNeededAsync(AlbumDto album, MusicDataAlbumDto albumApi)

--- a/src/Rok.Application/Features/Albums/Services/AlbumApiUpdateResult.cs
+++ b/src/Rok.Application/Features/Albums/Services/AlbumApiUpdateResult.cs
@@ -1,0 +1,6 @@
+namespace Rok.Application.Features.Albums.Services;
+
+public readonly record struct AlbumApiUpdateResult(bool DataUpdated, bool PictureDownloaded)
+{
+    public static AlbumApiUpdateResult None => new(false, false);
+}

--- a/src/Rok.Application/Features/Artists/Services/ArtistApiService.cs
+++ b/src/Rok.Application/Features/Artists/Services/ArtistApiService.cs
@@ -12,54 +12,59 @@ public class ArtistApiService(
     IMusicDataApiService musicDataApiService,
     ILogger<ArtistApiService> logger)
 {
-    public async Task<bool> GetAndUpdateArtistDataAsync(ArtistDto artist, IArtistPictureService pictureService, IBackdropPicture backdropPicture)
+    public async Task<ArtistApiUpdateResult> GetAndUpdateArtistDataAsync(ArtistDto artist, IArtistPictureService pictureService, IBackdropPicture backdropPicture)
     {
         if (string.IsNullOrEmpty(artist.Name))
-            return false;
+            return ArtistApiUpdateResult.None;
 
         if (!musicDataApiService.IsApiRetryAllowed(artist.GetMetaDataLastAttempt))
-            return false;
+            return ArtistApiUpdateResult.None;
 
         await mediator.SendMessageAsync(new UpdateArtistGetMetaDataLastAttemptCommand(artist.Id));
         artist.GetMetaDataLastAttempt = DateTime.UtcNow;
 
         MusicDataArtistDto? artistApi = await musicDataApiService.GetArtistAsync(artist.Name, artist.MusicBrainzID);
         if (artistApi == null)
-            return false;
+            return ArtistApiUpdateResult.None;
 
-        if (!string.IsNullOrEmpty(artistApi.MusicBrainzID))
-        {
-            await DownloadPictureIfNeededAsync(artist, artistApi, pictureService, CancellationToken.None);
-            await DownloadBackdropsIfNeededAsync(artist, artistApi, backdropPicture, CancellationToken.None);
+        if (string.IsNullOrEmpty(artistApi.MusicBrainzID))
+            return ArtistApiUpdateResult.None;
 
-            if (CompareArtistFromApi(artist, artistApi))
-                return await UpdateArtistDataIfNeededAsync(artist, artistApi);
-        }
+        bool pictureDownloaded = await DownloadPictureIfNeededAsync(artist, artistApi, pictureService, CancellationToken.None);
+        bool backdropsDownloaded = await DownloadBackdropsIfNeededAsync(artist, artistApi, backdropPicture, CancellationToken.None);
 
-        return false;
+        bool dataUpdated = false;
+        if (CompareArtistFromApi(artist, artistApi))
+            dataUpdated = await UpdateArtistDataIfNeededAsync(artist, artistApi);
+
+        return new ArtistApiUpdateResult(dataUpdated, pictureDownloaded, backdropsDownloaded);
     }
 
-    private async Task DownloadPictureIfNeededAsync(ArtistDto artist, MusicDataArtistDto artistApi, IArtistPictureService pictureService, CancellationToken cancellationToken)
+    private async Task<bool> DownloadPictureIfNeededAsync(ArtistDto artist, MusicDataArtistDto artistApi, IArtistPictureService pictureService, CancellationToken cancellationToken)
     {
         if (pictureService.PictureExists(artist.Name))
-            return;
+            return false;
 
         if (string.IsNullOrWhiteSpace(artistApi.PictureUrl))
-            return;
+            return false;
 
         string picturePath = pictureService.GetPictureFilePath(artist.Name);
 
         await musicDataApiService.DownloadArtistPictureAsync(artistApi, picturePath, cancellationToken);
+
+        return pictureService.PictureExists(artist.Name);
     }
 
-    private async Task DownloadBackdropsIfNeededAsync(ArtistDto artist, MusicDataArtistDto artistApi, IBackdropPicture backdropPicture, CancellationToken cancellationToken)
+    private async Task<bool> DownloadBackdropsIfNeededAsync(ArtistDto artist, MusicDataArtistDto artistApi, IBackdropPicture backdropPicture, CancellationToken cancellationToken)
     {
         if (backdropPicture.HasBackdrops(artist.Name))
-            return;
+            return false;
 
         string backdropFolder = backdropPicture.GetArtistPictureFolder(artist.Name);
 
         await musicDataApiService.DownloadArtistBackdropsAsync(artistApi, backdropFolder, cancellationToken);
+
+        return backdropPicture.HasBackdrops(artist.Name);
     }
 
     private async Task<bool> UpdateArtistDataIfNeededAsync(ArtistDto artist, MusicDataArtistDto artistApi)

--- a/src/Rok.Application/Features/Artists/Services/ArtistApiUpdateResult.cs
+++ b/src/Rok.Application/Features/Artists/Services/ArtistApiUpdateResult.cs
@@ -1,0 +1,6 @@
+namespace Rok.Application.Features.Artists.Services;
+
+public readonly record struct ArtistApiUpdateResult(bool DataUpdated, bool PictureDownloaded, bool BackdropsDownloaded)
+{
+    public static ArtistApiUpdateResult None => new(false, false, false);
+}

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Albums/Services/AlbumApiServiceTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Albums/Services/AlbumApiServiceTests.cs
@@ -17,26 +17,26 @@ public class AlbumApiServiceTests
 
     private AlbumApiService BuildService() => new(_mediator.Object, _musicData.Object, NullLogger<AlbumApiService>.Instance);
 
-    [Theory(DisplayName = "GetAndUpdateAlbumDataAsync should return false when album name or artist name is empty")]
+    [Theory(DisplayName = "GetAndUpdateAlbumDataAsync should return None when album name or artist name is empty")]
     [InlineData("", "Beatles")]
     [InlineData("Album", "")]
     [InlineData("", "")]
-    public async Task GetAndUpdateAlbumDataAsync_ShouldReturnFalse_WhenNamesMissing(string name, string artistName)
+    public async Task GetAndUpdateAlbumDataAsync_ShouldReturnNone_WhenNamesMissing(string name, string artistName)
     {
         // Arrange
         AlbumDto album = new() { Id = 1, Name = name, ArtistName = artistName };
         AlbumApiService sut = BuildService();
 
         // Act
-        bool result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
+        AlbumApiUpdateResult result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
 
         // Assert
-        Assert.False(result);
+        Assert.Equal(AlbumApiUpdateResult.None, result);
         _musicData.Verify(m => m.GetAlbumAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
     }
 
-    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should return false when API retry is not allowed")]
-    public async Task GetAndUpdateAlbumDataAsync_ShouldReturnFalse_WhenRetryNotAllowed()
+    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should return None when API retry is not allowed")]
+    public async Task GetAndUpdateAlbumDataAsync_ShouldReturnNone_WhenRetryNotAllowed()
     {
         // Arrange
         AlbumDto album = new() { Id = 1, Name = "Album", ArtistName = "Artist" };
@@ -44,10 +44,10 @@ public class AlbumApiServiceTests
         AlbumApiService sut = BuildService();
 
         // Act
-        bool result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
+        AlbumApiUpdateResult result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
 
         // Assert
-        Assert.False(result);
+        Assert.Equal(AlbumApiUpdateResult.None, result);
         _musicData.Verify(m => m.GetAlbumAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
         _mediator.Verify(m => m.SendMessageAsync(It.IsAny<UpdateAlbumGetMetaDataLastAttemptCommand>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -69,8 +69,8 @@ public class AlbumApiServiceTests
         Assert.NotNull(album.GetMetaDataLastAttempt);
     }
 
-    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should return false when the API returns null")]
-    public async Task GetAndUpdateAlbumDataAsync_ShouldReturnFalse_WhenApiReturnsNull()
+    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should return None when the API returns null")]
+    public async Task GetAndUpdateAlbumDataAsync_ShouldReturnNone_WhenApiReturnsNull()
     {
         // Arrange
         AlbumDto album = new() { Id = 1, Name = "Album", ArtistName = "Artist" };
@@ -79,14 +79,14 @@ public class AlbumApiServiceTests
         AlbumApiService sut = BuildService();
 
         // Act
-        bool result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
+        AlbumApiUpdateResult result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
 
         // Assert
-        Assert.False(result);
+        Assert.Equal(AlbumApiUpdateResult.None, result);
     }
 
-    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should return false when the API response has no MusicBrainz id")]
-    public async Task GetAndUpdateAlbumDataAsync_ShouldReturnFalse_WhenApiResponseHasNoMbid()
+    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should return None when the API response has no MusicBrainz id")]
+    public async Task GetAndUpdateAlbumDataAsync_ShouldReturnNone_WhenApiResponseHasNoMbid()
     {
         // Arrange
         AlbumDto album = new() { Id = 1, Name = "Album", ArtistName = "Artist" };
@@ -96,9 +96,69 @@ public class AlbumApiServiceTests
         AlbumApiService sut = BuildService();
 
         // Act
-        bool result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
+        AlbumApiUpdateResult result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
 
         // Assert
-        Assert.False(result);
+        Assert.Equal(AlbumApiUpdateResult.None, result);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should report PictureDownloaded when the cover is fetched and now exists")]
+    public async Task GetAndUpdateAlbumDataAsync_ShouldReportPictureDownloaded_WhenCoverFetched()
+    {
+        // Arrange
+        AlbumDto album = new() { Id = 1, Name = "Album", ArtistName = "Artist", AlbumPath = "C:/music/Album" };
+        MusicDataAlbumDto albumApi = new() { MusicBrainzID = "mbid" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetAlbumAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>())).ReturnsAsync(albumApi);
+        _pictureService.SetupSequence(p => p.PictureExists(album.AlbumPath)).Returns(false).Returns(true);
+        _pictureService.Setup(p => p.GetPictureFilePath(album.AlbumPath)).Returns("C:/music/Album/cover.jpg");
+        AlbumApiService sut = BuildService();
+
+        // Act
+        AlbumApiUpdateResult result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
+
+        // Assert
+        Assert.True(result.PictureDownloaded);
+        _musicData.Verify(m => m.DownloadCoverAsync(albumApi, "C:/music/Album/cover.jpg", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should not report PictureDownloaded when the cover already exists locally")]
+    public async Task GetAndUpdateAlbumDataAsync_ShouldNotReportPictureDownloaded_WhenCoverAlreadyExists()
+    {
+        // Arrange
+        AlbumDto album = new() { Id = 1, Name = "Album", ArtistName = "Artist", AlbumPath = "C:/music/Album" };
+        MusicDataAlbumDto albumApi = new() { MusicBrainzID = "mbid" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetAlbumAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>())).ReturnsAsync(albumApi);
+        _pictureService.Setup(p => p.PictureExists(album.AlbumPath)).Returns(true);
+        AlbumApiService sut = BuildService();
+
+        // Act
+        AlbumApiUpdateResult result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
+
+        // Assert
+        Assert.False(result.PictureDownloaded);
+        _musicData.Verify(m => m.DownloadCoverAsync(It.IsAny<MusicDataAlbumDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateAlbumDataAsync should report PictureDownloaded independently of DataUpdated")]
+    public async Task GetAndUpdateAlbumDataAsync_ShouldReportPictureDownloaded_EvenWhenNoDataChanged()
+    {
+        // Arrange
+        AlbumDto album = new() { Id = 1, Name = "Album", ArtistName = "Artist", AlbumPath = "C:/music/Album", MusicBrainzID = "mbid" };
+        MusicDataAlbumDto albumApi = new() { MusicBrainzID = "mbid" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetAlbumAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>())).ReturnsAsync(albumApi);
+        _pictureService.SetupSequence(p => p.PictureExists(album.AlbumPath)).Returns(false).Returns(true);
+        _pictureService.Setup(p => p.GetPictureFilePath(album.AlbumPath)).Returns("C:/music/Album/cover.jpg");
+        AlbumApiService sut = BuildService();
+
+        // Act
+        AlbumApiUpdateResult result = await sut.GetAndUpdateAlbumDataAsync(album, _pictureService.Object);
+
+        // Assert
+        Assert.True(result.PictureDownloaded);
+        Assert.False(result.DataUpdated);
+        _mediator.Verify(m => m.SendMessageAsync(It.IsAny<UpdateAlbumCommand>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Artists/Services/ArtistApiServiceTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Artists/Services/ArtistApiServiceTests.cs
@@ -18,23 +18,23 @@ public class ArtistApiServiceTests
 
     private ArtistApiService BuildService() => new(_mediator.Object, _musicData.Object, NullLogger<ArtistApiService>.Instance);
 
-    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should return false when artist name is empty")]
-    public async Task GetAndUpdateArtistDataAsync_ShouldReturnFalse_WhenNameMissing()
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should return None when artist name is empty")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldReturnNone_WhenNameMissing()
     {
         // Arrange
         ArtistDto artist = new() { Id = 1, Name = "" };
         ArtistApiService sut = BuildService();
 
         // Act
-        bool result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
 
         // Assert
-        Assert.False(result);
+        Assert.Equal(ArtistApiUpdateResult.None, result);
         _musicData.Verify(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
     }
 
-    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should return false when API retry is not allowed")]
-    public async Task GetAndUpdateArtistDataAsync_ShouldReturnFalse_WhenRetryNotAllowed()
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should return None when API retry is not allowed")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldReturnNone_WhenRetryNotAllowed()
     {
         // Arrange
         ArtistDto artist = new() { Id = 1, Name = "Beatles" };
@@ -42,10 +42,10 @@ public class ArtistApiServiceTests
         ArtistApiService sut = BuildService();
 
         // Act
-        bool result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
 
         // Assert
-        Assert.False(result);
+        Assert.Equal(ArtistApiUpdateResult.None, result);
         _musicData.Verify(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
     }
 
@@ -66,8 +66,8 @@ public class ArtistApiServiceTests
         Assert.NotNull(artist.GetMetaDataLastAttempt);
     }
 
-    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should return false when the API returns null")]
-    public async Task GetAndUpdateArtistDataAsync_ShouldReturnFalse_WhenApiReturnsNull()
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should return None when the API returns null")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldReturnNone_WhenApiReturnsNull()
     {
         // Arrange
         ArtistDto artist = new() { Id = 1, Name = "Beatles" };
@@ -76,14 +76,14 @@ public class ArtistApiServiceTests
         ArtistApiService sut = BuildService();
 
         // Act
-        bool result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
 
         // Assert
-        Assert.False(result);
+        Assert.Equal(ArtistApiUpdateResult.None, result);
     }
 
-    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should return false when the API response has no MusicBrainz id")]
-    public async Task GetAndUpdateArtistDataAsync_ShouldReturnFalse_WhenApiResponseHasNoMbid()
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should return None when the API response has no MusicBrainz id")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldReturnNone_WhenApiResponseHasNoMbid()
     {
         // Arrange
         ArtistDto artist = new() { Id = 1, Name = "Beatles" };
@@ -93,9 +93,134 @@ public class ArtistApiServiceTests
         ArtistApiService sut = BuildService();
 
         // Act
-        bool result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
 
         // Assert
-        Assert.False(result);
+        Assert.Equal(ArtistApiUpdateResult.None, result);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should report PictureDownloaded when the picture is fetched and now exists")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldReportPictureDownloaded_WhenPictureFetched()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 1, Name = "Beatles" };
+        MusicDataArtistDto artistApi = new() { MusicBrainzID = "mbid", PictureUrl = "https://example.com/pic.jpg" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>())).ReturnsAsync(artistApi);
+        _pictureService.SetupSequence(p => p.PictureExists(artist.Name)).Returns(false).Returns(true);
+        _pictureService.Setup(p => p.GetPictureFilePath(artist.Name)).Returns("C:/tmp/Beatles.jpg");
+        _backdropPicture.Setup(b => b.HasBackdrops(artist.Name)).Returns(true);
+        ArtistApiService sut = BuildService();
+
+        // Act
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+
+        // Assert
+        Assert.True(result.PictureDownloaded);
+        Assert.False(result.BackdropsDownloaded);
+        _musicData.Verify(m => m.DownloadArtistPictureAsync(artistApi, "C:/tmp/Beatles.jpg", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should not report PictureDownloaded when the picture already exists locally")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldNotReportPictureDownloaded_WhenPictureAlreadyExists()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 1, Name = "Beatles" };
+        MusicDataArtistDto artistApi = new() { MusicBrainzID = "mbid", PictureUrl = "https://example.com/pic.jpg" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>())).ReturnsAsync(artistApi);
+        _pictureService.Setup(p => p.PictureExists(artist.Name)).Returns(true);
+        _backdropPicture.Setup(b => b.HasBackdrops(artist.Name)).Returns(true);
+        ArtistApiService sut = BuildService();
+
+        // Act
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+
+        // Assert
+        Assert.False(result.PictureDownloaded);
+        _musicData.Verify(m => m.DownloadArtistPictureAsync(It.IsAny<MusicDataArtistDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should not report PictureDownloaded when the API picture URL is empty")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldNotReportPictureDownloaded_WhenApiPictureUrlIsEmpty()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 1, Name = "Beatles" };
+        MusicDataArtistDto artistApi = new() { MusicBrainzID = "mbid", PictureUrl = string.Empty };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>())).ReturnsAsync(artistApi);
+        _pictureService.Setup(p => p.PictureExists(artist.Name)).Returns(false);
+        _backdropPicture.Setup(b => b.HasBackdrops(artist.Name)).Returns(true);
+        ArtistApiService sut = BuildService();
+
+        // Act
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+
+        // Assert
+        Assert.False(result.PictureDownloaded);
+        _musicData.Verify(m => m.DownloadArtistPictureAsync(It.IsAny<MusicDataArtistDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should report BackdropsDownloaded when backdrops are fetched and the folder is now populated")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldReportBackdropsDownloaded_WhenBackdropsFetched()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 1, Name = "Beatles" };
+        MusicDataArtistDto artistApi = new() { MusicBrainzID = "mbid" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>())).ReturnsAsync(artistApi);
+        _pictureService.Setup(p => p.PictureExists(artist.Name)).Returns(true);
+        _backdropPicture.SetupSequence(b => b.HasBackdrops(artist.Name)).Returns(false).Returns(true);
+        _backdropPicture.Setup(b => b.GetArtistPictureFolder(artist.Name)).Returns("C:/tmp/backdrops");
+        ArtistApiService sut = BuildService();
+
+        // Act
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+
+        // Assert
+        Assert.True(result.BackdropsDownloaded);
+        _musicData.Verify(m => m.DownloadArtistBackdropsAsync(artistApi, "C:/tmp/backdrops", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should not report BackdropsDownloaded when backdrops already exist")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldNotReportBackdropsDownloaded_WhenBackdropsAlreadyExist()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 1, Name = "Beatles" };
+        MusicDataArtistDto artistApi = new() { MusicBrainzID = "mbid" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>())).ReturnsAsync(artistApi);
+        _pictureService.Setup(p => p.PictureExists(artist.Name)).Returns(true);
+        _backdropPicture.Setup(b => b.HasBackdrops(artist.Name)).Returns(true);
+        ArtistApiService sut = BuildService();
+
+        // Act
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+
+        // Assert
+        Assert.False(result.BackdropsDownloaded);
+        _musicData.Verify(m => m.DownloadArtistBackdropsAsync(It.IsAny<MusicDataArtistDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should report PictureDownloaded independently of DataUpdated")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldReportPictureDownloaded_EvenWhenNoDataChanged()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 1, Name = "Beatles", MusicBrainzID = "mbid" };
+        MusicDataArtistDto artistApi = new() { MusicBrainzID = "mbid", PictureUrl = "https://example.com/pic.jpg" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>())).ReturnsAsync(artistApi);
+        _pictureService.SetupSequence(p => p.PictureExists(artist.Name)).Returns(false).Returns(true);
+        _pictureService.Setup(p => p.GetPictureFilePath(artist.Name)).Returns("C:/tmp/Beatles.jpg");
+        _backdropPicture.Setup(b => b.HasBackdrops(artist.Name)).Returns(true);
+        ArtistApiService sut = BuildService();
+
+        // Act
+        ArtistApiUpdateResult result = await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+
+        // Assert
+        Assert.True(result.PictureDownloaded);
+        Assert.False(result.DataUpdated);
+        _mediator.Verify(m => m.SendMessageAsync(It.IsAny<UpdateArtistCommand>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }


### PR DESCRIPTION
Add comparison logic before patching artist data to avoid unnecessary updates. Download artist picture and backdrops only when missing.

Update artist metadata including social URLs, biography, AudioDb ID, birth/death years and MusicBrainz ID from the music data API response.