### PR TITLE
fix(import): stop import gracefully on application close

### DIFF
--- a/src/Presentation/App.xaml.cs
+++ b/src/Presentation/App.xaml.cs
@@ -209,6 +209,9 @@ public partial class App : Microsoft.UI.Xaml.Application
         ISettingsFile settingFileService = ServiceProvider.GetRequiredService<ISettingsFile>();
         ITelemetryClient telemetryClient = ServiceProvider.GetRequiredService<ITelemetryClient>();
 
+        IImport importService = ServiceProvider.GetRequiredService<IImport>();
+        await importService.StopAsync();
+
         await telemetryClient.CaptureEventAsync("Event", "Stop");
 
         await settingFileService.SaveAsync(options);

--- a/src/Rok.Application/Interfaces/IImport.cs
+++ b/src/Rok.Application/Interfaces/IImport.cs
@@ -5,4 +5,7 @@ public interface IImport
     bool UpdateInProgress { get; }
 
     void StartAsync(int delayInSeconds);
+
+    /// <summary>Cancels the import in progress and waits for it to complete.</summary>
+    Task StopAsync();
 }

--- a/src/Rok.Import/ImportService.cs
+++ b/src/Rok.Import/ImportService.cs
@@ -48,6 +48,7 @@ ILogger<ImportService> logger) : IImport
     private readonly PostImportDominantColorTask _postImportDominantColorTask = Guard.Against.Null(postImportDominantColorTask);
 
     private CancellationTokenSource? _cancellationToken;
+    private Task _runningTask = Task.CompletedTask;
 
     public void StartAsync(int delayInSeconds)
     {
@@ -70,7 +71,28 @@ ILogger<ImportService> logger) : IImport
         _progressService.ReportRunning();
         var stopwatch = Stopwatch.StartNew();
 
-        _ = RunImportAsync(delayInSeconds, stopwatch);
+        _runningTask = RunImportAsync(delayInSeconds, stopwatch);
+    }
+
+    public async Task StopAsync()
+    {
+        if (_cancellationToken is null || !UpdateInProgress)
+            return;
+
+        await _cancellationToken.CancelAsync();
+
+        try
+        {
+            await _runningTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected.
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Import did not stop within the expected timeout.");
+        }
     }
 
     private async Task RunImportAsync(int delayInSeconds, Stopwatch stopwatch)
@@ -114,8 +136,7 @@ ILogger<ImportService> logger) : IImport
 
         List<string> pathsToImport = await GetLibraryImportPathsAsync(cancellationToken);
 
-        foreach (string path in pathsToImport
-)
+        foreach (string path in pathsToImport)
         {
             if (cancellationToken.IsCancellationRequested)
                 break;
@@ -126,10 +147,19 @@ ILogger<ImportService> logger) : IImport
             }
         }
 
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
         await UpdateStatisticsAsync();
+
+        if (cancellationToken.IsCancellationRequested)
+            return;
 
         if (!errorOccurred)
             await CleanDataAsync(cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+            return;
 
         if (!errorOccurred)
             await _postImportDominantColorTask.RunAsync(cancellationToken);


### PR DESCRIPTION
Add StopAsync() to IImport interface and implement it in ImportService. The running task is now tracked so it can be awaited after cancellation. A 5-second timeout prevents the shutdown from blocking indefinitely.

Call StopAsync() in MainWindow_Closed before flushing Serilog logs, ensuring the import thread has stopped before the logger is disposed.

Fixes ObjectDisposedException on the log file sink at shutdown.