### PR TITLE
feat(albums): add anniversary filter on albums page

### DIFF
--- a/src/Presentation/Pages/AlbumsFilterMenuBuilder.cs
+++ b/src/Presentation/Pages/AlbumsFilterMenuBuilder.cs
@@ -22,6 +22,7 @@ internal class AlbumsFilterMenuBuilder
         "COMPILATION",
         "ALBUM",
         "NEVERLISTENED",
+        "ANNIVERSARY",
     ];
 
 

--- a/src/Presentation/Strings/en-US/Resources.resw
+++ b/src/Presentation/Strings/en-US/Resources.resw
@@ -372,6 +372,9 @@
   <data name="albumsViewFilterByFavoriteGenreMenu.Text" xml:space="preserve">
     <value>favorites genres</value>
   </data>
+  <data name="albumsViewFilterByAnniversary" xml:space="preserve">
+    <value>anniversaries</value>
+  </data>
   <data name="albumsViewFilterByNeverListened" xml:space="preserve">
     <value>never listened</value>
   </data>
@@ -963,6 +966,9 @@
   </data>
   <data name="filterneverlistened" xml:space="preserve">
     <value>Never listened</value>
+  </data>
+  <data name="filteranniversary" xml:space="preserve">
+    <value>Anniversaries</value>
   </data>
   <data name="filterfavorite" xml:space="preserve">
     <value>Favorites</value>

--- a/src/Presentation/Strings/es-ES/Resources.resw
+++ b/src/Presentation/Strings/es-ES/Resources.resw
@@ -255,6 +255,9 @@
   <data name="albumsViewFilterByFavoriteGenreMenu.Text" xml:space="preserve">
     <value>géneros favoritos</value>
   </data>
+  <data name="albumsViewFilterByAnniversary" xml:space="preserve">
+    <value>aniversarios</value>
+  </data>
   <data name="albumsViewFilterByNeverListened" xml:space="preserve">
     <value>nunca escuchó</value>
   </data>
@@ -846,6 +849,9 @@
   </data>
   <data name="filterneverlistened" xml:space="preserve">
     <value>Nunca escuché</value>
+  </data>
+  <data name="filteranniversary" xml:space="preserve">
+    <value>Aniversarios</value>
   </data>
   <data name="filterfavorite" xml:space="preserve">
     <value>Favoritos</value>

--- a/src/Presentation/Strings/fr-FR/Resources.resw
+++ b/src/Presentation/Strings/fr-FR/Resources.resw
@@ -372,6 +372,9 @@
   <data name="albumsViewFilterByFavoriteGenreMenu.Text" xml:space="preserve">
     <value>genres favoris</value>
   </data>
+  <data name="albumsViewFilterByAnniversary" xml:space="preserve">
+    <value>anniversaires</value>
+  </data>
   <data name="albumsViewFilterByNeverListened" xml:space="preserve">
     <value>jamais écoutés</value>
   </data>
@@ -962,6 +965,9 @@
   </data>
   <data name="filterneverlistened" xml:space="preserve">
     <value>Jamais écoutés</value>
+  </data>
+  <data name="filteranniversary" xml:space="preserve">
+    <value>Anniversaires</value>
   </data>
   <data name="filterfavorite" xml:space="preserve">
     <value>Favoris</value>

--- a/src/Presentation/Strings/uk-UA/Resources.resw
+++ b/src/Presentation/Strings/uk-UA/Resources.resw
@@ -313,6 +313,9 @@
   <data name="albumsViewFilterByFavoriteGenreMenu.Text" xml:space="preserve">
     <value>улюблені жанри</value>
   </data>
+  <data name="albumsViewFilterByAnniversary" xml:space="preserve">
+    <value>річниці</value>
+  </data>
   <data name="albumsViewFilterByNeverListened" xml:space="preserve">
     <value>ніколи не слухав</value>
   </data>
@@ -904,6 +907,9 @@
   </data>
   <data name="filterneverlistened" xml:space="preserve">
     <value>Ніколи не слухав (-ла)</value>
+  </data>
+  <data name="filteranniversary" xml:space="preserve">
+    <value>Річниці</value>
   </data>
   <data name="filterfavorite" xml:space="preserve">
     <value>Обране</value>

--- a/src/Presentation/ViewModels/Album/AlbumViewModel.cs
+++ b/src/Presentation/ViewModels/Album/AlbumViewModel.cs
@@ -66,6 +66,8 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
 
     public bool IsAlbumFavorite => Album.IsFavorite;
 
+    public DateTime? ReleaseDate => Album.ReleaseDate;
+
     [ObservableProperty]
     public partial Windows.UI.Color DominantColor { get; set; }
     private int _dominantColorCalculating = 0;

--- a/src/Presentation/ViewModels/Albums/Services/AlbumProvider.cs
+++ b/src/Presentation/ViewModels/Albums/Services/AlbumProvider.cs
@@ -34,14 +34,24 @@ public class AlbumProvider(AlbumsDataLoader dataLoader, AlbumsFilter filterServi
             filtered = filterService.FilterByTags(tagFilters, filtered);
 
         List<AlbumViewModel> filteredList = filtered.Cast<AlbumViewModel>().ToList();
-        List<AlbumsGroupCategoryViewModel> groups = groupService
-            .GetGroupedItems(groupBy, filteredList.Cast<IGroupableAlbum>().ToList())
-            .Select(g => new AlbumsGroupCategoryViewModel { Title = g.Title, Items = g.Items.Cast<AlbumViewModel>().ToList() })
-            .ToList();
+        List<AlbumsGroupCategoryViewModel> groups = filters.Contains(AlbumsFilter.KFilterByAnniversary)
+            ? BuildFlatGroup(filteredList)
+            : groupService
+                .GetGroupedItems(groupBy, filteredList.Cast<IGroupableAlbum>().ToList())
+                .Select(g => new AlbumsGroupCategoryViewModel { Title = g.Title, Items = g.Items.Cast<AlbumViewModel>().ToList() })
+                .ToList();
 
         bool isGroupingEnabled = groups.Count > 1 || !string.IsNullOrEmpty(groups.FirstOrDefault()?.Title ?? string.Empty);
 
         return new AlbumProviderResult(filteredList, groups, isGroupingEnabled);
+    }
+
+    private static List<AlbumsGroupCategoryViewModel> BuildFlatGroup(List<AlbumViewModel> albums)
+    {
+        if (albums.Count == 0)
+            return [];
+
+        return [new AlbumsGroupCategoryViewModel { Title = string.Empty, Items = [.. albums.OrderBy(a => a.Album.Name)] }];
     }
 
     public void Clear() => dataLoader.Clear();

--- a/src/Rok.Application/Services/Filters/AlbumsFilter.cs
+++ b/src/Rok.Application/Services/Filters/AlbumsFilter.cs
@@ -2,7 +2,7 @@
 
 namespace Rok.Application.Services.Filters;
 
-public class AlbumsFilter(IResourceService resourceLoader) : FilterService<IFilterableAlbum>(resourceLoader)
+public class AlbumsFilter(IResourceService resourceLoader, TimeProvider timeProvider) : FilterService<IFilterableAlbum>(resourceLoader)
 {
     public const string KFilterByAlbumFavorite = "ALBUMFAVORITE";
     public const string KFilterByArtistFavorite = "ARTISTFAVORITE";
@@ -12,6 +12,7 @@ public class AlbumsFilter(IResourceService resourceLoader) : FilterService<IFilt
     public const string KFilterByBestOf = "BESTOF";
     public const string KFilterByCompilation = "COMPILATION";
     public const string KFilterByAlbum = "ALBUM";
+    public const string KFilterByAnniversary = "ANNIVERSARY";
 
     protected override void RegisterFilterStrategies()
     {
@@ -23,6 +24,36 @@ public class AlbumsFilter(IResourceService resourceLoader) : FilterService<IFilt
         RegisterFilter(KFilterByBestOf, albums => albums.Where(a => a.IsBestOf));
         RegisterFilter(KFilterByCompilation, albums => albums.Where(a => a.IsCompilation));
         RegisterFilter(KFilterByAlbum, albums => albums.Where(a => !a.IsCompilation && !a.IsLive && !a.IsBestOf));
+        RegisterFilter(KFilterByAnniversary, albums =>
+        {
+            DateOnly today = DateOnly.FromDateTime(timeProvider.GetLocalNow().DateTime);
+            return albums.Where(a => IsAnniversary(a.ReleaseDate, today));
+        });
+    }
+
+    internal const int AnniversaryWindowDays = 3;
+
+    /// <summary>
+    /// Returns true when the album celebrates a release anniversary (one year or older)
+    /// within <see cref="AnniversaryWindowDays"/> days around <paramref name="today"/>.
+    /// </summary>
+    internal static bool IsAnniversary(DateTime? releaseDate, DateOnly today)
+    {
+        if (releaseDate is null)
+            return false;
+
+        DateOnly release = DateOnly.FromDateTime(releaseDate.Value);
+
+        for (int offset = -AnniversaryWindowDays; offset <= AnniversaryWindowDays; offset++)
+        {
+            DateOnly candidate = today.AddDays(offset);
+            int age = candidate.Year - release.Year;
+
+            if (age >= 1 && release.AddYears(age) == candidate)
+                return true;
+        }
+
+        return false;
     }
 
     public override string GetLabel(string filterBy)
@@ -37,6 +68,7 @@ public class AlbumsFilter(IResourceService resourceLoader) : FilterService<IFilt
             KFilterByBestOf => ResourceLoader.GetString("albumsViewFilterByBestof"),
             KFilterByCompilation => ResourceLoader.GetString("albumsViewFilterByCompilation"),
             KFilterByAlbum => ResourceLoader.GetString("albumsViewFilterByAlbum"),
+            KFilterByAnniversary => ResourceLoader.GetString("albumsViewFilterByAnniversary"),
             _ => ResourceLoader.GetString("albumsViewFilterNone"),
         };
     }

--- a/src/Rok.Application/Services/Filters/IFilterableAlbum.cs
+++ b/src/Rok.Application/Services/Filters/IFilterableAlbum.cs
@@ -8,4 +8,5 @@ public interface IFilterableAlbum : IFilterable
     bool IsLive { get; }
     bool IsBestOf { get; }
     bool IsCompilation { get; }
+    DateTime? ReleaseDate { get; }
 }

--- a/tests/UnitTests/Rok.ApplicationTests/Services/Filters/AlbumsFilterTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Services/Filters/AlbumsFilterTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Rok.Application.Interfaces;
 using Rok.Application.Services.Filters;
@@ -6,7 +7,8 @@ namespace Rok.ApplicationTests.Services.Filters;
 
 public class AlbumsFilterTests
 {
-    private static AlbumsFilter CreateFilter(IResourceService? resource = null) => new(resource ?? Mock.Of<IResourceService>());
+    private static AlbumsFilter CreateFilter(IResourceService? resource = null, TimeProvider? timeProvider = null)
+        => new(resource ?? Mock.Of<IResourceService>(), timeProvider ?? new FakeTimeProvider());
 
     private sealed class FakeAlbum : IFilterableAlbum
     {
@@ -19,6 +21,7 @@ public class AlbumsFilterTests
         public bool IsCompilation { get; set; }
         public int ListenCount { get; set; }
         public long? GenreId { get; set; }
+        public DateTime? ReleaseDate { get; set; }
         public List<string> Tags { get; set; } = new();
     }
 
@@ -147,6 +150,90 @@ public class AlbumsFilterTests
         Assert.Single(result);
     }
 
+    [Theory(DisplayName = "AlbumsFilter IsAnniversary should match anniversaries within the window and ignore recent or future releases")]
+    [InlineData(2020, 6, 15, true)]   // exact anniversary day
+    [InlineData(2020, 6, 18, true)]   // window upper edge (+3 days)
+    [InlineData(2020, 6, 12, true)]   // window lower edge (-3 days)
+    [InlineData(2020, 6, 19, false)]  // one day outside the window
+    [InlineData(2020, 6, 11, false)]  // one day outside the window
+    [InlineData(2025, 6, 16, true)]   // first anniversary falls tomorrow, inside the window
+    [InlineData(2026, 6, 15, false)]  // released today, no anniversary yet
+    [InlineData(2027, 1, 1, false)]   // future release date
+    public void IsAnniversary_ShouldMatchWindowAndIgnoreRecentOrFutureReleases(int year, int month, int day, bool expected)
+    {
+        // Arrange
+        DateTime releaseDate = new(year, month, day);
+        DateOnly today = new(2026, 6, 15);
+
+        // Act
+        bool result = AlbumsFilter.IsAnniversary(releaseDate, today);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact(DisplayName = "AlbumsFilter IsAnniversary with no release date should return false")]
+    public void IsAnniversary_WithNoReleaseDate_ShouldReturnFalse()
+    {
+        // Arrange
+        DateOnly today = new(2026, 6, 15);
+
+        // Act
+        bool result = AlbumsFilter.IsAnniversary(null, today);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact(DisplayName = "AlbumsFilter IsAnniversary with a leap day release should match february 28 on non leap years")]
+    public void IsAnniversary_WithLeapDayRelease_ShouldMatchFebruary28OnNonLeapYears()
+    {
+        // Arrange
+        DateTime releaseDate = new(2020, 2, 29);
+        DateOnly today = new(2026, 2, 28);
+
+        // Act
+        bool result = AlbumsFilter.IsAnniversary(releaseDate, today);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "AlbumsFilter IsAnniversary should match across a year boundary")]
+    public void IsAnniversary_ShouldMatchAcrossYearBoundary()
+    {
+        // Arrange
+        DateTime releaseDate = new(2020, 12, 31);
+        DateOnly today = new(2026, 1, 2);
+
+        // Act
+        bool result = AlbumsFilter.IsAnniversary(releaseDate, today);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "AlbumsFilter Filter by anniversary should keep only albums celebrating an anniversary")]
+    public void Filter_ByAnniversary_ShouldKeepOnlyAnniversaryAlbums()
+    {
+        // Arrange
+        FakeTimeProvider timeProvider = new(new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        AlbumsFilter sut = CreateFilter(timeProvider: timeProvider);
+        List<IFilterableAlbum> input = new()
+        {
+            new FakeAlbum { ReleaseDate = new DateTime(2016, 6, 15) },
+            new FakeAlbum { ReleaseDate = new DateTime(2016, 9, 1) },
+            new FakeAlbum { ReleaseDate = null }
+        };
+
+        // Act
+        List<IFilterableAlbum> result = sut.Filter(AlbumsFilter.KFilterByAnniversary, input).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(new DateTime(2016, 6, 15), result[0].ReleaseDate);
+    }
+
     [Fact(DisplayName = "AlbumsFilter Filter with unknown key should return all items unchanged")]
     public void Filter_WithUnknownKey_ShouldReturnAllItemsUnchanged()
     {
@@ -170,6 +257,7 @@ public class AlbumsFilterTests
     [InlineData(AlbumsFilter.KFilterByBestOf, "albumsViewFilterByBestof")]
     [InlineData(AlbumsFilter.KFilterByCompilation, "albumsViewFilterByCompilation")]
     [InlineData(AlbumsFilter.KFilterByAlbum, "albumsViewFilterByAlbum")]
+    [InlineData(AlbumsFilter.KFilterByAnniversary, "albumsViewFilterByAnniversary")]
     [InlineData("UNKNOWN", "albumsViewFilterNone")]
     public void GetLabel_ShouldRequestExpectedResourceKey(string filterBy, string expectedResourceKey)
     {

--- a/tests/UnitTests/Rok.PresentationTests/ViewModels/Albums/Services/AlbumProviderTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/ViewModels/Albums/Services/AlbumProviderTests.cs
@@ -21,7 +21,7 @@ public class AlbumProviderTests
     private AlbumProvider BuildService()
     {
         AlbumsDataLoader loader = new(_mediator, _vmFactory.Object, NullLogger<AlbumsDataLoader>.Instance);
-        AlbumsFilter filter = new(_resource.Object);
+        AlbumsFilter filter = new(_resource.Object, TimeProvider.System);
         AlbumsGroupCategory grouper = new(_resource.Object);
         return new AlbumProvider(loader, filter, grouper);
     }


### PR DESCRIPTION
Adds an "Anniversaries" option to the type filter menu that keeps albums whose release date celebrates an anniversary (one year or older) within a +/-3 days window around today. Leap-day releases match February 28 on non-leap years thanks to date arithmetic. When the filter is active the list is shown flat (no grouping) sorted by album name.