### PR TITLE
fix(player): fix non-deterministic crossfade timing

### DIFF
--- a/docs/superpowers/plans/2026-05-18-crossfade-timing-fix.md
+++ b/docs/superpowers/plans/2026-05-18-crossfade-timing-fix.md
@@ -1,0 +1,189 @@
+# Crossfade Timing Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix non-deterministic crossfade timing by replacing step-based fade progress with Stopwatch-based progress, and reading a fresh engine position before computing the pre-crossfade wait.
+
+**Architecture:** Two localized changes — `NAudioMediaPlayer.CrossfadeToAsync` gets a Stopwatch loop (primary fix: eliminates fade-loop drift), and `PlayerService.RunCrossfadeAsync` reads `_player.Position` fresh (secondary fix: eliminates stale-snapshot error). No interface changes, no structural refactor. Existing tests remain valid.
+
+**Tech Stack:** .NET 10, C# 13, NAudio, xUnit, `dotnet test /p:Platform=x64`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs` | Replace step-based loop with Stopwatch loop + guard on `durationSeconds <= 0` |
+| `src/Rok.Application/Player/PlayerService.cs` | Read `_player.Position` fresh in `RunCrossfadeAsync` |
+
+No new files. No new tests (NAudioMediaPlayer requires real audio hardware; existing `PlayerServiceCrossfadeTests` already covers the application-level crossfade flow and remains valid).
+
+---
+
+## Task 1 — Fix the crossfade loop in `NAudioMediaPlayer.CrossfadeToAsync`
+
+**Files:**
+- Modify: `src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs:227-321`
+
+The current loop computes `progress = (double)i / steps` which ties fade progress to iteration count. With Windows `Task.Delay` drift (~15ms/call), 100 iterations at 50ms can take 5.0–5.7s instead of 5.0s, causing the old track to end before the fade completes.
+
+- [ ] **Step 1: Add the `durationSeconds <= 0` guard**
+
+Open `src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs`. Locate `CrossfadeToAsync` (line ~227). Add a guard as the very first statement of the method body, before anything else:
+
+```csharp
+public async Task CrossfadeToAsync(TrackDto nextTrack, double durationSeconds, double masterVolume, CancellationToken ct)
+{
+    if (durationSeconds <= 0)
+        return;
+
+    AudioFileReader nextReader;
+    try
+    {
+        nextReader = new AudioFileReader(nextTrack.MusicFile);
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Crossfade: failed to open next track {File}", nextTrack.MusicFile);
+        return;
+    }
+    // ... rest of the method unchanged ...
+```
+
+- [ ] **Step 2: Replace the `for` loop with a Stopwatch-based `while` loop**
+
+Locate the block starting at `const int intervalMs = 50;` (around line 265). Replace the entire block (from `const int intervalMs` to the closing brace of the `for` loop, inclusive) with:
+
+```csharp
+const int intervalMs = 50;
+var sw = System.Diagnostics.Stopwatch.StartNew();
+
+while (true)
+{
+    ct.ThrowIfCancellationRequested();
+
+    double progress = Math.Clamp(sw.Elapsed.TotalSeconds / durationSeconds, 0.0, 1.0);
+
+    double fadeOutVolume = Math.Max(0, DbInterpolate(progress, masterVolume));
+    SetVolume(fadeOutVolume);
+
+    double fadeInVolume = Math.Max(0, DbInterpolate(1.0 - progress, masterVolume));
+    nextReader.Volume = (float)Math.Clamp(fadeInVolume / 100.0, 0.0, 1.0);
+
+    if (progress >= 1.0)
+        break;
+
+    await Task.Delay(intervalMs, ct);
+}
+```
+
+The Stopwatch measures wall-clock time regardless of per-iteration `Task.Delay` drift. When `progress` reaches 1.0 the loop exits — the fade always lasts exactly `durationSeconds` of real time.
+
+- [ ] **Step 3: Build to verify no compilation errors**
+
+```bash
+dotnet build /p:Platform=x64 -v quiet
+```
+
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).`
+
+- [ ] **Step 4: Run existing crossfade tests**
+
+```bash
+dotnet test tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj /p:Platform=x64 --filter "Crossfade" -v normal
+```
+
+Expected: all existing crossfade tests pass (they mock `CrossfadeToAsync` entirely and are unaffected by this change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs
+git commit -m "fix(player): use Stopwatch-based progress in crossfade loop to eliminate timing drift"
+```
+
+---
+
+## Task 2 — Read fresh position in `PlayerService.RunCrossfadeAsync`
+
+**Files:**
+- Modify: `src/Rok.Application/Player/PlayerService.cs:591-631`
+
+`currentPosition` is captured in `CrossfadeToNextTrackAsync` and passed through to `RunCrossfadeAsync`. By the time `timeToWaitBeforeCrossfade` is computed, the value is slightly stale (CTS creation overhead etc.). Reading the position fresh removes this small error.
+
+- [ ] **Step 1: Read position fresh just before the delay computation**
+
+Open `src/Rok.Application/Player/PlayerService.cs`. Locate `RunCrossfadeAsync` (around line 591). The method signature is:
+
+```csharp
+private async Task RunCrossfadeAsync(int nextIndex, TrackDto nextTrack, double trackLength, double currentPosition, CancellationToken cancellationToken)
+```
+
+Find these two lines inside the method:
+
+```csharp
+double timeToWaitBeforeCrossfade = Math.Max(0, trackLength - currentPosition - crossfadeDurationSeconds);
+
+if (timeToWaitBeforeCrossfade > 0)
+    await Task.Delay(TimeSpan.FromSeconds(timeToWaitBeforeCrossfade), cancellationToken);
+```
+
+Replace them with:
+
+```csharp
+double freshPosition = _player.Position;
+double timeToWaitBeforeCrossfade = Math.Max(0, trackLength - freshPosition - crossfadeDurationSeconds);
+
+if (timeToWaitBeforeCrossfade > 0)
+    await Task.Delay(TimeSpan.FromSeconds(timeToWaitBeforeCrossfade), cancellationToken);
+```
+
+Leave `currentPosition` in place — it is still used earlier in the method for `remainingTime` and `crossfadeDurationSeconds` computation, which is correct (those need the value at the moment the crossfade decision was made).
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build /p:Platform=x64 -v quiet
+```
+
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).`
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+dotnet test /p:Platform=x64
+```
+
+Expected: all tests pass. Note the exact count so you can verify no test was silently dropped.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Rok.Application/Player/PlayerService.cs
+git commit -m "fix(player): read fresh engine position before computing crossfade wait delay"
+```
+
+---
+
+## Task 3 — Final verification
+
+- [ ] **Step 1: Clean build**
+
+```bash
+dotnet build /p:Platform=x64
+```
+
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).`
+
+- [ ] **Step 2: Full test suite**
+
+```bash
+dotnet test /p:Platform=x64
+```
+
+Expected: all tests green.
+
+- [ ] **Step 3: Manual smoke test**
+
+Launch the app (`src/Presentation`). Play a playlist of at least 3 tracks with crossfade enabled. Listen to 2–3 transitions and confirm the fade is smooth and consistently timed. The old track should fade out exactly as the new track fades in, with no audible gap or abrupt cut.

--- a/docs/superpowers/specs/2026-05-18-crossfade-design.md
+++ b/docs/superpowers/specs/2026-05-18-crossfade-design.md
@@ -1,0 +1,104 @@
+# Crossfade timing fix — Design spec
+
+**Date**: 2026-05-18  
+**Branch**: feat/crossfade-improvements  
+**Status**: Approved
+
+## Problem
+
+The crossfade between tracks has inconsistent timing: sometimes smooth, sometimes the old track ends before the new one has fully faded in, creating an audible gap or abrupt cut. The issue is non-deterministic and affects all track lengths.
+
+### Root cause
+
+Two sources of drift accumulate:
+
+1. **Crossfade loop drift (primary)** — `CrossfadeToAsync` uses a step-based loop of `steps × Task.Delay(50ms)`. On Windows, `Task.Delay` resolution is ~15ms per call. For a 5s crossfade (100 iterations), the loop can run 5.0–5.7s instead of 5.0s. The old track finishes while the fade is still in progress.
+
+2. **Position snapshot staleness (secondary)** — `currentPosition` is read in `CrossfadeToNextTrackAsync` and passed to `RunCrossfadeAsync`. The value is slightly stale by the time the wait is computed. Drift of the single `Task.Delay(timeToWaitBeforeCrossfade)` is ≤15ms — acceptable by itself, but compounds with source 1.
+
+## Solution
+
+Two minimal, localized changes. No interface changes, no structural refactor.
+
+### Fix 1 — Stopwatch-based progress in `CrossfadeToAsync` (primary)
+
+**File**: `src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs`
+
+Replace the step-counting `for` loop with a `while` loop driven by `Stopwatch.Elapsed`. `Task.Delay(50ms)` remains as sleep granularity, but fade progress is computed from actual elapsed time — immune to per-iteration drift.
+
+```csharp
+// Before
+int steps = Math.Max(1, (int)(durationSeconds * 1000 / intervalMs));
+for (int i = 0; i <= steps; i++)
+{
+    double progress = Math.Clamp((double)i / steps, 0.0, 1.0);
+    ...
+    await Task.Delay(intervalMs, ct);
+}
+
+// After
+var sw = System.Diagnostics.Stopwatch.StartNew();
+while (true)
+{
+    ct.ThrowIfCancellationRequested();
+    double progress = Math.Clamp(sw.Elapsed.TotalSeconds / durationSeconds, 0.0, 1.0);
+    double fadeOutVolume = Math.Max(0, DbInterpolate(progress, masterVolume));
+    SetVolume(fadeOutVolume);
+    double fadeInVolume = Math.Max(0, DbInterpolate(1.0 - progress, masterVolume));
+    nextReader.Volume = (float)Math.Clamp(fadeInVolume / 100.0, 0.0, 1.0);
+    if (progress >= 1.0) break;
+    await Task.Delay(intervalMs, ct);
+}
+```
+
+**Guard** — add at entry of `CrossfadeToAsync`:
+```csharp
+if (durationSeconds <= 0)
+    return; // already handled upstream by RunCrossfadeAsync, but defense-in-depth
+```
+
+### Fix 2 — Fresh position read in `RunCrossfadeAsync` (secondary)
+
+**File**: `src/Rok.Application/Player/PlayerService.cs`
+
+Read `_player.Position` fresh just before computing `timeToWaitBeforeCrossfade`, instead of using the stale `currentPosition` parameter captured earlier in the call chain.
+
+```csharp
+// Before
+double timeToWaitBeforeCrossfade = Math.Max(0, trackLength - currentPosition - crossfadeDurationSeconds);
+
+// After
+double freshPosition = _player.Position;
+double timeToWaitBeforeCrossfade = Math.Max(0, trackLength - freshPosition - crossfadeDurationSeconds);
+```
+
+The `currentPosition` parameter is still used for `remainingTime` / `crossfadeDurationSeconds` computation (which happens before this point and is correct).
+
+## Tests
+
+### Existing tests (unchanged)
+
+`PlayerServiceCrossfadeTests` mocks `CrossfadeToAsync` and does not test the internal loop. All existing tests remain valid.
+
+### New tests in `Rok.Infrastructure.UnitTests`
+
+Two new tests on `NAudioMediaPlayer` using real in-memory audio (e.g., NAudio `SilenceProvider` → `WaveFileWriter` → temp file, or a short real fixture file):
+
+**`CrossfadeToAsync_ShouldCompleteWithinExpectedDuration`**
+- Arrange: two short real audio files (or silence), engine loaded with track 1
+- Act: measure wall-clock time of `CrossfadeToAsync(duration: 1.0)` with a `Stopwatch`
+- Assert: elapsed ∈ `[1.0s, 1.3s]` (tight upper bound, ~30% margin for CI load)
+
+**`CrossfadeToAsync_ShouldSetFullVolumeOnNextTrackAtEnd`**
+- Arrange: same setup, `masterVolume = 80`
+- Act: run `CrossfadeToAsync(duration: 0.1)` to completion
+- Assert: after completion, `nextReader.Volume ≈ 0.8` (fade-in reached full)  
+  (verify via the swapped `_audioFileReader` — the engine exposes nothing directly, so check via `SetVolume` call or a thin seam)
+
+> Note: `NAudioMediaPlayer` currently has no seam for reading back volume. If testing via behavior (Stopwatch timing) proves sufficient, the second test may be dropped in favor of an integration test at `PlayerService` level.
+
+## Out of scope
+
+- Equalizer preset application during fade-in (new track plays with default EQ bands during crossfade; the preset is applied after `OnMediaChangedAsync`). This is a separate concern and not blocking.
+- `WinUIMediaPlayer.CrossfadeToAsync` — already falls back to instant switch by design. No change.
+- Configurable crossfade duration (currently hardcoded to 5s). No change.

--- a/src/Rok.Application/Player/PlayerService.cs
+++ b/src/Rok.Application/Player/PlayerService.cs
@@ -588,9 +588,9 @@ public class PlayerService : IPlayerService, IDisposable
         return true;
     }
 
-    private async Task RunCrossfadeAsync(int nextIndex, TrackDto nextTrack, double trackLength, double currentPosition, CancellationToken cancellationToken)
+    private async Task RunCrossfadeAsync(int nextIndex, TrackDto nextTrack, double trackLength, double positionAtDecisionTime, CancellationToken cancellationToken)
     {
-        double remainingTime = Math.Max(0, trackLength - currentPosition);
+        double remainingTime = Math.Max(0, trackLength - positionAtDecisionTime);
         double crossfadeDurationSeconds = Math.Min(_player.CrossfadeDelay, remainingTime);
 
         if (crossfadeDurationSeconds <= 0)
@@ -604,7 +604,8 @@ public class PlayerService : IPlayerService, IDisposable
             return;
         }
 
-        double timeToWaitBeforeCrossfade = Math.Max(0, trackLength - currentPosition - crossfadeDurationSeconds);
+        double freshPosition = _player.Position;
+        double timeToWaitBeforeCrossfade = Math.Max(0, trackLength - freshPosition - crossfadeDurationSeconds);
 
         if (timeToWaitBeforeCrossfade > 0)
             await Task.Delay(TimeSpan.FromSeconds(timeToWaitBeforeCrossfade), cancellationToken);

--- a/src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs
+++ b/src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Timers;
 using Microsoft.Extensions.Logging;
 using NAudio;
@@ -226,6 +227,9 @@ public class NAudioMediaPlayer : IPlayerEngine, IDisposable
     /// <inheritdoc />
     public async Task CrossfadeToAsync(TrackDto nextTrack, double durationSeconds, double masterVolume, CancellationToken ct)
     {
+        if (durationSeconds <= 0)
+            return;
+
         AudioFileReader nextReader;
         try
         {
@@ -263,19 +267,22 @@ public class NAudioMediaPlayer : IPlayerEngine, IDisposable
             nextDevice.Play();
 
             const int intervalMs = 50;
-            int steps = Math.Max(1, (int)(durationSeconds * 1000 / intervalMs));
+            var sw = Stopwatch.StartNew();
 
-            for (int i = 0; i <= steps; i++)
+            while (true)
             {
                 ct.ThrowIfCancellationRequested();
 
-                double progress = Math.Clamp((double)i / steps, 0.0, 1.0);
+                double progress = Math.Clamp(sw.Elapsed.TotalSeconds / durationSeconds, 0.0, 1.0);
 
                 double fadeOutVolume = Math.Max(0, DbInterpolate(progress, masterVolume));
                 SetVolume(fadeOutVolume);
 
                 double fadeInVolume = Math.Max(0, DbInterpolate(1.0 - progress, masterVolume));
                 nextReader.Volume = (float)Math.Clamp(fadeInVolume / 100.0, 0.0, 1.0);
+
+                if (progress >= 1.0)
+                    break;
 
                 await Task.Delay(intervalMs, ct);
             }


### PR DESCRIPTION
Replace step-based progress (i/steps) with Stopwatch-based progress (elapsed/duration) in NAudioMediaPlayer.CrossfadeToAsync to eliminate Task.Delay drift accumulation over the fade loop.

Also read a fresh engine position in PlayerService.RunCrossfadeAsync just before computing the pre-crossfade wait delay, instead of using the stale snapshot from the event handler.