### PR TITLE
fix(playlists): dispose PlaylistsPage when navigating away

### DIFF
--- a/src/Presentation/Pages/PlaylistsPage.xaml.cs
+++ b/src/Presentation/Pages/PlaylistsPage.xaml.cs
@@ -37,6 +37,13 @@ public sealed partial class PlaylistsPage : Page, IDisposable
         }
     }
 
+    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+    {
+        Dispose();
+
+        base.OnNavigatingFrom(e);
+    }
+
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(PlaylistsViewModel.IsGridView))


### PR DESCRIPTION
Dispose() was never invoked because the page had no OnNavigatingFrom, so every visit leaked a page instance through its PropertyChanged subscription on the singleton ViewModel. Wire it up like the other list pages do.