### PR TITLE
fix(import): normalize artist/album/genre names to avoid unicode-hyph…

### DIFF
--- a/src/Rok.Import/AlbumImport.cs
+++ b/src/Rok.Import/AlbumImport.cs
@@ -138,9 +138,11 @@ public class AlbumImport(IAlbumRepository _albumRepository, TimeProvider _timePr
 
     private static string GetKey(string albumName, bool isCompilation, long? artistId)
     {
+        string normalized = albumName.NormalizeIndexedName();
+
         if (isCompilation || !artistId.HasValue)
-            return albumName;
+            return normalized;
         else
-            return $"{artistId}___{albumName}";
+            return $"{artistId}___{normalized}";
     }
 }

--- a/src/Rok.Import/ArtistImport.cs
+++ b/src/Rok.Import/ArtistImport.cs
@@ -117,6 +117,6 @@ public class ArtistImport(IArtistRepository _artistRepository, TimeProvider _tim
 
     private static string GetKey(string artistName)
     {
-        return artistName.ToUpperInvariant();
+        return artistName.NormalizeIndexedName().ToUpperInvariant();
     }
 }

--- a/src/Rok.Import/GenreImport.cs
+++ b/src/Rok.Import/GenreImport.cs
@@ -77,6 +77,6 @@ public class GenreImport(IGenreRepository _genreRepository, TimeProvider _timePr
 
     private static string GetKey(string genreName)
     {
-        return genreName.ToUpperInvariant();
+        return genreName.NormalizeIndexedName().ToUpperInvariant();
     }
 }

--- a/src/Rok.Infrastructure/Tag/TagService.cs
+++ b/src/Rok.Infrastructure/Tag/TagService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rok.Application.Tag;
+using Rok.Shared.Extensions;
 
 namespace Rok.Infrastructure.Tag;
 
@@ -30,9 +31,9 @@ public class TagService(ILogger<TagService> logger) : ITagService
             using TagLib.File tag = TagLib.File.Create(file);
 
             track.Title = tag.Tag.Title?.Trim() ?? "";
-            track.Artist = tag.Tag.FirstAlbumArtist?.Trim() ?? tag.Tag.FirstPerformer?.Trim() ?? "";
-            track.Album = tag.Tag.Album?.Trim() ?? "";
-            track.Genre = tag.Tag.FirstGenre?.Trim() ?? "";
+            track.Artist = (tag.Tag.FirstAlbumArtist?.Trim() ?? tag.Tag.FirstPerformer?.Trim() ?? "").NormalizeIndexedName();
+            track.Album = (tag.Tag.Album?.Trim() ?? "").NormalizeIndexedName();
+            track.Genre = (tag.Tag.FirstGenre?.Trim() ?? "").NormalizeIndexedName();
             track.Year = tag.Tag.Year > 0 ? (int)tag.Tag.Year : null;
             track.TrackNumber = (int)tag.Tag.Track;
             track.Duration = tag.Properties.Duration;

--- a/src/Rok.Shared/Extensions/StringExtensions.cs
+++ b/src/Rok.Shared/Extensions/StringExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace Rok.Shared.Extensions;
+﻿using System.Globalization;
+using System.Text;
+
+namespace Rok.Shared.Extensions;
 
 public static class StringExtensions
 {
@@ -62,4 +65,39 @@ public static class StringExtensions
     /// <returns><see langword="true"/> if the strings are different; otherwise, <see langword="false"/>.</returns>
     public static bool AreDifferent(this string? a, string? b) => (a ?? "") != (b ?? "");
 
+    /// <summary>
+    /// Normalizes a name used as a case-insensitive index or lookup key.
+    /// Trims surrounding whitespace, applies Unicode NFC composition, folds the
+    /// common dash and hyphen variants (U+2010 to U+2015, U+2212, U+FE58, U+FE63, U+FF0D)
+    /// to ASCII '-' (U+002D), and folds non-breaking and zero-width spaces
+    /// (U+00A0, U+202F, U+2007, U+200B) to a regular space.
+    /// Returns the input unchanged if null or empty.
+    /// </summary>
+    public static string NormalizeIndexedName(this string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        string trimmed = value.Trim();
+
+        if (trimmed.Length == 0)
+            return trimmed;
+
+        string normalized = trimmed.Normalize(NormalizationForm.FormC);
+
+        StringBuilder sb = new(normalized.Length);
+
+        foreach (char c in normalized)
+        {
+            char folded = c switch
+            {
+                '‐' or '‑' or '‒' or '–' or '—' or '―' or '−' or '﹘' or '﹣' or '－' => '-',
+                ' ' or ' ' or ' ' or '​' => ' ',
+                _ => c
+            };
+            sb.Append(folded);
+        }
+
+        return sb.ToString();
+    }
 }

--- a/tests/UnitTests/Rok.ApplicationTests/Shared/Extensions/StringExtensionsTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Shared/Extensions/StringExtensionsTests.cs
@@ -96,4 +96,72 @@ public class StringExtensionsTests
         // Assert
         Assert.Equal(expected, result);
     }
+
+    [Theory(DisplayName = "NormalizeIndexedName should fold unicode dash variants to ascii hyphen")]
+    [InlineData("Pro-pain", "Pro-pain")]
+    [InlineData("Pro‐pain", "Pro-pain")]
+    [InlineData("Pro‑pain", "Pro-pain")]
+    [InlineData("Pro‒pain", "Pro-pain")]
+    [InlineData("Pro–pain", "Pro-pain")]
+    [InlineData("Pro—pain", "Pro-pain")]
+    [InlineData("Pro―pain", "Pro-pain")]
+    [InlineData("Pro−pain", "Pro-pain")]
+    [InlineData("Pro﹘pain", "Pro-pain")]
+    [InlineData("Pro﹣pain", "Pro-pain")]
+    [InlineData("Pro－pain", "Pro-pain")]
+    public void NormalizeIndexedName_ShouldFoldUnicodeDashes_ToAsciiHyphen(string input, string expected)
+    {
+        // Act
+        string result = input.NormalizeIndexedName();
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory(DisplayName = "NormalizeIndexedName should fold non-breaking and zero-width spaces to a regular space")]
+    [InlineData("Daft Punk", "Daft Punk")]
+    [InlineData("Daft Punk", "Daft Punk")]
+    [InlineData("Daft Punk", "Daft Punk")]
+    [InlineData("Daft​Punk", "Daft Punk")]
+    public void NormalizeIndexedName_ShouldFoldNonBreakingAndZeroWidthSpaces(string input, string expected)
+    {
+        // Act
+        string result = input.NormalizeIndexedName();
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact(DisplayName = "NormalizeIndexedName should trim surrounding whitespace")]
+    public void NormalizeIndexedName_ShouldTrimSurroundingWhitespace()
+    {
+        // Act
+        string result = "  Pro-pain  ".NormalizeIndexedName();
+
+        // Assert
+        Assert.Equal("Pro-pain", result);
+    }
+
+    [Fact(DisplayName = "NormalizeIndexedName should compose decomposed unicode to NFC")]
+    public void NormalizeIndexedName_ShouldComposeDecomposedUnicode_ToNfc()
+    {
+        // Built from char escapes so the source-file encoding cannot pre-normalize the input.
+        string decomposed = "Béatrice";
+        string composed = "Béatrice";
+
+        Assert.NotEqual(composed, decomposed);
+        Assert.Equal(composed, decomposed.NormalizeIndexedName());
+    }
+
+    [Theory(DisplayName = "NormalizeIndexedName should return input unchanged when null or empty")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    public void NormalizeIndexedName_ShouldReturnInputUnchanged_WhenNullOrEmpty(string input, string expected)
+    {
+        // Act
+        string result = input.NormalizeIndexedName();
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
 }

--- a/tests/UnitTests/Rok.ImportTests/AlbumImportTests.cs
+++ b/tests/UnitTests/Rok.ImportTests/AlbumImportTests.cs
@@ -42,6 +42,27 @@ public class AlbumImportTests
         Assert.NotNull(import.GetFromCache("Now That's What I Call Music", true, null));
     }
 
+    [Fact(DisplayName = "GetFromCache should find existing album when stored name uses unicode hyphen and lookup uses ascii hyphen")]
+    public async Task GetFromCache_ShouldFindExistingAlbum_WhenStoredNameUsesUnicodeHyphen_AndLookupUsesAsciiHyphen()
+    {
+        // Arrange — non compilation, scoped by artistId
+        List<AlbumEntity> albums = new()
+        {
+            new() { Id = 77, Name = "Foul Taste of Freedom – the album", ArtistId = 42, IsCompilation = false }
+        };
+        Mock<IAlbumRepository> repository = new();
+        repository.Setup(r => r.GetAllAsync(It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(albums);
+        AlbumImport import = new(repository.Object, TimeProvider.System);
+        await import.LoadCacheAsync();
+
+        // Act — same album name but lookup uses ASCII hyphen
+        AlbumCacheItem? hit = import.GetFromCache("Foul Taste of Freedom - the album", false, 42);
+
+        // Assert
+        Assert.NotNull(hit);
+        Assert.Equal(77, hit!.Id);
+    }
+
     [Fact(DisplayName = "GetFromCache should differentiate same album name by artist when not a compilation")]
     public async Task GetFromCache_ShouldDifferentiateSameAlbumName_ByArtist_WhenNotCompilation()
     {

--- a/tests/UnitTests/Rok.ImportTests/ArtistImportTests.cs
+++ b/tests/UnitTests/Rok.ImportTests/ArtistImportTests.cs
@@ -153,6 +153,27 @@ public class ArtistImportTests
         Assert.Equal(100, import.NewlyCreatedIds.Count);
     }
 
+    [Fact(DisplayName = "GetFromCache should find existing artist when stored name uses unicode hyphen and lookup uses ascii hyphen")]
+    public async Task GetFromCache_ShouldFindExistingArtist_WhenStoredNameUsesUnicodeHyphen_AndLookupUsesAsciiHyphen()
+    {
+        // Arrange — stored "Pro<U+2010>pain", lookup with ascii hyphen
+        List<ArtistEntity> artists = new()
+        {
+            new() { Id = 42, Name = "Pro‐pain" }
+        };
+        Mock<IArtistRepository> repository = new();
+        repository.Setup(r => r.GetAllAsync(It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(artists);
+        ArtistImport import = new(repository.Object, TimeProvider.System);
+        await import.LoadCacheAsync();
+
+        // Act
+        ArtistCacheItem? hit = import.GetFromCache("Pro-pain");
+
+        // Assert
+        Assert.NotNull(hit);
+        Assert.Equal(42, hit!.Id);
+    }
+
     [Fact(DisplayName = "LoadCacheAsync should clear NewlyCreatedIds")]
     public async Task LoadCacheAsync_ShouldClearNewlyCreatedIds()
     {

--- a/tests/UnitTests/Rok.ImportTests/GenreImportTests.cs
+++ b/tests/UnitTests/Rok.ImportTests/GenreImportTests.cs
@@ -48,6 +48,24 @@ public class GenreImportTests
         Assert.Null(result);
     }
 
+    [Fact(DisplayName = "GetFromCache should find existing genre when stored name uses unicode hyphen and lookup uses ascii hyphen")]
+    public async Task GetFromCache_ShouldFindExistingGenre_WhenStoredNameUsesUnicodeHyphen_AndLookupUsesAsciiHyphen()
+    {
+        // Arrange
+        List<GenreEntity> genres = new() { new() { Id = 9, Name = "Hip‐hop" } };
+        Mock<IGenreRepository> repository = new();
+        repository.Setup(r => r.GetAllAsync(It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(genres);
+        GenreImport import = new(repository.Object, TimeProvider.System);
+        await import.LoadCacheAsync();
+
+        // Act
+        GenreCacheItem? hit = import.GetFromCache("Hip-hop");
+
+        // Assert
+        Assert.NotNull(hit);
+        Assert.Equal(9, hit!.Id);
+    }
+
     [Fact(DisplayName = "CreateAsync should persist capitalized genre name with artist count seeded at one")]
     public async Task CreateAsync_ShouldPersistCapitalizedGenreName_WithArtistCountSeededAtOne()
     {


### PR DESCRIPTION
…en duplicates

Tag values containing Unicode dash variants (U+2010, U+2013, etc.) or non-breaking spaces produced cache misses against existing DB rows whose names used ASCII hyphen-minus, leading to byte-distinct but visually identical duplicates that bypassed the SQLite UNIQUE(name) constraint.

Add NormalizeIndexedName extension (NFC + dash and space folding) and apply it at the tag-read boundary plus in the three Import cache keys for defense in depth.