### PR TITLE
@

### DIFF
--- a/src/Presentation/ViewModels/Playlists/PlaylistsViewModel.cs
+++ b/src/Presentation/ViewModels/Playlists/PlaylistsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Dispatching;
 using Rok.Application.Features.Playlists.Messages;
 using Rok.ViewModels.Playlist;
 using Rok.ViewModels.Playlists.Handlers;
@@ -19,6 +20,7 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
     private readonly PlaylistImportedMessageHandler _importedHandler;
     private readonly IAppOptions _appOptions;
     private readonly IMessenger _messenger;
+    private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
     private readonly List<IDisposable> _subscriptions = new();
 
     public RangeObservableCollection<PlaylistViewModel> Playlists { get; private set; } = [];
@@ -71,7 +73,7 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
 
     private void OnDataChanged(object? sender, EventArgs e)
     {
-        RefreshPlaylists();
+        _dispatcherQueue.TryEnqueue(() => RefreshPlaylists());
     }
 
     public async Task LoadDataAsync(bool forceReload)


### PR DESCRIPTION
fix(playlists): marshal collection refresh to UI thread

PlaylistsViewModel was the only library viewmodel mutating its bound RangeObservableCollections (Playlists/SmartPlaylists) without marshalling to the UI thread. The DataChanged event from the playlist message handlers is raised after an await without a SynchronizationContext, so it runs on a thread-pool thread; the resulting CollectionChanged fired off the UI thread, invalidating layout on the wrong thread and surfacing as an empty-message COMException in FrameworkElement.MeasureOverride.

Wrap RefreshPlaylists in DispatcherQueue.TryEnqueue, mirroring the pattern already used by AlbumsViewModel/ArtistsViewModel/TracksViewModel.


@