### PR TITLE
fix(lyrics): show raw .lrc content when parsed lyrics are empty

### DIFF
--- a/src/Presentation/ViewModels/Track/TrackViewModel.cs
+++ b/src/Presentation/ViewModels/Track/TrackViewModel.cs
@@ -328,12 +328,14 @@ public partial class TrackViewModel : ObservableObject, IDisposable, IFilterable
     {
         await LoadLyricsAsync();
 
-        if (!string.IsNullOrEmpty(PlainLyrics))
+        string lyrics = _lyrics?.DisplayText ?? string.Empty;
+
+        if (!string.IsNullOrEmpty(lyrics))
         {
             string? rawLanguage = Windows.Globalization.ApplicationLanguages.Languages.FirstOrDefault();
             string language = LanguageHelpers.NormalizeLanguageCode(rawLanguage, "fr");
 
-            await _dialogService.ShowTextAsync($"{ArtistName} - {Title}", PlainLyrics, showTranslateButton: _appOptions.NovaApiEnabled, language);
+            await _dialogService.ShowTextAsync($"{ArtistName} - {Title}", lyrics, showTranslateButton: _appOptions.NovaApiEnabled, language);
         }
     }
 

--- a/src/Rok.Application/Dto/Lyrics/LyricsModel.cs
+++ b/src/Rok.Application/Dto/Lyrics/LyricsModel.cs
@@ -9,4 +9,12 @@ public class LyricsModel
     public string? SynchronizedLyrics { get; set; }
 
     public ELyricsType LyricsType { get; set; }
+
+    // Lyrics to show to the user: the parsed plain text when available, otherwise
+    // the raw file content. Some .lrc files only carry metadata (e.g.
+    // "[au: instrumental]") which strips down to nothing once timestamps are
+    // removed; falling back to the raw content guarantees the dialog still has
+    // something to display instead of silently doing nothing.
+    public string DisplayText =>
+        !string.IsNullOrWhiteSpace(PlainLyrics) ? PlainLyrics : SynchronizedLyrics ?? string.Empty;
 }

--- a/tests/UnitTests/Rok.ApplicationTests/Dto/Lyrics/LyricsModelTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Dto/Lyrics/LyricsModelTests.cs
@@ -1,0 +1,60 @@
+using Rok.Application.Dto.Lyrics;
+
+namespace Rok.ApplicationTests.Dto.Lyrics;
+
+public class LyricsModelTests
+{
+    [Fact(DisplayName = "DisplayText should return the parsed plain lyrics when they are present")]
+    public void DisplayText_ShouldReturnPlainLyrics_WhenPlainLyricsPresent()
+    {
+        // Arrange
+        LyricsModel model = new()
+        {
+            PlainLyrics = "First line\nSecond line",
+            SynchronizedLyrics = "[00:12.00]First line\n[00:15.00]Second line",
+            LyricsType = ELyricsType.Synchronized
+        };
+
+        // Act
+        string result = model.DisplayText;
+
+        // Assert
+        Assert.Equal("First line\nSecond line", result);
+    }
+
+    [Fact(DisplayName = "DisplayText should fall back to the raw file content when the parsed lyrics are empty")]
+    public void DisplayText_ShouldFallBackToRawContent_WhenPlainLyricsEmpty()
+    {
+        // Arrange
+        LyricsModel model = new()
+        {
+            PlainLyrics = string.Empty,
+            SynchronizedLyrics = "[au: instrumental]",
+            LyricsType = ELyricsType.Synchronized
+        };
+
+        // Act
+        string result = model.DisplayText;
+
+        // Assert
+        Assert.Equal("[au: instrumental]", result);
+    }
+
+    [Fact(DisplayName = "DisplayText should return empty when there is nothing to display")]
+    public void DisplayText_ShouldReturnEmpty_WhenNothingToDisplay()
+    {
+        // Arrange
+        LyricsModel model = new()
+        {
+            PlainLyrics = string.Empty,
+            SynchronizedLyrics = null,
+            LyricsType = ELyricsType.None
+        };
+
+        // Act
+        string result = model.DisplayText;
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+}


### PR DESCRIPTION
Instrumental tracks ship .lrc sidecar files containing only metadata (e.g. "[au: instrumental]"). Those files made CheckLyricsFileExists report Synchronized lyrics, so the "sync lyrics" badge and the track context-menu item were shown. But opening them ran GetRawLyrics, which strips the [..] tags down to an empty string, so LyricsOpenAsync silently showed no dialog ("nothing happens" on the menu).

Add LyricsModel.DisplayText, which falls back to the raw file content when the parsed plain text is empty, and use it in LyricsOpenAsync so the dialog always has something to display. Detection stays untouched, so there is no extra file I/O while scrolling track lists.