### PR TITLE
fix(player): prevent crash when album/artist query returns no tracks

### DIFF
--- a/src/Presentation/ViewModels/Albums/Services/AlbumsPlaybackService.cs
+++ b/src/Presentation/ViewModels/Albums/Services/AlbumsPlaybackService.cs
@@ -16,6 +16,12 @@ public class AlbumsPlaybackService(IMediator mediator, IPlayerService playerServ
 
         var tracks = (await mediator.SendMessageAsync(new GetTracksByAlbumListQuery { AlbumsId = albumIds.ToList() })).ToList();
 
+        if (tracks.Count == 0)
+        {
+            logger.LogWarning("No tracks found for the selected albums.");
+            return;
+        }
+
         if (albumIds.Count() > 1)
             TracksRandomizer.ArtistBalancedTrackRandomize(tracks, 0);
 

--- a/src/Presentation/ViewModels/Artists/Services/ArtistsPlaybackService.cs
+++ b/src/Presentation/ViewModels/Artists/Services/ArtistsPlaybackService.cs
@@ -16,6 +16,12 @@ public class ArtistsPlaybackService(IMediator mediator, IPlayerService playerSer
 
         List<TrackDto> tracks = (await mediator.SendMessageAsync(new GetTracksByArtistListQuery { ArtistIds = artistIds.ToList() })).ToList();
 
+        if (tracks.Count == 0)
+        {
+            logger.LogWarning("No tracks found for the selected artists.");
+            return;
+        }
+
         if (artistIds.Count() == 1)
             TracksRandomizer.Randomize(tracks);
         else

--- a/src/Rok.Application/Player/PlayerService.cs
+++ b/src/Rok.Application/Player/PlayerService.cs
@@ -336,7 +336,7 @@ public class PlayerService : IPlayerService, IDisposable
         else
             _currentIndex = Playlist.FindIndex(c => c.Id == startTrack.Id);
 
-        if (_currentIndex < 0)
+        if (_currentIndex < 0 || _currentIndex >= Playlist.Count)
             return;
 
         LoadFile(Playlist[_currentIndex]);


### PR DESCRIPTION
PlayerService.Start() guard only checked for -1 (FindIndex not found) but not for empty playlist when startTrack is null and _currentIndex=0, causing ArgumentOutOfRangeException on Playlist[0].

Added early-return guards in AlbumsPlaybackService and ArtistsPlaybackService when the track query returns an empty list.