### PR TITLE
@

### DIFF
--- a/src/Rok.Infrastructure/Telemetry/TelemetryClient.cs
+++ b/src/Rok.Infrastructure/Telemetry/TelemetryClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http.Json;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Rok.Application.Interfaces;
@@ -76,7 +77,7 @@ public class TelemetryClient : ITelemetryClient
             EventType = "screen",
             EventName = screenName,
             AppVersion = _appVersion,
-            OsVersion = Environment.OSVersion.Platform.ToString(),
+            OsVersion = GetOsVersion(),
             Language = System.Globalization.CultureInfo.CurrentCulture.Name,
             TimeZone = TimeZoneInfo.Local.StandardName,
         };
@@ -105,7 +106,7 @@ public class TelemetryClient : ITelemetryClient
             EventType = eventType,
             EventName = eventName,
             AppVersion = _appVersion,
-            OsVersion = Environment.OSVersion.Platform.ToString(),
+            OsVersion = GetOsVersion(),
             Language = System.Globalization.CultureInfo.CurrentCulture.Name,
             TimeZone = TimeZoneInfo.Local.StandardName,
             Payload = properties is not null ? System.Text.Json.JsonSerializer.Serialize(properties) : string.Empty
@@ -134,9 +135,10 @@ public class TelemetryClient : ITelemetryClient
             CorrelationId = _correlationId,
             Type = ex.GetType().FullName ?? ex.GetType().Name,
             Message = BuildFullMessage(ex),
+            HResult = FormatHResult(ResolveHResult(ex)),
             StackTrace = BuildFullStackTrace(ex),
             AppVersion = _appVersion,
-            OsVersion = Environment.OSVersion.Platform.ToString(),
+            OsVersion = GetOsVersion(),
             Language = System.Globalization.CultureInfo.CurrentCulture.Name,
             TimeZone = TimeZoneInfo.Local.StandardName
         };
@@ -153,7 +155,7 @@ public class TelemetryClient : ITelemetryClient
         }
     }
 
-    private static string BuildFullMessage(Exception ex)
+    internal static string BuildFullMessage(Exception ex)
     {
         var parts = new System.Text.StringBuilder();
         Exception? current = ex;
@@ -161,11 +163,27 @@ public class TelemetryClient : ITelemetryClient
         {
             if (parts.Length > 0)
                 parts.Append(" ---> ");
-            parts.Append($"[{current.GetType().Name}] {current.Message}");
+            parts.Append($"[{current.GetType().Name} {FormatHResult(current.HResult)}] {current.Message}");
             current = current.InnerException;
         }
         return parts.ToString();
     }
+
+    internal static int ResolveHResult(Exception ex)
+    {
+        Exception? current = ex;
+        while (current is not null)
+        {
+            if (current is COMException)
+                return current.HResult;
+            current = current.InnerException;
+        }
+        return ex.HResult;
+    }
+
+    internal static string FormatHResult(int hresult) => $"0x{hresult:X8}";
+
+    private static string GetOsVersion() => RuntimeInformation.OSDescription;
 
     private static string BuildFullStackTrace(Exception ex)
     {
@@ -201,6 +219,7 @@ public class TelemetryClient : ITelemetryClient
         public string CorrelationId { get; init; } = string.Empty;
         public string Type { get; init; } = string.Empty;
         public string Message { get; init; } = string.Empty;
+        public string HResult { get; init; } = string.Empty;
         public string StackTrace { get; init; } = string.Empty;
         public string AppVersion { get; init; } = string.Empty;
         public string OsVersion { get; init; } = string.Empty;

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Telemetry/TelemetryClientTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Telemetry/TelemetryClientTests.cs
@@ -1,0 +1,77 @@
+using System.Runtime.InteropServices;
+using Rok.Infrastructure.Telemetry;
+
+namespace Rok.Infrastructure.UnitTests.Telemetry;
+
+public class TelemetryClientTests
+{
+    private const int RpcEWrongThread = unchecked((int)0x8001010E);
+
+    [Fact(DisplayName = "format_hresult_pads_to_eight_hex_digits_with_prefix")]
+    public void FormatHResult_PadsToEightHexDigits()
+    {
+        // Arrange
+        // Act
+        string result = TelemetryClient.FormatHResult(RpcEWrongThread);
+
+        // Assert
+        Assert.Equal("0x8001010E", result);
+    }
+
+    [Fact(DisplayName = "resolve_hresult_prefers_inner_comexception_hresult")]
+    public void ResolveHResult_WithWrappedComException_ReturnsComHResult()
+    {
+        // Arrange
+        COMException inner = new(string.Empty, RpcEWrongThread);
+        InvalidOperationException outer = new("wrapper", inner);
+
+        // Act
+        int result = TelemetryClient.ResolveHResult(outer);
+
+        // Assert
+        Assert.Equal(RpcEWrongThread, result);
+    }
+
+    [Fact(DisplayName = "resolve_hresult_without_comexception_falls_back_to_top_level_hresult")]
+    public void ResolveHResult_WithoutComException_ReturnsTopLevelHResult()
+    {
+        // Arrange
+        InvalidOperationException ex = new("boom");
+
+        // Act
+        int result = TelemetryClient.ResolveHResult(ex);
+
+        // Assert
+        Assert.Equal(ex.HResult, result);
+    }
+
+    [Fact(DisplayName = "build_full_message_surfaces_hresult_of_empty_message_comexception")]
+    public void BuildFullMessage_WithEmptyMessageComException_IncludesHResult()
+    {
+        // Arrange
+        COMException ex = new(string.Empty, RpcEWrongThread);
+
+        // Act
+        string result = TelemetryClient.BuildFullMessage(ex);
+
+        // Assert
+        Assert.Equal("[COMException 0x8001010E] ", result);
+    }
+
+    [Fact(DisplayName = "build_full_message_chains_inner_exceptions_with_their_hresults")]
+    public void BuildFullMessage_WithInnerException_ChainsBothNodes()
+    {
+        // Arrange
+        COMException inner = new(string.Empty, RpcEWrongThread);
+        InvalidOperationException outer = new("layout failed", inner);
+
+        // Act
+        string result = TelemetryClient.BuildFullMessage(outer);
+
+        // Assert
+        Assert.Contains("[InvalidOperationException", result);
+        Assert.Contains("layout failed", result);
+        Assert.Contains(" ---> ", result);
+        Assert.Contains("[COMException 0x8001010E] ", result);
+    }
+}


### PR DESCRIPTION
feat(telemetry): capture HResult and real OS build in crash reports

Empty-message COMExceptions (e.g. RPC_E_WRONG_THREAD surfacing in MeasureOverride) were undiagnosable: ExceptionDto dropped the HResult and OsVersion was Environment.OSVersion.Platform, which always returns "Win32NT".

- Inline each exception node HResult into the captured message ([COMException 0x8001010E] ...), so it is visible without any backend change.
- Add a dedicated HResult field on ExceptionDto, resolved from the inner COMException when present, for structured server-side filtering.
- Replace OsVersion with RuntimeInformation.OSDescription (real Windows build) across screen/event/exception payloads.

Covered by TelemetryClientTests (HResult formatting, COM resolution, message chaining).


@