### PR TITLE
@

### DIFF
--- a/src/Rok.Infrastructure/MusicData/MusicDataApiService.cs
+++ b/src/Rok.Infrastructure/MusicData/MusicDataApiService.cs
@@ -91,20 +91,17 @@ public class MusicDataApiService : IMusicDataApiService, IDisposable
         if (artistName is null)
             return null;
 
-        MusicDataArtistDto? artist;
-        string url;
+        if (_artistCache.TryGetValue(artistName, out MusicDataArtistDto? cached))
+            return cached;
 
-        if (!_artistCache.TryGetValue(artistName, out artist!))
-        {
-            if (string.IsNullOrEmpty(musicBrainzId))
-                url = $"v1/artists/byname/{Uri.EscapeDataString(artistName)}";
-            else
-                url = $"v1/artists/bymbid/{Uri.EscapeDataString(musicBrainzId)}";
+        string url = string.IsNullOrEmpty(musicBrainzId)
+            ? $"v1/artists/byname/{Uri.EscapeDataString(artistName)}"
+            : $"v1/artists/bymbid/{Uri.EscapeDataString(musicBrainzId)}";
 
-            artist = await GetAsync<MusicDataArtistDto>(url);
+        (bool cacheable, MusicDataArtistDto? artist) = await GetAsync<MusicDataArtistDto>(url);
 
+        if (cacheable)
             SaveArtistToCache(artistName, artist);
-        }
 
         return artist;
     }
@@ -123,22 +120,19 @@ public class MusicDataApiService : IMusicDataApiService, IDisposable
         if (albumMusicBrainzId is null && artistMusicBrainzId is not null)
             artistMusicBrainzId = null;
 
-        MusicDataAlbumDto? album;
-        string url;
-
         string key = $"{artistName}_{albumName}";
 
-        if (!_albumCache.TryGetValue(key, out album!))
-        {
-            if (string.IsNullOrEmpty(albumMusicBrainzId))
-                url = $"v1/albums/byname/{Uri.EscapeDataString(artistName)}/{Uri.EscapeDataString(albumName)}";
-            else
-                url = $"v1/albums/bymbid/{Uri.EscapeDataString(artistMusicBrainzId!)}/{Uri.EscapeDataString(albumMusicBrainzId)}";
+        if (_albumCache.TryGetValue(key, out MusicDataAlbumDto? cached))
+            return cached;
 
-            album = await GetAsync<MusicDataAlbumDto>(url);
+        string url = string.IsNullOrEmpty(albumMusicBrainzId)
+            ? $"v1/albums/byname/{Uri.EscapeDataString(artistName)}/{Uri.EscapeDataString(albumName)}"
+            : $"v1/albums/bymbid/{Uri.EscapeDataString(artistMusicBrainzId!)}/{Uri.EscapeDataString(albumMusicBrainzId)}";
 
+        (bool cacheable, MusicDataAlbumDto? album) = await GetAsync<MusicDataAlbumDto>(url);
+
+        if (cacheable)
             SaveAlbumToCache(key, album);
-        }
 
         return album;
     }
@@ -154,16 +148,17 @@ public class MusicDataApiService : IMusicDataApiService, IDisposable
         if (string.IsNullOrEmpty(title))
             return null;
 
-        MusicDataLyricsDto? lyrics;
         string key = $"{artistName}_{title}";
 
-        if (!_lyricsCache.TryGetValue(key, out lyrics))
-        {
-            string url = $"v1/lyrics?artistName={Uri.EscapeDataString(artistName)}&albumName={Uri.EscapeDataString(albumName)}&title={Uri.EscapeDataString(title)}&duration={duration}";
-            lyrics = await GetAsync<MusicDataLyricsDto>(url);
+        if (_lyricsCache.TryGetValue(key, out MusicDataLyricsDto? cached))
+            return cached;
 
+        string url = $"v1/lyrics?artistName={Uri.EscapeDataString(artistName)}&albumName={Uri.EscapeDataString(albumName)}&title={Uri.EscapeDataString(title)}&duration={duration}";
+
+        (bool cacheable, MusicDataLyricsDto? lyrics) = await GetAsync<MusicDataLyricsDto>(url);
+
+        if (cacheable)
             SaveLyricsToCache(key, lyrics);
-        }
 
         return lyrics;
     }
@@ -290,14 +285,17 @@ public class MusicDataApiService : IMusicDataApiService, IDisposable
         entry.AbsoluteExpiration = DateTime.UtcNow.AddMinutes(KCacheDelayMinutes);
     }
 
-    private async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken = default)
+    // Cacheable is true only when the API gave a definitive answer (a 2xx
+    // response — even an empty one — or a 404 "not found"). Transient outcomes
+    // (active rate-limit window, busy concurrency limiter, cancellation, network
+    // errors, auth/server errors) return Cacheable = false so the caller retries
+    // on the next request instead of caching the failure for hours.
+    private async Task<(bool Cacheable, T? Value)> GetAsync<T>(string url, CancellationToken cancellationToken = default)
     {
-        T? result = default;
-
         if (IsRateLimitActive(out DateTime ignoreUntilSnapshot))
         {
             _logger.LogDebug("Skipping request due to active rate-limit window until {Until} for {Url}", ignoreUntilSnapshot, url);
-            return result;
+            return (false, default);
         }
 
         bool acquired;
@@ -309,52 +307,59 @@ public class MusicDataApiService : IMusicDataApiService, IDisposable
         catch (OperationCanceledException ex)
         {
             _logger.LogWarning(ex, "Request cancelled before entering limiter {Url}", url);
-            return result;
+            return (false, default);
         }
 
-        if (acquired)
+        if (!acquired)
+        {
+            _logger.LogWarning("Concurrency limiter timed out for {Url}", url);
+            return (false, default);
+        }
+
+        try
+        {
+            _logger.LogDebug("Sending request to RoK API {Url}", url);
+
+            HttpResponseMessage response = await _httpClient.GetAsync(url, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("RoK API response successful {Url}", url);
+
+                using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                T? result = await JsonSerializer.DeserializeAsync<T>(stream, _jsonOptions, cancellationToken);
+
+                return (true, result);
+            }
+
+            _logger.LogError("RoK API response {Error} {Url}", response.StatusCode, url);
+            HandleErrorResponse(response);
+
+            bool isDefinitiveNegative = response.StatusCode == System.Net.HttpStatusCode.NotFound;
+
+            return (isDefinitiveNegative, default);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation requested by caller — expected, no action needed
+            return (false, default);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "HTTP error {Url}", url);
+            return (false, default);
+        }
+        finally
         {
             try
             {
-                _logger.LogDebug("Sending request to RoK API {Url}", url);
-
-                HttpResponseMessage response = await _httpClient.GetAsync(url, cancellationToken);
-
-                if (response.IsSuccessStatusCode)
-                {
-                    _logger.LogDebug("RoK API response successful {Url}", url);
-
-                    using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
-                    result = await JsonSerializer.DeserializeAsync<T>(stream, _jsonOptions, cancellationToken);
-                }
-                else
-                {
-                    _logger.LogError("RoK API response {Error} {Url}", response.StatusCode, url);
-                    HandleErrorResponse(response);
-                }
+                _concurrencyLimiter.Release();
             }
-            catch (OperationCanceledException)
+            catch (SemaphoreFullException ex)
             {
-                // Cancellation requested by caller — expected, no action needed
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "HTTP error {Url}", url);
-            }
-            finally
-            {
-                try
-                {
-                    _concurrencyLimiter.Release();
-                }
-                catch (SemaphoreFullException ex)
-                {
-                    _logger.LogWarning(ex, "Semaphore release called when full for {Url}", url);
-                }
+                _logger.LogWarning(ex, "Semaphore release called when full for {Url}", url);
             }
         }
-
-        return result;
     }
 
     private void HandleErrorResponse(HttpResponseMessage response)

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/MusicData/MusicDataApiServiceTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/MusicData/MusicDataApiServiceTests.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Rok.Application.Dto.MusicDataApi;
+using Rok.Application.Interfaces;
+using Rok.Application.Options;
+using Rok.Infrastructure.MusicData;
+
+namespace Rok.Infrastructure.UnitTests.MusicData;
+
+public class MusicDataApiServiceTests
+{
+    private sealed class SequenceHandler(IEnumerable<(HttpStatusCode Status, string Body)> responses) : HttpMessageHandler
+    {
+        private readonly Queue<(HttpStatusCode Status, string Body)> _responses = new(responses);
+
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+
+            (HttpStatusCode status, string body) = _responses.Count > 0 ? _responses.Dequeue() : (HttpStatusCode.OK, "{}");
+
+            HttpResponseMessage response = new(status)
+            {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes(body))
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private static MusicDataApiService CreateService(SequenceHandler handler)
+    {
+        HttpClient httpClient = new(handler);
+
+        Mock<IAppOptions> appOptions = new();
+        appOptions.SetupGet(o => o.NovaApiEnabled).Returns(true);
+
+        IOptions<MusicDataApiOptions> options = Options.Create(new MusicDataApiOptions
+        {
+            BaseAddress = "https://musicdata.test/",
+            ApiKey = "test-key"
+        });
+
+        Mock<IHttpClientFactory> factory = new();
+
+        return new MusicDataApiService(httpClient, factory.Object, appOptions.Object, options, NullLogger<MusicDataApiService>.Instance);
+    }
+
+    [Fact(DisplayName = "transient_failure_is_not_cached_and_is_retried_on_next_call")]
+    public async Task Transient_failure_is_not_cached_and_is_retried_on_next_call()
+    {
+        // Arrange
+        SequenceHandler handler = new(
+        [
+            (HttpStatusCode.InternalServerError, "boom"),
+            (HttpStatusCode.OK, """{ "name": "Radiohead" }""")
+        ]);
+        MusicDataApiService sut = CreateService(handler);
+
+        // Act
+        MusicDataArtistDto? first = await sut.GetArtistAsync("Radiohead", null);
+        MusicDataArtistDto? second = await sut.GetArtistAsync("Radiohead", null);
+
+        // Assert
+        Assert.Null(first);
+        Assert.NotNull(second);
+        Assert.Equal("Radiohead", second!.Name);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact(DisplayName = "successful_response_is_cached_and_not_requeried")]
+    public async Task Successful_response_is_cached_and_not_requeried()
+    {
+        // Arrange
+        SequenceHandler handler = new(
+        [
+            (HttpStatusCode.OK, """{ "name": "Radiohead" }""")
+        ]);
+        MusicDataApiService sut = CreateService(handler);
+
+        // Act
+        MusicDataArtistDto? first = await sut.GetArtistAsync("Radiohead", null);
+        MusicDataArtistDto? second = await sut.GetArtistAsync("Radiohead", null);
+
+        // Assert
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact(DisplayName = "definitive_not_found_is_cached_as_negative")]
+    public async Task Definitive_not_found_is_cached_as_negative()
+    {
+        // Arrange
+        SequenceHandler handler = new(
+        [
+            (HttpStatusCode.NotFound, string.Empty)
+        ]);
+        MusicDataApiService sut = CreateService(handler);
+
+        // Act
+        MusicDataArtistDto? first = await sut.GetArtistAsync("Unknown Artist", null);
+        MusicDataArtistDto? second = await sut.GetArtistAsync("Unknown Artist", null);
+
+        // Assert
+        Assert.Null(first);
+        Assert.Null(second);
+        Assert.Equal(1, handler.CallCount);
+    }
+}


### PR DESCRIPTION
fix(musicdata): stop caching transient failures for 24h

GetAsync returned null both for definitive negatives (API responded with no data) and for transient outcomes (active rate-limit window, busy concurrency limiter, cancellation, network/server errors). Callers cached that null for 24h in an app-lifetime singleton, so a brief network blip or the 60s rate-limit window left lyrics/artwork empty for a full day.

GetAsync now returns (Cacheable, Value): only a 2xx response (even empty) or a 404 not-found is cacheable; every transient outcome returns Cacheable=false so the next request retries. Callers cache only when Cacheable is true. Add MusicDataApiServiceTests covering the three paths.


@