### PR TITLE
fix(track-vm): restore lazy lyrics-type init in getter so list badges…

### DIFF
--- a/src/Presentation/ViewModels/Track/TrackViewModel.cs
+++ b/src/Presentation/ViewModels/Track/TrackViewModel.cs
@@ -136,7 +136,14 @@ public partial class TrackViewModel : ObservableObject, IDisposable, IFilterable
 
     public string PlainLyrics => _lyrics?.PlainLyrics ?? string.Empty;
 
-    public ELyricsType LyricsType => _lyricsType ?? ELyricsType.None;
+    public ELyricsType LyricsType
+    {
+        get
+        {
+            _lyricsType ??= _lyricsService.CheckLyricsType(Track.MusicFile);
+            return _lyricsType.Value;
+        }
+    }
 
     public bool LyricsExists => LyricsType != ELyricsType.None;
 


### PR DESCRIPTION
… show

Commit 6562099 moved the lyrics-type init out of the LyricsType getter into LoadDataAsync, but LoadDataAsync only runs for single-track navigation. In list contexts (TracksPage, AlbumPage, ArtistPage, PlaylistPage, ListeningPage, SearchPage, SmartPlaylistPage), TrackViewModel is populated via SetData which never touches _lyricsType, so LyricsType returned None and both sync/plain lyrics badges stayed Collapsed.

Restore the synchronous lazy file check in the getter (only the sync part — the async API auto-download still lives in LoadDataAsync, avoiding the API spam that motivated 6562099).