### PR TITLE
fix(viewmodels): correct race conditions and collection handling in A…

### DIFF
--- a/src/Presentation/GlobalUsings.cs
+++ b/src/Presentation/GlobalUsings.cs
@@ -3,6 +3,7 @@ global using System.Collections.Generic;
 global using System.Collections.ObjectModel;
 global using System.Diagnostics;
 global using System.Linq;
+global using System.Threading;
 global using System.Threading.Tasks;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;

--- a/src/Presentation/ViewModels/Album/AlbumViewModel.cs
+++ b/src/Presentation/ViewModels/Album/AlbumViewModel.cs
@@ -40,7 +40,6 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
     public AlbumDto Album { get; private set; } = new();
     public IPlaylistMenuService PlaylistMenuService { get; }
 
-
     public ObservableCollection<string> EditableTags { get; set; } = new();
 
     public ObservableCollection<string> SuggestedTags { get; set; } = new();
@@ -85,7 +84,6 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
     string? IGroupable.CountryCode => Album.CountryCode;
     DateTime IGroupable.CreatDate => Album.CreatDate;
     DateTime? IGroupable.LastListen => Album.LastListen;
-
 
     [ObservableProperty]
     public partial BitmapImage? Backdrop { get; set; }
@@ -144,7 +142,7 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
     {
         get
         {
-            TimeSpan time = TimeSpan.FromSeconds(Album.Duration);
+            var time = TimeSpan.FromSeconds(Album.Duration);
             int roundedMinutes = (int)Math.Round(time.TotalMinutes);
             return roundedMinutes.ToString();
         }
@@ -162,8 +160,6 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
         }
         set => SetProperty(ref _picture, value);
     }
-
-
 
     public AlbumViewModel(
         IBackdropLoader backdropLoader,
@@ -200,9 +196,6 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
         _logger = Guard.Against.Null(logger);
     }
 
-
-
-
     public void SetData(AlbumDto album)
     {
         Album = Guard.Against.Null(album);
@@ -225,7 +218,7 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
         if (cancellationToken.IsCancellationRequested)
             return;
 
-        await LoadTracksAsync(albumId);
+        await LoadTracksAsync(albumId, cancellationToken);
 
         if (cancellationToken.IsCancellationRequested)
             return;
@@ -257,7 +250,6 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
         Backdrop = null;
     }
 
-
     private CancellationToken InitNavigationCancellation()
     {
         _navigationCts.Cancel();
@@ -266,12 +258,15 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
         return _navigationCts.Token;
     }
 
-
-    private async Task LoadTracksAsync(long albumId)
+    private async Task LoadTracksAsync(long albumId, CancellationToken cancellationToken)
     {
         List<TrackViewModel> tracks = await _dataLoader.LoadTracksAsync(albumId);
+
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
         _tracks = tracks.Select(t => t.Track);
-        Tracks.AddRange(tracks);
+        Tracks.InitWithAddRange(tracks);
     }
 
     private async Task LoadAlbumAsync(long albumId)
@@ -301,7 +296,6 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
         }
     }
 
-
     private void LoadBackrop()
     {
         CancellationToken token = _navigationCts.Token;
@@ -312,7 +306,6 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
                 Backdrop = backdropImage;
         });
     }
-
 
     private async Task CalculatePictureDominantColorAsync()
     {
@@ -373,7 +366,6 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
             Messenger.Send(new AlbumUpdateMessage(Album.Id, ActionType.Update));
     }
 
-
     [RelayCommand]
     private void AlbumOpen()
     {
@@ -398,7 +390,7 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
     private async Task ListenAsync(TrackViewModel? startTrack = null)
     {
         if (_tracks == null)
-            await LoadTracksAsync(Album.Id);
+            await LoadTracksAsync(Album.Id, CancellationToken.None);
 
         if (_tracks?.Any() == true)
             _playerService.LoadPlaylist(_tracks.ToList(), startTrack?.Track);

--- a/src/Presentation/ViewModels/Albums/Services/AlbumsPlaybackService.cs
+++ b/src/Presentation/ViewModels/Albums/Services/AlbumsPlaybackService.cs
@@ -14,11 +14,9 @@ public class AlbumsPlaybackService(IMediator mediator, IPlayerService playerServ
             return;
         }
 
-        List<TrackDto> tracks = (await mediator.SendMessageAsync(new GetTracksByAlbumListQuery { AlbumsId = albumIds.ToList() })).ToList();
+        var tracks = (await mediator.SendMessageAsync(new GetTracksByAlbumListQuery { AlbumsId = albumIds.ToList() })).ToList();
 
-        if (albumIds.Count() == 1)
-            TracksRandomizer.Randomize(tracks);
-        else
+        if (albumIds.Count() > 1)
             TracksRandomizer.ArtistBalancedTrackRandomize(tracks, 0);
 
         playerService.LoadPlaylist(tracks.ToList());

--- a/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
+++ b/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
@@ -289,14 +289,17 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
 
         await LoadArtistAsync(artistId);
 
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
         if (loadAlbums)
-            await LoadAlbumsAsync(artistId);
+            await LoadAlbumsAsync(artistId, cancellationToken);
 
         if (cancellationToken.IsCancellationRequested)
             return;
 
         if (loadTracks)
-            await LoadTracksAsync(artistId);
+            await LoadTracksAsync(artistId, cancellationToken);
 
         if (cancellationToken.IsCancellationRequested)
             return;
@@ -401,17 +404,25 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
         }
     }
 
-    private async Task LoadAlbumsAsync(long artistId)
+    private async Task LoadAlbumsAsync(long artistId, CancellationToken cancellationToken)
     {
         List<AlbumViewModel> albums = await _dataLoader.LoadAlbumsAsync(artistId);
-        Albums.AddRange(albums);
+
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
+        Albums.InitWithAddRange(albums);
     }
 
-    private async Task LoadTracksAsync(long artistId)
+    private async Task LoadTracksAsync(long artistId, CancellationToken cancellationToken)
     {
         List<TrackViewModel> tracks = await _dataLoader.LoadTracksAsync(artistId);
+
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
         _tracks = tracks.Select(t => t.Track);
-        Tracks.AddRange(tracks);
+        Tracks.InitWithAddRange(tracks);
 
         OnPropertyChanged(nameof(DurationTotal));
     }
@@ -499,7 +510,7 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
     private async Task ListenAsync()
     {
         if (_tracks == null)
-            await LoadTracksAsync(Artist.Id);
+            await LoadTracksAsync(Artist.Id, CancellationToken.None);
 
         if (_tracks?.Any() == true)
         {

--- a/src/Presentation/ViewModels/Genre/GenreViewModel.cs
+++ b/src/Presentation/ViewModels/Genre/GenreViewModel.cs
@@ -21,6 +21,8 @@ public partial class GenreViewModel : ObservableObject
     private readonly ArtistPictureService _pictureService;
     private readonly GenreEditService _editService;
 
+    private CancellationTokenSource _navigationCts = new();
+
     public RangeObservableCollection<AlbumViewModel> Albums { get; set; } = [];
     public GenreDto Genre { get; private set; } = new();
 
@@ -156,16 +158,36 @@ public partial class GenreViewModel : ObservableObject
 
     public async Task LoadDataAsync(long genreId, bool loadAlbums = true, bool loadTracks = true)
     {
+        CancellationToken cancellationToken = InitNavigationCancellation();
+
         Stopwatch stopwatch = new();
         stopwatch.Start();
 
         await LoadGenreAsync(genreId);
-        await LoadAlbumsAsync(genreId);
+
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
+        await LoadAlbumsAsync(genreId, cancellationToken);
 
         stopwatch.Stop();
 
         _logger.LogInformation("Genre {GenreId} loaded in {ElapsedMilliseconds} ms (albums: {LoadAlbums}, tracks: {LoadTracks})",
                                 genreId, stopwatch.ElapsedMilliseconds, loadAlbums, loadTracks);
+    }
+
+    public void OnNavigatedFrom()
+    {
+        InitNavigationCancellation();
+        Backdrop = null;
+    }
+
+    private CancellationToken InitNavigationCancellation()
+    {
+        _navigationCts.Cancel();
+        _navigationCts.Dispose();
+        _navigationCts = new CancellationTokenSource();
+        return _navigationCts.Token;
     }
 
 
@@ -178,21 +200,24 @@ public partial class GenreViewModel : ObservableObject
     }
 
 
-    private async Task LoadAlbumsAsync(long genreId)
+    private async Task LoadAlbumsAsync(long genreId, CancellationToken cancellationToken)
     {
         List<AlbumViewModel> albums = await _dataLoader.LoadAlbumsAsync(genreId);
 
-        if (albums.Count > 0)
-        {
-            Albums.AddRange(albums);
+        if (cancellationToken.IsCancellationRequested)
+            return;
 
-            List<AlbumViewModel> albumsWithArtist = albums.Where(a => !string.IsNullOrEmpty(a.Album.ArtistName)).ToList();
-            int index = Random.Shared.Next(albumsWithArtist.Count);
-            AlbumViewModel randomAlbum = albumsWithArtist[index];
+        Albums.InitWithAddRange(albums);
 
-            LoadPicture(randomAlbum.Album.ArtistName);
-            LoadBackdrop(randomAlbum.Album.ArtistName);
-        }
+        if (albums.Count == 0)
+            return;
+
+        List<AlbumViewModel> albumsWithArtist = albums.Where(a => !string.IsNullOrEmpty(a.Album.ArtistName)).ToList();
+        int index = Random.Shared.Next(albumsWithArtist.Count);
+        AlbumViewModel randomAlbum = albumsWithArtist[index];
+
+        LoadPicture(randomAlbum.Album.ArtistName);
+        LoadBackdrop(randomAlbum.Album.ArtistName, cancellationToken);
     }
 
 
@@ -202,11 +227,12 @@ public partial class GenreViewModel : ObservableObject
     }
 
 
-    public void LoadBackdrop(string artistName)
+    public void LoadBackdrop(string artistName, CancellationToken cancellationToken = default)
     {
         _backdropLoader.LoadBackdrop(artistName, (BitmapImage? backdropImage) =>
         {
-            Backdrop = backdropImage;
+            if (!cancellationToken.IsCancellationRequested)
+                Backdrop = backdropImage;
         });
     }
 

--- a/src/Rok.Infrastructure/Repositories/TrackRepository.cs
+++ b/src/Rok.Infrastructure/Repositories/TrackRepository.cs
@@ -109,7 +109,6 @@ public class TrackRepository(IDbConnection db, [FromKeyedServices("BackgroundCon
         string sql = GetSelectQuery() +
                      "WHERE tracks.albumId IN @sampledAlbumIds " +
                      DefaultGroupBy +
-                     "ORDER BY RANDOM() " +
                      "LIMIT @limit";
 
         return await ExecuteQueryAsync(sql, kind, new { sampledAlbumIds, limit });


### PR DESCRIPTION
…lbum, Artist, and Genre ViewModels

- Added CancellationToken support to LoadDataAsync, LoadAlbumsAsync, and LoadTracksAsync in AlbumViewModel, ArtistViewModel, and GenreViewModel.
- Replaced Tracks.AddRange() and Albums.AddRange() with InitWithAddRange() for atomic operations.
- Fixed potential race conditions by verifying CancellationToken after async calls.
- Updated LoadBackdrop to handle CancellationToken and prevent UI race conditions.
- Added global using for System.Threading in Presentation layer.

BREAKING CHANGE: ViewModels now require CancellationToken for async data loaders.