### PR TITLE
fix(listening): make artist name readable in light theme

### DIFF
--- a/src/Presentation/Pages/ListeningPage.xaml
+++ b/src/Presentation/Pages/ListeningPage.xaml
@@ -60,7 +60,7 @@
 
             <RelativePanel Grid.Column="1" Margin="6,0,0,0">
 
-                <HyperlinkButton x:Name="artistName" Content="{x:Bind ViewModel.CurrentTrack.ArtistName, Mode=OneWay}" Command="{x:Bind ViewModel.ArtistOpenCommand}" FontSize="{StaticResource FontSizeLarge}" FontWeight="Bold" Padding="0" Margin="0" Foreground="White" Style="{StaticResource HeaderHyperlinkStyle}" />
+                <HyperlinkButton x:Name="artistName" Content="{x:Bind ViewModel.CurrentTrack.ArtistName, Mode=OneWay}" Command="{x:Bind ViewModel.ArtistOpenCommand}" FontSize="{StaticResource FontSizeLarge}" FontWeight="Bold" Padding="0" Margin="0" Style="{StaticResource HeaderHyperlinkStyle}" />
 
                 <Button x:Name="buttonCountry" RelativePanel.RightOf="artistName" RelativePanel.AlignVerticalCenterWith="artistName" Margin="4,0,0,0" Style="{StaticResource ButtonTextBlockStyle}" Visibility="{x:Bind ViewModel.Artist.Artist.CountryCode, Mode=OneWay, Converter={StaticResource StringToVisibilityConverter}}" BorderBrush="Transparent" Background="Transparent" ToolTipService.ToolTip="{x:Bind ViewModel.Artist.Artist.CountryName, Mode=OneWay}">
                     <Image Source="{x:Bind ViewModel.Artist.Artist.CountryCode, Mode=OneWay, Converter={StaticResource CountryCodeToImageSourceConverter}}" Height="10"></Image>


### PR DESCRIPTION
Remove the hard-coded Foreground=White on the artist HyperlinkButton so the HeaderHyperlinkStyle theme-aware OnSurfaceAccentBrush applies, matching AlbumPage. White text was unreadable on the light header background.