### PR TITLE
fix(navigation): restore menu selection when navigating back to a roo…

### DIFF
--- a/src/Presentation/MainWindow.xaml.cs
+++ b/src/Presentation/MainWindow.xaml.cs
@@ -383,20 +383,16 @@ public sealed partial class MainWindow : Window
             return;
         }
 
-        // Ensure that the navigation menu selection is cleared if the navigated page is not one of the expected pages.
-        Type[] menuPages =
-        [
-            typeof(Pages.ArtistsPage),
-            typeof(Pages.AlbumsPage),
-            typeof(Pages.TracksPage),
-            typeof(Pages.PlaylistsPage),
-            typeof(Pages.InsightsPage),
-            typeof(Pages.OptionsPage),
-            typeof(Pages.ListeningPage)
-        ];
+        // Keep the menu selection in sync with the displayed page (back navigation included);
+        // pages without a menu entry clear the selection.
+        navMenu.SelectedItem = FindMenuItemForPage(e.Content.GetType());
+    }
 
-        if (!menuPages.Contains(e.Content.GetType()))
-            navMenu.SelectedItem = null;
+    private NavigationViewItem? FindMenuItemForPage(Type pageType)
+    {
+        return navMenu.MenuItems
+            .OfType<NavigationViewItem>()
+            .FirstOrDefault(item => item.Tag is string tag && pageType.FullName == "Rok.Pages." + tag + "Page");
     }
 
 


### PR DESCRIPTION
…t page

ContentFrame_Navigated only cleared the selection for non-menu pages, so going back from a detail page left the NavigationView with no item highlighted. Resolve the menu item from the displayed page type (same Tag convention as ItemInvoked) and keep the selection in sync on every navigation, back included.