### PR TITLE
@

### DIFF
--- a/src/Presentation/Pages/TracksPage.xaml.cs
+++ b/src/Presentation/Pages/TracksPage.xaml.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Threading;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using Rok.Commons;
@@ -147,7 +148,13 @@ public sealed partial class TracksPage : Page, IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        if (!this.DispatcherQueue.HasThreadAccess)
+        {
+            this.DispatcherQueue.TryEnqueue(() => Dispose());
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _disposed, true))
             return;
 
         try
@@ -158,7 +165,10 @@ public sealed partial class TracksPage : Page, IDisposable
             _durationAnimation.Dispose();
 
             if (ViewModel != null)
+            {
                 ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+                ViewModel.GroupedItems.CollectionChanged -= GroupedItems_CollectionChanged;
+            }
 
             if (tracksList is not null)
                 tracksList.ItemsSource = null;
@@ -178,7 +188,5 @@ public sealed partial class TracksPage : Page, IDisposable
         {
             _logger.LogError(ex, "Error during Dispose in TracksPage");
         }
-
-        _disposed = true;
     }
 }


### PR DESCRIPTION
fix(tracks): unsubscribe GroupedItems.CollectionChanged on TracksPage dispose

TracksViewModel is a singleton, so its bound GroupedItems collection outlives every TracksPage instance. The page subscribed to GroupedItems.CollectionChanged in its constructor but never unsubscribed in Dispose, unlike the working AlbumsPage. Each navigation left another handler attached; on a later FilterAndSort, handlers from already-disposed pages ran UpdateItemsSource and mutated their detached ListView/GridView, invalidating layout on dead elements and throwing a COMException (E_FAIL) from FrameworkElement.MeasureOverride.

Align TracksPage.Dispose with AlbumsPage: unsubscribe the collection handler, marshal Dispose to the UI thread, and guard _disposed with Interlocked.Exchange.


@