### PR TITLE
refactor: migrate to CleanArch.DevKit.Guards and align devkit to 1.1.1

### DIFF
--- a/src/Presentation/GlobalUsings.cs
+++ b/src/Presentation/GlobalUsings.cs
@@ -14,7 +14,7 @@ global using Microsoft.UI.Xaml;
 global using Microsoft.UI.Xaml.Data;
 global using Microsoft.UI.Xaml.Media;
 global using Microsoft.UI.Xaml.Media.Imaging;
-global using MiF.Guard;
+global using CleanArch.DevKit.Guards;
 global using MiF.RelayCommand;
 global using Rok.Application;
 global using Rok.Application.Dto;

--- a/src/Presentation/MainWindow.xaml.cs
+++ b/src/Presentation/MainWindow.xaml.cs
@@ -69,13 +69,13 @@ public sealed partial class MainWindow : Window
 
     public MainWindow(NavigationService navigationService, ITelemetryClient telemetryClient, ResourceLoader resourceLoader, IAppDbContext dbContext, IAppOptions appOptions, IReviewPromptEligibilityService reviewPromptEligibilityService, IMessenger messenger)
     {
-        _navigationService = Guard.Against.Null(navigationService);
-        _telemetryClient = Guard.Against.Null(telemetryClient);
-        _resourceLoader = Guard.Against.Null(resourceLoader);
-        _dbContext = Guard.Against.Null(dbContext);
-        _appOptions = Guard.Against.Null(appOptions);
-        _reviewPromptEligibilityService = Guard.Against.Null(reviewPromptEligibilityService);
-        _messenger = Guard.Against.Null(messenger);
+        _navigationService = Guard.NotNull(navigationService);
+        _telemetryClient = Guard.NotNull(telemetryClient);
+        _resourceLoader = Guard.NotNull(resourceLoader);
+        _dbContext = Guard.NotNull(dbContext);
+        _appOptions = Guard.NotNull(appOptions);
+        _reviewPromptEligibilityService = Guard.NotNull(reviewPromptEligibilityService);
+        _messenger = Guard.NotNull(messenger);
 
         this.InitializeComponent();
 

--- a/src/Presentation/Rok.csproj
+++ b/src/Presentation/Rok.csproj
@@ -136,7 +136,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
-		<PackageReference Include="MiF.Guard" Version="1.0.0" />
+		<PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
 		<PackageReference Include="MiF.RelayCommand" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/Presentation/Services/NavigationService.cs
+++ b/src/Presentation/Services/NavigationService.cs
@@ -26,7 +26,7 @@ public class NavigationService(ITelemetryClient telemetryClient)
 
     public void NavigateToArtist(long artistId)
     {
-        Guard.Against.NegativeOrZero(artistId);
+        Guard.NotNegativeOrZero(artistId);
         _ = telemetryClient.CaptureScreenAsync("ArtistPage");
         MainFrame.Navigate(typeof(ArtistPage), new ArtistOpenArgs(artistId));
     }
@@ -39,21 +39,21 @@ public class NavigationService(ITelemetryClient telemetryClient)
 
     public void NavigateToAlbum(long albumId)
     {
-        Guard.Against.NegativeOrZero(albumId);
+        Guard.NotNegativeOrZero(albumId);
         _ = telemetryClient.CaptureScreenAsync("AlbumPage");
         MainFrame.Navigate(typeof(AlbumPage), new AlbumOpenArgs(albumId));
     }
 
     public void NavigateToGenre(long genreId)
     {
-        Guard.Against.NegativeOrZero(genreId);
+        Guard.NotNegativeOrZero(genreId);
         _ = telemetryClient.CaptureScreenAsync("GenrePage");
         MainFrame.Navigate(typeof(GenrePage), new GenreOpenArgs(genreId));
     }
 
     public void NavigateToTrack(long trackId)
     {
-        Guard.Against.NegativeOrZero(trackId);
+        Guard.NotNegativeOrZero(trackId);
         _ = telemetryClient.CaptureScreenAsync("TrackPage");
         MainFrame.Navigate(typeof(TrackPage), new TrackOpenArgs(trackId));
     }
@@ -84,7 +84,7 @@ public class NavigationService(ITelemetryClient telemetryClient)
 
     public void NavigateToSearch(SearchOpenArgs args)
     {
-        Guard.Against.Null(args);
+        Guard.NotNull(args);
         _ = telemetryClient.CaptureScreenAsync("SearchPage");
         MainFrame.Navigate(typeof(SearchPage), args);
     }

--- a/src/Presentation/ViewModels/Album/AlbumViewModel.cs
+++ b/src/Presentation/ViewModels/Album/AlbumViewModel.cs
@@ -180,27 +180,27 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
         IMessenger messenger,
         ILogger<AlbumViewModel> logger)
     {
-        _backdropLoader = Guard.Against.Null(backdropLoader);
-        _navigationService = Guard.Against.Null(navigationService);
-        _playerService = Guard.Against.Null(playerService);
-        _resourceLoader = Guard.Against.Null(resourceLoader);
-        _dataLoader = Guard.Against.Null(dataLoader);
-        _tagsProvider = Guard.Against.Null(tagsDataLoader);
-        _pictureService = Guard.Against.Null(pictureService);
-        _apiService = Guard.Against.Null(apiService);
-        _messenger = Guard.Against.Null(messenger);
-        _statisticsService = Guard.Against.Null(statisticsService);
-        _dominantColorCalculator = Guard.Against.Null(dominantColorCalculator);
-        _editService = Guard.Against.Null(editService);
-        _appOptions = Guard.Against.Null(appOptions);
-        _dialogService = Guard.Against.Null(dialogService);
-        PlaylistMenuService = Guard.Against.Null(playlistMenuService);
-        _logger = Guard.Against.Null(logger);
+        _backdropLoader = Guard.NotNull(backdropLoader);
+        _navigationService = Guard.NotNull(navigationService);
+        _playerService = Guard.NotNull(playerService);
+        _resourceLoader = Guard.NotNull(resourceLoader);
+        _dataLoader = Guard.NotNull(dataLoader);
+        _tagsProvider = Guard.NotNull(tagsDataLoader);
+        _pictureService = Guard.NotNull(pictureService);
+        _apiService = Guard.NotNull(apiService);
+        _messenger = Guard.NotNull(messenger);
+        _statisticsService = Guard.NotNull(statisticsService);
+        _dominantColorCalculator = Guard.NotNull(dominantColorCalculator);
+        _editService = Guard.NotNull(editService);
+        _appOptions = Guard.NotNull(appOptions);
+        _dialogService = Guard.NotNull(dialogService);
+        PlaylistMenuService = Guard.NotNull(playlistMenuService);
+        _logger = Guard.NotNull(logger);
     }
 
     public void SetData(AlbumDto album)
     {
-        Album = Guard.Against.Null(album);
+        Album = Guard.NotNull(album);
 
         IsNew = Album.CreatDate > DateTime.UtcNow.AddDays(-_appOptions.AlbumRecentThresholdDays);
 

--- a/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
+++ b/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
@@ -254,29 +254,29 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
         IMessenger messenger,
         ILogger<ArtistViewModel> logger)
     {
-        _backdropLoader = Guard.Against.Null(backdropLoader);
-        _navigationService = Guard.Against.Null(navigationService);
-        _playerService = Guard.Against.Null(playerService);
-        _dialogService = Guard.Against.Null(dialogService);
-        _resourceLoader = Guard.Against.Null(resourceLoader);
-        _dataLoader = Guard.Against.Null(dataLoader);
-        _tagsProvider = Guard.Against.Null(tagsDataLoader);
-        _pictureService = Guard.Against.Null(pictureService);
-        _messenger = Guard.Against.Null(messenger);
-        _apiService = Guard.Against.Null(apiService);
-        _statisticsService = Guard.Against.Null(statisticsService);
-        _dominantColorCalculator = Guard.Against.Null(dominantColorCalculator);
-        _editService = Guard.Against.Null(editService);
-        _backdropPicture = Guard.Against.Null(backdropPicture);
-        _appOptions = Guard.Against.Null(appOptions);
-        PlaylistMenuService = Guard.Against.Null(playlistMenuService);
-        _logger = Guard.Against.Null(logger);
+        _backdropLoader = Guard.NotNull(backdropLoader);
+        _navigationService = Guard.NotNull(navigationService);
+        _playerService = Guard.NotNull(playerService);
+        _dialogService = Guard.NotNull(dialogService);
+        _resourceLoader = Guard.NotNull(resourceLoader);
+        _dataLoader = Guard.NotNull(dataLoader);
+        _tagsProvider = Guard.NotNull(tagsDataLoader);
+        _pictureService = Guard.NotNull(pictureService);
+        _messenger = Guard.NotNull(messenger);
+        _apiService = Guard.NotNull(apiService);
+        _statisticsService = Guard.NotNull(statisticsService);
+        _dominantColorCalculator = Guard.NotNull(dominantColorCalculator);
+        _editService = Guard.NotNull(editService);
+        _backdropPicture = Guard.NotNull(backdropPicture);
+        _appOptions = Guard.NotNull(appOptions);
+        PlaylistMenuService = Guard.NotNull(playlistMenuService);
+        _logger = Guard.NotNull(logger);
     }
 
 
     public void SetData(ArtistDto artist)
     {
-        Artist = Guard.Against.Null(artist);
+        Artist = Guard.NotNull(artist);
         IsNew = Artist.CreatDate > DateTime.UtcNow.AddDays(-_appOptions.ArtistRecentThresholdDays);
 
         if (Artist.PictureDominantColor.HasValue)

--- a/src/Presentation/ViewModels/Listening/ListeningViewModel.cs
+++ b/src/Presentation/ViewModels/Listening/ListeningViewModel.cs
@@ -42,15 +42,15 @@ public partial class ListeningViewModel : ObservableObject, IDisposable
         ResourceLoader resourceLoader,
         ILogger<ListeningViewModel> logger)
     {
-        _playerService = Guard.Against.Null(playerService);
-        _playlistManager = Guard.Against.Null(playlistManager);
-        _playbackService = Guard.Against.Null(playbackService);
-        _playerSleepModeService = Guard.Against.Null(playerSleepModeService);
-        _stateManager = Guard.Against.Null(stateManager);
-        _navigationService = Guard.Against.Null(navigationService);
-        _messenger = Guard.Against.Null(messenger);
-        _resourceLoader = Guard.Against.Null(resourceLoader);
-        _logger = Guard.Against.Null(logger);
+        _playerService = Guard.NotNull(playerService);
+        _playlistManager = Guard.NotNull(playlistManager);
+        _playbackService = Guard.NotNull(playbackService);
+        _playerSleepModeService = Guard.NotNull(playerSleepModeService);
+        _stateManager = Guard.NotNull(stateManager);
+        _navigationService = Guard.NotNull(navigationService);
+        _messenger = Guard.NotNull(messenger);
+        _resourceLoader = Guard.NotNull(resourceLoader);
+        _logger = Guard.NotNull(logger);
 
         SubscribeToMessages();
         SubscribeToEvents();

--- a/src/Presentation/ViewModels/Player/PlayerViewModel.cs
+++ b/src/Presentation/ViewModels/Player/PlayerViewModel.cs
@@ -160,21 +160,21 @@ public partial class PlayerViewModel : ObservableObject, IDisposable
         ITelemetryClient telemetryClient,
         ILogger<PlayerViewModel> logger)
     {
-        _player = Guard.Against.Null(player);
-        _navigationService = Guard.Against.Null(navigationService);
-        _mediator = Guard.Against.Null(mediator);
-        _messenger = Guard.Against.Null(messenger);
-        _dataLoader = Guard.Against.Null(dataLoader);
-        _lyricsService = Guard.Against.Null(lyricsService);
-        _listenTracker = Guard.Against.Null(listenTracker);
-        _timerManager = Guard.Against.Null(timerManager);
-        _stateManager = Guard.Against.Null(stateManager);
-        EqualizerViewModel = Guard.Against.Null(equalizerViewModel);
-        _equalizerWindowService = Guard.Against.Null(equalizerWindowService);
-        _resourceLoader = Guard.Against.Null(resourceLoader);
-        _playerSleepModeService = Guard.Against.Null(playerSleepModeService);
-        _telemetryClient = Guard.Against.Null(telemetryClient);
-        _logger = Guard.Against.Null(logger);
+        _player = Guard.NotNull(player);
+        _navigationService = Guard.NotNull(navigationService);
+        _mediator = Guard.NotNull(mediator);
+        _messenger = Guard.NotNull(messenger);
+        _dataLoader = Guard.NotNull(dataLoader);
+        _lyricsService = Guard.NotNull(lyricsService);
+        _listenTracker = Guard.NotNull(listenTracker);
+        _timerManager = Guard.NotNull(timerManager);
+        _stateManager = Guard.NotNull(stateManager);
+        EqualizerViewModel = Guard.NotNull(equalizerViewModel);
+        _equalizerWindowService = Guard.NotNull(equalizerWindowService);
+        _resourceLoader = Guard.NotNull(resourceLoader);
+        _playerSleepModeService = Guard.NotNull(playerSleepModeService);
+        _telemetryClient = Guard.NotNull(telemetryClient);
+        _logger = Guard.NotNull(logger);
 
         _stateManager.PropertyChanged += OnStateManagerPropertyChanged;
         _playerSleepModeService.SleepTimerStateChanged += OnSleepTimerStateChanged;

--- a/src/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
+++ b/src/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
@@ -110,23 +110,23 @@ public partial class PlaylistViewModel : ObservableObject
         PlaylistExportService exportService,
         ILogger<PlaylistViewModel> logger)
     {
-        _backdropLoader = Guard.Against.Null(backdropLoader);
-        _navigationService = Guard.Against.Null(navigationService);
-        _playerService = Guard.Against.Null(playerService);
-        _resourceLoader = Guard.Against.Null(resourceLoader);
-        _dataLoader = Guard.Against.Null(dataLoader);
-        _pictureService = Guard.Against.Null(pictureService);
-        _updateService = Guard.Against.Null(updateService);
-        _generationService = Guard.Against.Null(generationService);
-        _exportService = Guard.Against.Null(exportService);
-        _logger = Guard.Against.Null(logger);
+        _backdropLoader = Guard.NotNull(backdropLoader);
+        _navigationService = Guard.NotNull(navigationService);
+        _playerService = Guard.NotNull(playerService);
+        _resourceLoader = Guard.NotNull(resourceLoader);
+        _dataLoader = Guard.NotNull(dataLoader);
+        _pictureService = Guard.NotNull(pictureService);
+        _updateService = Guard.NotNull(updateService);
+        _generationService = Guard.NotNull(generationService);
+        _exportService = Guard.NotNull(exportService);
+        _logger = Guard.NotNull(logger);
         Tracks.CollectionChanged += (_, _) => OnPropertyChanged(nameof(IsTracksEmpty));
     }
 
     public void SetData(PlaylistHeaderDto playlist)
     {
         string oldPicture = Playlist.Picture;
-        Playlist = Guard.Against.Null(playlist);
+        Playlist = Guard.NotNull(playlist);
 
         if (oldPicture != Playlist.Picture)
         {

--- a/src/Presentation/ViewModels/Playlists/PlaylistsViewModel.cs
+++ b/src/Presentation/ViewModels/Playlists/PlaylistsViewModel.cs
@@ -43,14 +43,14 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
         IMessenger messenger,
         ILogger<PlaylistsViewModel> logger)
     {
-        _dataLoader = Guard.Against.Null(dataLoader);
-        _creationService = Guard.Against.Null(creationService);
-        _importService = Guard.Against.Null(importService);
-        _updateHandler = Guard.Against.Null(updateHandler);
-        _importedHandler = Guard.Against.Null(importedHandler);
-        _appOptions = Guard.Against.Null(appOptions);
-        _messenger = Guard.Against.Null(messenger);
-        _logger = Guard.Against.Null(logger);
+        _dataLoader = Guard.NotNull(dataLoader);
+        _creationService = Guard.NotNull(creationService);
+        _importService = Guard.NotNull(importService);
+        _updateHandler = Guard.NotNull(updateHandler);
+        _importedHandler = Guard.NotNull(importedHandler);
+        _appOptions = Guard.NotNull(appOptions);
+        _messenger = Guard.NotNull(messenger);
+        _logger = Guard.NotNull(logger);
 
         SubscribeToMessages();
         SubscribeToEvents();

--- a/src/Presentation/ViewModels/Search/SearchViewModel.cs
+++ b/src/Presentation/ViewModels/Search/SearchViewModel.cs
@@ -4,6 +4,6 @@ public class SearchViewModel
 {
     public void LoadData(SearchOpenArgs openArgs)
     {
-        Guard.Against.Null(openArgs, nameof(openArgs));
+        Guard.NotNull(openArgs, nameof(openArgs));
     }
 }

--- a/src/Presentation/ViewModels/Track/TrackViewModel.cs
+++ b/src/Presentation/ViewModels/Track/TrackViewModel.cs
@@ -182,17 +182,17 @@ public partial class TrackViewModel : ObservableObject, IDisposable, IFilterable
         IMessenger messenger,
         ILogger<TrackViewModel> logger)
     {
-        _backdropLoader = Guard.Against.Null(backdropLoader);
-        PlaylistMenuService = Guard.Against.Null(playlistMenuService);
-        _resourceLoader = Guard.Against.Null(resourceLoader);
-        _dialogService = Guard.Against.Null(dialogService);
-        _playerService = Guard.Against.Null(playerService);
-        _dataLoader = Guard.Against.Null(dataLoader);
-        _lyricsService = Guard.Against.Null(lyricsService);
-        _scoreService = Guard.Against.Null(scoreService);
-        _navigationService = Guard.Against.Null(navigationService);
-        _appOptions = Guard.Against.Null(appOptions);
-        _messenger = Guard.Against.Null(messenger);
+        _backdropLoader = Guard.NotNull(backdropLoader);
+        PlaylistMenuService = Guard.NotNull(playlistMenuService);
+        _resourceLoader = Guard.NotNull(resourceLoader);
+        _dialogService = Guard.NotNull(dialogService);
+        _playerService = Guard.NotNull(playerService);
+        _dataLoader = Guard.NotNull(dataLoader);
+        _lyricsService = Guard.NotNull(lyricsService);
+        _scoreService = Guard.NotNull(scoreService);
+        _navigationService = Guard.NotNull(navigationService);
+        _appOptions = Guard.NotNull(appOptions);
+        _messenger = Guard.NotNull(messenger);
 
         _trackScoreUpdateSubscription = _messenger.Subscribe<TrackScoreUpdateMessage>(TrackScoreUpdateMessageHandle);
     }

--- a/src/Rok.Application/Features/Playlists/PlaylistService.cs
+++ b/src/Rok.Application/Features/Playlists/PlaylistService.cs
@@ -1,15 +1,15 @@
-﻿using MiF.Guard;
+﻿using CleanArch.DevKit.Guards;
 using Rok.Application.Features.Playlists.Requests;
 
 namespace Rok.Application.Features.Playlists;
 
 public class PlaylistService(IMediator _mediator) : IPlaylistService
 {
-    private readonly IMediator _mediator = Guard.Against.Null(_mediator);
+    private readonly IMediator _mediator = Guard.NotNull(_mediator);
 
     public async Task<PlaylistTracksDto> GenerateAsync(PlaylistHeaderDto playlist)
     {
-        Guard.Against.Null(playlist);
+        Guard.NotNull(playlist);
 
         List<PlaylistGroupDto> emptyGroups = [];
         PlaylistTracksDto result = new PlaylistTracksDto();

--- a/src/Rok.Application/Options/AppOptions.cs
+++ b/src/Rok.Application/Options/AppOptions.cs
@@ -1,4 +1,4 @@
-﻿using MiF.Guard;
+﻿using CleanArch.DevKit.Guards;
 using Rok.Application.Interfaces;
 using Rok.Shared.Enums;
 
@@ -91,7 +91,7 @@ public class AppOptions : IAppOptions
 
     public void SetCachePath(string path)
     {
-        Guard.Against.NullOrEmpty(path);
+        Guard.NotNullOrEmpty(path);
 
         CachePath = path;
     }

--- a/src/Rok.Application/Player/PlayerService.cs
+++ b/src/Rok.Application/Player/PlayerService.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using MiF.Guard;
+using CleanArch.DevKit.Guards;
 using Rok.Application.Interfaces;
 using Rok.Application.Interfaces.Pictures;
 using Rok.Application.Messages;
@@ -148,15 +148,15 @@ public class PlayerService : IPlayerService, IDisposable
 
     public PlayerService(ICallDetectionService callDetectionService, IPlayerEngine player, IAppOptions appOptions, IDiscordRichPresenceService? discordService, ISystemMediaTransportControlsService? smtcService, IAlbumPicture albumPicture, TimeProvider timeProvider, IMessenger messenger, ILogger<PlayerService> logger)
     {
-        _callDetectionService = Guard.Against.Null(callDetectionService, nameof(callDetectionService));
-        _player = Guard.Against.Null(player, nameof(player));
-        _appOptions = Guard.Against.Null(appOptions, nameof(appOptions));
+        _callDetectionService = Guard.NotNull(callDetectionService, nameof(callDetectionService));
+        _player = Guard.NotNull(player, nameof(player));
+        _appOptions = Guard.NotNull(appOptions, nameof(appOptions));
         _discordService = discordService;
         _smtcService = smtcService;
-        _albumPicture = Guard.Against.Null(albumPicture, nameof(albumPicture));
-        _timeProvider = Guard.Against.Null(timeProvider, nameof(timeProvider));
-        _messenger = Guard.Against.Null(messenger, nameof(messenger));
-        _logger = Guard.Against.Null(logger, nameof(logger));
+        _albumPicture = Guard.NotNull(albumPicture, nameof(albumPicture));
+        _timeProvider = Guard.NotNull(timeProvider, nameof(timeProvider));
+        _messenger = Guard.NotNull(messenger, nameof(messenger));
+        _logger = Guard.NotNull(logger, nameof(logger));
 
         _isCrossfadeEnabled = appOptions.CrossFade;
 
@@ -277,7 +277,7 @@ public class PlayerService : IPlayerService, IDisposable
 
     public void LoadPlaylist(List<TrackDto> tracks, TrackDto? startTrack = null)
     {
-        Guard.Against.Null(tracks);
+        Guard.NotNull(tracks);
 
         if (CurrentTrack != null)
             _messenger.Send(new MediaEvent(EPlaybackState.Ended, CurrentTrack));
@@ -300,7 +300,7 @@ public class PlayerService : IPlayerService, IDisposable
 
     public void AddTracksToPlaylist(List<TrackDto> tracks)
     {
-        Guard.Against.Null(tracks);
+        Guard.NotNull(tracks);
 
         bool hasTracks = Playlist.Count > 0;
 
@@ -314,7 +314,7 @@ public class PlayerService : IPlayerService, IDisposable
 
     public void InsertTracksToPlaylist(List<TrackDto> tracks, int? index = null)
     {
-        Guard.Against.Null(tracks);
+        Guard.NotNull(tracks);
 
         if (tracks.Count == 0)
             return;

--- a/src/Rok.Application/Rok.Application.csproj
+++ b/src/Rok.Application/Rok.Application.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CleanArch.DevKit.Mediator" Version="1.0.0" />
-    <PackageReference Include="CleanArch.DevKit.Mediator.Behaviors" Version="1.0.0" />
-    <PackageReference Include="CleanArch.DevKit.Mediator.Results" Version="1.0.0" />
-    <PackageReference Include="CleanArch.DevKit.Mediator.Validation" Version="1.0.0" />
+    <PackageReference Include="CleanArch.DevKit.Mediator" Version="1.1.1" />
+    <PackageReference Include="CleanArch.DevKit.Mediator.Behaviors" Version="1.1.1" />
+    <PackageReference Include="CleanArch.DevKit.Mediator.Results" Version="1.1.1" />
+    <PackageReference Include="CleanArch.DevKit.Mediator.Validation" Version="1.1.1" />
     <PackageReference Include="Dapper" Version="2.1.72" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="CleanArch.DevKit.Messaging" Version="1.0.0" />
-    <PackageReference Include="MiF.Guard" Version="1.0.0" />
+    <PackageReference Include="CleanArch.DevKit.Messaging" Version="1.1.1" />
+    <PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rok.Domain/Rok.Domain.csproj
+++ b/src/Rok.Domain/Rok.Domain.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
-    <PackageReference Include="MiF.Guard" Version="1.0.0" />
+    <PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rok.Import/ImportService.cs
+++ b/src/Rok.Import/ImportService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using Microsoft.Extensions.Logging;
-using MiF.Guard;
+using CleanArch.DevKit.Guards;
 using Rok.Application.Dto;
 using Rok.Application.Interfaces;
 using Rok.Import.Services;
@@ -30,29 +30,29 @@ ILogger<ImportService> logger) : IImport
     public bool UpdateInProgress { get; private set; }
     public ImportStatisticsDto Statistics { get; private set; } = new();
 
-    private readonly IFolderResolver _folderResolver = Guard.Against.Null(folderResolver);
-    private readonly ILogger<ImportService> _logger = Guard.Against.Null(logger);
-    private readonly IAppOptions _options = Guard.Against.Null(options);
-    private readonly ICleanLibrary _cleanLibraryService = Guard.Against.Null(cleanLibraryService);
-    private readonly Statistics _statistics = Guard.Against.Null(statistics);
-    private readonly TrackImport _importTrack = Guard.Against.Null(importTrack);
-    private readonly AlbumImport _importAlbum = Guard.Against.Null(importAlbum);
-    private readonly ArtistImport _importArtist = Guard.Against.Null(importArtist);
-    private readonly GenreImport _importGenre = Guard.Against.Null(importGenre);
-    private readonly ImportProgressService _progressService = Guard.Against.Null(progressService);
-    private readonly ImportTrackingService _trackingService = Guard.Against.Null(trackingService);
-    private readonly FileSystemService _fileSystemService = Guard.Against.Null(fileSystemService);
-    private readonly FolderImportProcessor _folderProcessor = Guard.Against.Null(folderProcessor);
-    private readonly ImportMessageThrottler _messageThrottler = Guard.Against.Null(messageThrottler);
-    private readonly PostImportDominantColorTask _postImportDominantColorTask = Guard.Against.Null(postImportDominantColorTask);
-    private readonly PostImportApiEnrichmentTask _postImportApiEnrichmentTask = Guard.Against.Null(postImportApiEnrichmentTask);
+    private readonly IFolderResolver _folderResolver = Guard.NotNull(folderResolver);
+    private readonly ILogger<ImportService> _logger = Guard.NotNull(logger);
+    private readonly IAppOptions _options = Guard.NotNull(options);
+    private readonly ICleanLibrary _cleanLibraryService = Guard.NotNull(cleanLibraryService);
+    private readonly Statistics _statistics = Guard.NotNull(statistics);
+    private readonly TrackImport _importTrack = Guard.NotNull(importTrack);
+    private readonly AlbumImport _importAlbum = Guard.NotNull(importAlbum);
+    private readonly ArtistImport _importArtist = Guard.NotNull(importArtist);
+    private readonly GenreImport _importGenre = Guard.NotNull(importGenre);
+    private readonly ImportProgressService _progressService = Guard.NotNull(progressService);
+    private readonly ImportTrackingService _trackingService = Guard.NotNull(trackingService);
+    private readonly FileSystemService _fileSystemService = Guard.NotNull(fileSystemService);
+    private readonly FolderImportProcessor _folderProcessor = Guard.NotNull(folderProcessor);
+    private readonly ImportMessageThrottler _messageThrottler = Guard.NotNull(messageThrottler);
+    private readonly PostImportDominantColorTask _postImportDominantColorTask = Guard.NotNull(postImportDominantColorTask);
+    private readonly PostImportApiEnrichmentTask _postImportApiEnrichmentTask = Guard.NotNull(postImportApiEnrichmentTask);
 
     private CancellationTokenSource? _cts;
     private Task _runningTask = Task.CompletedTask;
 
     public void Start(int delayInSeconds)
     {
-        Guard.Against.Negative(delayInSeconds);
+        Guard.NotNegative(delayInSeconds);
 
         if (_options.LibraryTokens is null)
         {

--- a/src/Rok.Import/Services/FolderImportProcessor.cs
+++ b/src/Rok.Import/Services/FolderImportProcessor.cs
@@ -1,6 +1,6 @@
 using CleanArch.DevKit.Messaging;
 using Microsoft.Extensions.Logging;
-using MiF.Guard;
+using CleanArch.DevKit.Guards;
 using Rok.Application.Dto;
 using Rok.Application.Interfaces;
 using Rok.Application.Messages;
@@ -25,18 +25,18 @@ public class FolderImportProcessor(
     IMessenger messenger,
     ILogger<FolderImportProcessor> logger)
 {
-    private readonly IAppOptions _options = Guard.Against.Null(options);
-    private readonly TrackImport _importTrack = Guard.Against.Null(importTrack);
-    private readonly ArtistImport _importArtist = Guard.Against.Null(importArtist);
-    private readonly AlbumImport _importAlbum = Guard.Against.Null(importAlbum);
-    private readonly GenreImport _importGenre = Guard.Against.Null(importGenre);
-    private readonly FileSystemService _fileSystemService = Guard.Against.Null(fileSystemService);
-    private readonly TrackFileProcessor _trackFileProcessor = Guard.Against.Null(trackFileProcessor);
-    private readonly TrackMetadataService _metadataService = Guard.Against.Null(metadataService);
-    private readonly ImportTrackingService _trackingService = Guard.Against.Null(trackingService);
-    private readonly ITagService _tagService = Guard.Against.Null(tagService);
-    private readonly ImportMessageThrottler _messageThrottler = Guard.Against.Null(messageThrottler);
-    private readonly ILogger<FolderImportProcessor> _logger = Guard.Against.Null(logger);
+    private readonly IAppOptions _options = Guard.NotNull(options);
+    private readonly TrackImport _importTrack = Guard.NotNull(importTrack);
+    private readonly ArtistImport _importArtist = Guard.NotNull(importArtist);
+    private readonly AlbumImport _importAlbum = Guard.NotNull(importAlbum);
+    private readonly GenreImport _importGenre = Guard.NotNull(importGenre);
+    private readonly FileSystemService _fileSystemService = Guard.NotNull(fileSystemService);
+    private readonly TrackFileProcessor _trackFileProcessor = Guard.NotNull(trackFileProcessor);
+    private readonly TrackMetadataService _metadataService = Guard.NotNull(metadataService);
+    private readonly ImportTrackingService _trackingService = Guard.NotNull(trackingService);
+    private readonly ITagService _tagService = Guard.NotNull(tagService);
+    private readonly ImportMessageThrottler _messageThrottler = Guard.NotNull(messageThrottler);
+    private readonly ILogger<FolderImportProcessor> _logger = Guard.NotNull(logger);
 
     public async Task ImportFolderAsync(
         string musicFolder,

--- a/src/Rok.Import/TrackImport.cs
+++ b/src/Rok.Import/TrackImport.cs
@@ -1,4 +1,4 @@
-﻿using MiF.Guard;
+﻿using CleanArch.DevKit.Guards;
 using Rok.Application.Interfaces;
 using Rok.Application.Interfaces.Repositories;
 using Rok.Domain.Entities;
@@ -63,7 +63,7 @@ public class TrackImport(ITrackRepository _trackRepository)
 
     public Task UpdateTrackFileDateAsync(long trackId, DateTime fileDate)
     {
-        Guard.Against.NegativeOrZero(trackId);
+        Guard.NotNegativeOrZero(trackId);
 
         return _trackRepository.UpdateFileDateAsync(trackId, fileDate, RepositoryConnectionKind.Background);
     }

--- a/src/Rok.Infrastructure/AppDbContext.cs
+++ b/src/Rok.Infrastructure/AppDbContext.cs
@@ -4,11 +4,11 @@ namespace Rok.Infrastructure;
 
 public class AppDbContext(IDbConnection connection, [FromKeyedServices("BackgroundConnection")] IDbConnection backgroundDb, IMigrationService migrationService) : IAppDbContext, IDisposable
 {
-    public IDbConnection Connection { get; init; } = Guard.Against.Null(connection);
+    public IDbConnection Connection { get; init; } = Guard.NotNull(connection);
 
-    public IDbConnection BackgroundConnection { get; init; } = Guard.Against.Null(backgroundDb);
+    public IDbConnection BackgroundConnection { get; init; } = Guard.NotNull(backgroundDb);
 
-    private readonly IMigrationService _migrationService = Guard.Against.Null(migrationService);
+    private readonly IMigrationService _migrationService = Guard.NotNull(migrationService);
     private bool disposedValue;
 
     public bool IsFirstStart { get; private set; }

--- a/src/Rok.Infrastructure/Files/AlbumPicture.cs
+++ b/src/Rok.Infrastructure/Files/AlbumPicture.cs
@@ -11,14 +11,14 @@ public class AlbumPicture(IFileSystem _fileSystem) : IAlbumPicture
 
     public bool PictureFileExists(string albumPath)
     {
-        Guard.Against.NullOrEmpty(albumPath);
+        Guard.NotNullOrEmpty(albumPath);
 
         return _fileSystem.FileExists(GetPictureFile(albumPath));
     }
 
     public string GetPictureFile(string albumPath)
     {
-        Guard.Against.NullOrEmpty(albumPath);
+        Guard.NotNullOrEmpty(albumPath);
 
         for (int i = 0; i < _files.Length; i++)
         {

--- a/src/Rok.Infrastructure/Files/ArtistPicture.cs
+++ b/src/Rok.Infrastructure/Files/ArtistPicture.cs
@@ -23,7 +23,7 @@ public class ArtistPicture : IArtistPicture
 
     public void SetRepositoryArtistPath(string path)
     {
-        Guard.Against.NullOrEmpty(path);
+        Guard.NotNullOrEmpty(path);
 
         RepositoryArtistPath = Path.Combine(path, KArtistFolderName);
 
@@ -33,7 +33,7 @@ public class ArtistPicture : IArtistPicture
 
     public string GetArtistFolder(string artistName)
     {
-        Guard.Against.NullOrEmpty(artistName);
+        Guard.NotNullOrEmpty(artistName);
 
         return Path.Combine(RepositoryArtistPath, artistName.ToFileName());
     }
@@ -41,7 +41,7 @@ public class ArtistPicture : IArtistPicture
 
     public string GetPictureFile(string artistName)
     {
-        Guard.Against.NullOrEmpty(artistName);
+        Guard.NotNullOrEmpty(artistName);
 
         return Path.Combine(RepositoryArtistPath, artistName.ToFileName(), KArtistFileName);
     }
@@ -49,7 +49,7 @@ public class ArtistPicture : IArtistPicture
 
     public bool PictureFileExists(string artistName)
     {
-        Guard.Against.NullOrEmpty(artistName);
+        Guard.NotNullOrEmpty(artistName);
 
         return _fileSystem.FileExists(GetPictureFile(artistName));
     }

--- a/src/Rok.Infrastructure/Files/BackdropPicture.cs
+++ b/src/Rok.Infrastructure/Files/BackdropPicture.cs
@@ -21,7 +21,7 @@ public class BackdropPicture : IBackdropPicture
 
     public void SetRepositoryArtistPath(string path)
     {
-        Guard.Against.NullOrEmpty(path);
+        Guard.NotNullOrEmpty(path);
 
         RepositoryArtistPath = Path.Combine(path, KArtistFolderName);
 
@@ -30,7 +30,7 @@ public class BackdropPicture : IBackdropPicture
 
     public string GetArtistPictureFolder(string artistName)
     {
-        Guard.Against.NullOrEmpty(artistName);
+        Guard.NotNullOrEmpty(artistName);
 
         return Path.Combine(RepositoryArtistPath, artistName.ToFileName());
     }
@@ -38,7 +38,7 @@ public class BackdropPicture : IBackdropPicture
 
     public List<string> GetBackdrops(string artistName)
     {
-        Guard.Against.NullOrEmpty(artistName);
+        Guard.NotNullOrEmpty(artistName);
 
         string picturePath = GetArtistPictureFolder(artistName);
 
@@ -75,7 +75,7 @@ public class BackdropPicture : IBackdropPicture
 
     public bool HasBackdrops(string artistName)
     {
-        Guard.Against.NullOrEmpty(artistName, nameof(artistName));
+        Guard.NotNullOrEmpty(artistName, nameof(artistName));
 
         string picturePath = GetArtistPictureFolder(artistName);
 

--- a/src/Rok.Infrastructure/Files/SettingsFileService.cs
+++ b/src/Rok.Infrastructure/Files/SettingsFileService.cs
@@ -38,7 +38,7 @@ public class SettingsFileService(string applicationPath, IFolderResolver folderR
 
     public Task SaveAsync(IAppOptions options)
     {
-        Guard.Against.Null(options, nameof(options));
+        Guard.NotNull(options, nameof(options));
 
         string jsonString = JsonSerializer.Serialize(options, _jsonOptions);
 
@@ -47,7 +47,7 @@ public class SettingsFileService(string applicationPath, IFolderResolver folderR
 
     public async Task RemoveInvalidLibraryTokensAsync(IAppOptions options)
     {
-        Guard.Against.Null(options, nameof(options));
+        Guard.NotNull(options, nameof(options));
 
         if (options.LibraryTokens is null || options.LibraryTokens.Count == 0)
             return;

--- a/src/Rok.Infrastructure/GlobalUsings.cs
+++ b/src/Rok.Infrastructure/GlobalUsings.cs
@@ -1,4 +1,4 @@
 ﻿global using System.Data;
 global using Dapper;
-global using MiF.Guard;
+global using CleanArch.DevKit.Guards;
 global using Rok.Domain.Entities;

--- a/src/Rok.Infrastructure/Lyrics/LyricsParser.cs
+++ b/src/Rok.Infrastructure/Lyrics/LyricsParser.cs
@@ -15,7 +15,7 @@ public partial class LyricsParser : ILyricsParser
 
     public SyncLyricsModel Parse(string lyrics)
     {
-        Guard.Against.NullOrEmpty(lyrics);
+        Guard.NotNullOrEmpty(lyrics);
 
         SyncLyricsModel result = new();
         SortedDictionary<TimeSpan, string> sortedLyrics = new();

--- a/src/Rok.Infrastructure/Lyrics/LyricsService.cs
+++ b/src/Rok.Infrastructure/Lyrics/LyricsService.cs
@@ -13,7 +13,7 @@ public partial class LyricsService(IFileSystem fileSystem) : ILyricsService
 
     public string GetSynchronizedLyricsFileName(string musicFile)
     {
-        Guard.Against.NullOrEmpty(musicFile);
+        Guard.NotNullOrEmpty(musicFile);
 
         string? folder = fileSystem.GetDirectoryName(musicFile);
         string fileNameWithoutExtension = fileSystem.GetFileNameWithoutExtension(musicFile);
@@ -23,7 +23,7 @@ public partial class LyricsService(IFileSystem fileSystem) : ILyricsService
 
     public string GetPlainLyricsFileName(string musicFile)
     {
-        Guard.Against.NullOrEmpty(musicFile);
+        Guard.NotNullOrEmpty(musicFile);
 
         string? folder = fileSystem.GetDirectoryName(musicFile);
         string fileNameWithoutExtension = fileSystem.GetFileNameWithoutExtension(musicFile);
@@ -33,7 +33,7 @@ public partial class LyricsService(IFileSystem fileSystem) : ILyricsService
 
     public ELyricsType CheckLyricsFileExists(string musicFile)
     {
-        Guard.Against.NullOrEmpty(musicFile);
+        Guard.NotNullOrEmpty(musicFile);
 
         string? folder = fileSystem.GetDirectoryName(musicFile);
         string fileNameWithoutExtension = fileSystem.GetFileNameWithoutExtension(musicFile);
@@ -51,7 +51,7 @@ public partial class LyricsService(IFileSystem fileSystem) : ILyricsService
 
     public async Task<LyricsModel?> LoadLyricsAsync(string musicFile)
     {
-        Guard.Against.NullOrEmpty(musicFile);
+        Guard.NotNullOrEmpty(musicFile);
 
         string? folder = fileSystem.GetDirectoryName(musicFile);
 
@@ -90,7 +90,7 @@ public partial class LyricsService(IFileSystem fileSystem) : ILyricsService
 
     public Task SaveLyricsAsync(LyricsModel lyrics)
     {
-        Guard.Against.Null(lyrics);
+        Guard.NotNull(lyrics);
 
         return fileSystem.WriteAllTextAsync(lyrics.File, lyrics.PlainLyrics);
     }

--- a/src/Rok.Infrastructure/Migration/MigrationService.cs
+++ b/src/Rok.Infrastructure/Migration/MigrationService.cs
@@ -8,7 +8,7 @@ public class MigrationService(IDbConnection database, IEnumerable<IMigration>? m
     private readonly List<IMigration> _migrations = (migrations ?? Enumerable.Empty<IMigration>())
                                                     .OrderBy(m => m.TargetVersion).ToList();
 
-    private readonly IDbConnection _database = Guard.Against.Null(database);
+    private readonly IDbConnection _database = Guard.NotNull(database);
 
     public void Initial()
     {

--- a/src/Rok.Infrastructure/Migration/SqlBuilder.cs
+++ b/src/Rok.Infrastructure/Migration/SqlBuilder.cs
@@ -19,7 +19,7 @@ public class SqlBuilder
 
     public SqlBuilder CreateTable(string tableName)
     {
-        Guard.Against.NullOrEmpty(tableName);
+        Guard.NotNullOrEmpty(tableName);
 
         _currentTableName = tableName;
         _currentColumnName = "";
@@ -35,7 +35,7 @@ public class SqlBuilder
 
     public SqlBuilder WithIdColumn(string columnName)
     {
-        Guard.Against.NullOrEmpty(columnName);
+        Guard.NotNullOrEmpty(columnName);
 
         _sql.Append($"{columnName} INTEGER NOT NULL CONSTRAINT PK_{_currentTableName} PRIMARY KEY AUTOINCREMENT ");
 
@@ -47,7 +47,7 @@ public class SqlBuilder
 
     public SqlBuilder WithColumn(string columnName)
     {
-        Guard.Against.NullOrEmpty(columnName);
+        Guard.NotNullOrEmpty(columnName);
 
         _sql.Append($", {columnName} ");
 

--- a/src/Rok.Infrastructure/Rok.Infrastructure.csproj
+++ b/src/Rok.Infrastructure/Rok.Infrastructure.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
-		<PackageReference Include="MiF.Guard" Version="1.0.0" />
+		<PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
 		<PackageReference Include="NAudio" Version="2.3.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />

--- a/src/Rok.Shared/PerfLogger.cs
+++ b/src/Rok.Shared/PerfLogger.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
-using MiF.Guard;
+using CleanArch.DevKit.Guards;
 
 namespace Rok.Shared;
 
@@ -15,7 +15,7 @@ public class PerfLogger : IDisposable
 
     public PerfLogger(ILogger logger, [CallerMemberName] string caller = "")
     {
-        _logger = Guard.Against.Null(logger);
+        _logger = Guard.NotNull(logger);
         _caller = caller;
         _timer.Start();
     }

--- a/src/Rok.Shared/Rok.Shared.csproj
+++ b/src/Rok.Shared/Rok.Shared.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="MiF.Guard" Version="1.0.0" />
+    <PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
   </ItemGroup>
 
 

--- a/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
+++ b/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CleanArch.DevKit.Mediator.Results.Testing" Version="1.0.0" />
-		<PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.0.0" />
+		<PackageReference Include="CleanArch.DevKit.Mediator.Results.Testing" Version="1.1.1" />
+		<PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.1.1" />
 		<PackageReference Include="coverlet.collector" Version="10.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/UnitTests/Rok.ImportTests/Rok.ImportTests.csproj
+++ b/tests/UnitTests/Rok.ImportTests/Rok.ImportTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.0.0" />
+    <PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.1.1" />
     <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/UnitTests/Rok.ImportTests/TrackImportTests.cs
+++ b/tests/UnitTests/Rok.ImportTests/TrackImportTests.cs
@@ -91,6 +91,6 @@ public class TrackImportTests
         TrackImport import = new(Mock.Of<ITrackRepository>());
 
         // Act & Assert
-        return Assert.ThrowsAsync<ArgumentException>(() => import.UpdateTrackFileDateAsync(0, DateTime.UtcNow));
+        return Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => import.UpdateTrackFileDateAsync(0, DateTime.UtcNow));
     }
 }

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Files/ArtistPictureTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Files/ArtistPictureTests.cs
@@ -68,7 +68,7 @@ public class ArtistPictureTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.SetRepositoryArtistPath(""));
-        Assert.Throws<ArgumentNullException>(() => sut.SetRepositoryArtistPath(null!));
+        Assert.Throws<ArgumentException>(() => sut.SetRepositoryArtistPath(null!));
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class ArtistPictureTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.GetArtistFolder(""));
-        Assert.Throws<ArgumentNullException>(() => sut.GetArtistFolder(null!));
+        Assert.Throws<ArgumentException>(() => sut.GetArtistFolder(null!));
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class ArtistPictureTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.GetPictureFile(""));
-        Assert.Throws<ArgumentNullException>(() => sut.GetPictureFile(null!));
+        Assert.Throws<ArgumentException>(() => sut.GetPictureFile(null!));
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public class ArtistPictureTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.PictureFileExists(""));
-        Assert.Throws<ArgumentNullException>(() => sut.PictureFileExists(null!));
+        Assert.Throws<ArgumentException>(() => sut.PictureFileExists(null!));
     }
 
     [Fact]

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Files/BackdropPictureTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Files/BackdropPictureTests.cs
@@ -57,7 +57,7 @@ public class BackdropPictureTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.SetRepositoryArtistPath(""));
-        Assert.Throws<ArgumentNullException>(() => sut.SetRepositoryArtistPath(null!));
+        Assert.Throws<ArgumentException>(() => sut.SetRepositoryArtistPath(null!));
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class BackdropPictureTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.GetArtistPictureFolder(""));
-        Assert.Throws<ArgumentNullException>(() => sut.GetArtistPictureFolder(null!));
+        Assert.Throws<ArgumentException>(() => sut.GetArtistPictureFolder(null!));
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class BackdropPictureTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.GetBackdrops(""));
-        Assert.Throws<ArgumentNullException>(() => sut.GetBackdrops(null!));
+        Assert.Throws<ArgumentException>(() => sut.GetBackdrops(null!));
     }
 
     [Fact]
@@ -148,7 +148,7 @@ public class BackdropPictureTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.HasBackdrops(""));
-        Assert.Throws<ArgumentNullException>(() => sut.HasBackdrops(null!));
+        Assert.Throws<ArgumentException>(() => sut.HasBackdrops(null!));
     }
 
     [Fact]

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Lyrics/LyricsParserTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Lyrics/LyricsParserTests.cs
@@ -13,7 +13,7 @@ public class LyricsParserTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.Parse(""));
-        Assert.Throws<ArgumentNullException>(() => sut.Parse(null!));
+        Assert.Throws<ArgumentException>(() => sut.Parse(null!));
     }
 
     [Fact]

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Lyrics/LyricsServiceTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Lyrics/LyricsServiceTests.cs
@@ -43,7 +43,7 @@ public class LyricsServiceTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.GetSynchronizedLyricsFileName(""));
-        Assert.Throws<ArgumentNullException>(() => sut.GetSynchronizedLyricsFileName(null!));
+        Assert.Throws<ArgumentException>(() => sut.GetSynchronizedLyricsFileName(null!));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class LyricsServiceTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.GetPlainLyricsFileName(""));
-        Assert.Throws<ArgumentNullException>(() => sut.GetPlainLyricsFileName(null!));
+        Assert.Throws<ArgumentException>(() => sut.GetPlainLyricsFileName(null!));
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class LyricsServiceTests
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => sut.CheckLyricsFileExists(""));
-        Assert.Throws<ArgumentNullException>(() => sut.CheckLyricsFileExists(null!));
+        Assert.Throws<ArgumentException>(() => sut.CheckLyricsFileExists(null!));
     }
 
     [Fact]
@@ -277,7 +277,7 @@ public class LyricsServiceTests
 
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(() => sut.LoadLyricsAsync(""));
-        await Assert.ThrowsAsync<ArgumentNullException>(() => sut.LoadLyricsAsync(null!));
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.LoadLyricsAsync(null!));
     }
 
     [Fact]

--- a/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
+++ b/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.0.0" />
+		<PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.1.1" />
 		<PackageReference Include="coverlet.collector" Version="10.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Replace MiF.Guard 1.0.0 with CleanArch.DevKit.Guards 1.1.1 across the solution and bump all other CleanArch.DevKit.* packages from 1.0.0 to 1.1.1 for version consistency.

API migration (28 .cs files, 186 call sites):
- using MiF.Guard           -> using CleanArch.DevKit.Guards
- Guard.Against.Null        -> Guard.NotNull
- Guard.Against.NullOrEmpty -> Guard.NotNullOrEmpty
- Guard.Against.Negative    -> Guard.NotNegative
- Guard.Against.NegativeOrZero -> Guard.NotNegativeOrZero

Test adaptations for the new exception contract (5 test files):
- NotNullOrEmpty(null) now throws ArgumentException (was ArgumentNullException with MiF.Guard) -> 11 assertions updated across LyricsService, LyricsParser, BackdropPicture, ArtistPicture tests.
- NotNegativeOrZero(0) now throws ArgumentOutOfRangeException (was ArgumentException) -> 1 assertion updated in TrackImportTests.

Package bumps (9 references):
- Mediator, Mediator.Behaviors, Mediator.Results, Mediator.Validation, Messaging, Mediator.Testing (x3), Mediator.Results.Testing: 1.0.0 -> 1.1.1
- Guards: new package at 1.1.1

Build x64 green, 1282 tests passing (App 518, Pres 319, Infra 347, Import 98).