### PR TITLE
feat: enrichissement des métadonnées ID3 (colonnes étendues, paroles embarquées, outil de maj)

### DIFF
--- a/Rok.slnx
+++ b/Rok.slnx
@@ -37,4 +37,11 @@
   <Project Path="src/Rok.Import/Rok.Import.csproj" Id="60b6b0db-da95-4e34-8575-ecc901ce61fe" />
   <Project Path="src/Rok.Infrastructure/Rok.Infrastructure.csproj" Id="4e901456-0119-4ead-a5a9-aa09f5a2e145" />
   <Project Path="src/Rok.Shared/Rok.Shared.csproj" Id="ed68b8fa-0ff7-4c55-8fa6-ed5241eb3aab" />
+  <Folder Name="/tools/">
+    <Project Path="tools/Rok.MetadataTool/Rok.MetadataTool.csproj">
+      <Platform Solution="*|ARM64" Project="x64" />
+      <Platform Solution="*|x64" Project="x64" />
+      <Platform Solution="*|x86" Project="x64" />
+    </Project>
+  </Folder>
 </Solution>

--- a/src/Rok.Application/Tag/TrackFile.cs
+++ b/src/Rok.Application/Tag/TrackFile.cs
@@ -59,4 +59,30 @@ public class TrackFile
     public string MusicbrainzTrackID { get; set; } = string.Empty;
 
     public string Lyrics { get; set; } = string.Empty;
+
+    public int? Disc { get; set; }
+
+    public int? DiscCount { get; set; }
+
+    public int? Bpm { get; set; }
+
+    public string Composers { get; set; } = string.Empty;
+
+    public int SampleRate { get; set; }
+
+    public int BitsPerSample { get; set; }
+
+    public int Channels { get; set; }
+
+    public double? ReplayGainTrackGain { get; set; }
+
+    public double? ReplayGainTrackPeak { get; set; }
+
+    public double? ReplayGainAlbumGain { get; set; }
+
+    public double? ReplayGainAlbumPeak { get; set; }
+
+    public string MusicBrainzReleaseType { get; set; } = string.Empty;
+
+    public string MusicBrainzReleaseCountry { get; set; } = string.Empty;
 }

--- a/src/Rok.Domain/Entities/AlbumEntity.cs
+++ b/src/Rok.Domain/Entities/AlbumEntity.cs
@@ -76,6 +76,16 @@ public class AlbumEntity : BaseEntity, IAlbumEntity
 
     public bool IsLock { get; set; }
 
+    public int? DiscCount { get; set; }
+
+    public double? ReplayGainAlbumGain { get; set; }
+
+    public double? ReplayGainAlbumPeak { get; set; }
+
+    public string? MusicBrainzReleaseType { get; set; }
+
+    public string? MusicBrainzReleaseCountry { get; set; }
+
     /* -- */
 
     [Write(false)]

--- a/src/Rok.Domain/Entities/TrackEntity.cs
+++ b/src/Rok.Domain/Entities/TrackEntity.cs
@@ -42,6 +42,22 @@ public class TrackEntity : BaseEntity
 
     public DateTime? GetLyricsLastAttempt { get; set; }
 
+    public int? Disc { get; set; }
+
+    public int? Bpm { get; set; }
+
+    public string? Composers { get; set; }
+
+    public int SampleRate { get; set; }
+
+    public int BitsPerSample { get; set; }
+
+    public int Channels { get; set; }
+
+    public double? ReplayGainTrackGain { get; set; }
+
+    public double? ReplayGainTrackPeak { get; set; }
+
 
     [Write(false)]
     public string AlbumName { get; set; } = string.Empty;

--- a/src/Rok.Import/AlbumImport.cs
+++ b/src/Rok.Import/AlbumImport.cs
@@ -4,6 +4,7 @@ using Rok.Application.Interfaces.Repositories;
 using Rok.Application.Tag;
 using Rok.Domain.Entities;
 using Rok.Import.Models;
+using Rok.Import.Services;
 using Rok.Shared.Extensions;
 
 namespace Rok.Import;
@@ -112,14 +113,10 @@ public class AlbumImport(IAlbumRepository _albumRepository, TimeProvider _timePr
             IsBestOf = isBestOf,
             IsLive = isLive,
             AlbumPath = Path.GetDirectoryName(track.FullPath)!,
-            MusicBrainzID = track.MusicbrainzAlbumID,
-            DiscCount = track.DiscCount,
-            ReplayGainAlbumGain = track.ReplayGainAlbumGain,
-            ReplayGainAlbumPeak = track.ReplayGainAlbumPeak,
-            MusicBrainzReleaseType = string.IsNullOrEmpty(track.MusicBrainzReleaseType) ? null : track.MusicBrainzReleaseType,
-            MusicBrainzReleaseCountry = string.IsNullOrEmpty(track.MusicBrainzReleaseCountry) ? null : track.MusicBrainzReleaseCountry,
             CreatDate = _timeProvider.GetLocalNow().DateTime
         };
+
+        TagMetadataMapper.ApplyAlbumMetadata(album, track, MetadataWritePolicy.Mirror);
 
         long id = await _albumRepository.AddAsync(album, RepositoryConnectionKind.Background);
 

--- a/src/Rok.Import/AlbumImport.cs
+++ b/src/Rok.Import/AlbumImport.cs
@@ -113,6 +113,11 @@ public class AlbumImport(IAlbumRepository _albumRepository, TimeProvider _timePr
             IsLive = isLive,
             AlbumPath = Path.GetDirectoryName(track.FullPath)!,
             MusicBrainzID = track.MusicbrainzAlbumID,
+            DiscCount = track.DiscCount,
+            ReplayGainAlbumGain = track.ReplayGainAlbumGain,
+            ReplayGainAlbumPeak = track.ReplayGainAlbumPeak,
+            MusicBrainzReleaseType = string.IsNullOrEmpty(track.MusicBrainzReleaseType) ? null : track.MusicBrainzReleaseType,
+            MusicBrainzReleaseCountry = string.IsNullOrEmpty(track.MusicBrainzReleaseCountry) ? null : track.MusicBrainzReleaseCountry,
             CreatDate = _timeProvider.GetLocalNow().DateTime
         };
 

--- a/src/Rok.Import/DependencyInjection.cs
+++ b/src/Rok.Import/DependencyInjection.cs
@@ -28,6 +28,7 @@ public static class DependencyInjection
         services.AddScoped<TrackFileProcessor>();
         services.AddScoped<TrackMetadataService>();
         services.AddScoped<EmbeddedLyricsImporter>();
+        services.AddScoped<LibraryMetadataRefresher>();
         services.AddScoped<FolderImportProcessor>();
         services.AddScoped<IImport, ImportService>();
 

--- a/src/Rok.Import/DependencyInjection.cs
+++ b/src/Rok.Import/DependencyInjection.cs
@@ -27,6 +27,7 @@ public static class DependencyInjection
         services.AddScoped<FileSystemService>();
         services.AddScoped<TrackFileProcessor>();
         services.AddScoped<TrackMetadataService>();
+        services.AddScoped<EmbeddedLyricsImporter>();
         services.AddScoped<FolderImportProcessor>();
         services.AddScoped<IImport, ImportService>();
 

--- a/src/Rok.Import/Services/EmbeddedLyricsImporter.cs
+++ b/src/Rok.Import/Services/EmbeddedLyricsImporter.cs
@@ -19,18 +19,32 @@ public partial class EmbeddedLyricsImporter(ILyricsService lyricsService, ILogge
     [GeneratedRegex(@"\[\d{1,2}:\d{2}", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
     private static partial Regex SynchronizedTimestampRegex();
 
-    public async Task ExtractAsync(TrackFile file, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Writes a lyrics sidecar from the embedded tag when appropriate.
+    /// </summary>
+    /// <returns><see langword="true"/> when a sidecar was written, <see langword="false"/> otherwise.</returns>
+    /// <summary>
+    /// Indicates whether <see cref="ExtractAsync"/> would write a sidecar for this file
+    /// (embedded lyrics present and no <c>.lrc</c>/<c>.txt</c> sidecar yet). Lets callers
+    /// report a planned write without performing it.
+    /// </summary>
+    public bool WouldWriteSidecar(TrackFile file)
     {
         Guard.NotNull(file);
 
         if (string.IsNullOrWhiteSpace(file.Lyrics))
-            return;
+            return false;
 
         if (string.IsNullOrEmpty(file.FullPath))
-            return;
+            return false;
 
-        if (lyricsService.CheckLyricsFileExists(file.FullPath) != ELyricsType.None)
-            return;
+        return lyricsService.CheckLyricsFileExists(file.FullPath) == ELyricsType.None;
+    }
+
+    public async Task<bool> ExtractAsync(TrackFile file, CancellationToken cancellationToken = default)
+    {
+        if (!WouldWriteSidecar(file))
+            return false;
 
         bool isSynchronized = SynchronizedTimestampRegex().IsMatch(file.Lyrics);
 
@@ -48,10 +62,12 @@ public partial class EmbeddedLyricsImporter(ILyricsService lyricsService, ILogge
             });
 
             logger.LogTrace("Embedded lyrics extracted to {File}", fileName);
+            return true;
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to write embedded lyrics sidecar for '{File}'", file.FullPath);
+            return false;
         }
     }
 }

--- a/src/Rok.Import/Services/EmbeddedLyricsImporter.cs
+++ b/src/Rok.Import/Services/EmbeddedLyricsImporter.cs
@@ -1,0 +1,57 @@
+using System.Text.RegularExpressions;
+using CleanArch.DevKit.Guards;
+using Microsoft.Extensions.Logging;
+using Rok.Application.Dto.Lyrics;
+using Rok.Application.Interfaces;
+using Rok.Application.Tag;
+
+namespace Rok.Import.Services;
+
+/// <summary>
+/// Writes the lyrics embedded in an audio tag to a sidecar file during import:
+/// a <c>.lrc</c> file when the content carries <c>[mm:ss]</c> timestamps, a
+/// <c>.txt</c> file otherwise. The sidecar is written only when neither a
+/// <c>.lrc</c> nor a <c>.txt</c> file already exists for the track, so that
+/// API-fetched or hand-curated lyrics are never overwritten.
+/// </summary>
+public partial class EmbeddedLyricsImporter(ILyricsService lyricsService, ILogger<EmbeddedLyricsImporter> logger)
+{
+    [GeneratedRegex(@"\[\d{1,2}:\d{2}", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex SynchronizedTimestampRegex();
+
+    public async Task ExtractAsync(TrackFile file, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(file);
+
+        if (string.IsNullOrWhiteSpace(file.Lyrics))
+            return;
+
+        if (string.IsNullOrEmpty(file.FullPath))
+            return;
+
+        if (lyricsService.CheckLyricsFileExists(file.FullPath) != ELyricsType.None)
+            return;
+
+        bool isSynchronized = SynchronizedTimestampRegex().IsMatch(file.Lyrics);
+
+        string fileName = isSynchronized
+            ? lyricsService.GetSynchronizedLyricsFileName(file.FullPath)
+            : lyricsService.GetPlainLyricsFileName(file.FullPath);
+
+        try
+        {
+            await lyricsService.SaveLyricsAsync(new LyricsModel
+            {
+                File = fileName,
+                PlainLyrics = file.Lyrics,
+                LyricsType = isSynchronized ? ELyricsType.Synchronized : ELyricsType.Plain
+            });
+
+            logger.LogTrace("Embedded lyrics extracted to {File}", fileName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to write embedded lyrics sidecar for '{File}'", file.FullPath);
+        }
+    }
+}

--- a/src/Rok.Import/Services/EmbeddedLyricsImporter.cs
+++ b/src/Rok.Import/Services/EmbeddedLyricsImporter.cs
@@ -16,13 +16,9 @@ namespace Rok.Import.Services;
 /// </summary>
 public partial class EmbeddedLyricsImporter(ILyricsService lyricsService, ILogger<EmbeddedLyricsImporter> logger)
 {
-    [GeneratedRegex(@"\[\d{1,2}:\d{2}", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
+    [GeneratedRegex(@"^\s*\[\d{1,2}:\d{2}", RegexOptions.Compiled | RegexOptions.Multiline, matchTimeoutMilliseconds: 1000)]
     private static partial Regex SynchronizedTimestampRegex();
 
-    /// <summary>
-    /// Writes a lyrics sidecar from the embedded tag when appropriate.
-    /// </summary>
-    /// <returns><see langword="true"/> when a sidecar was written, <see langword="false"/> otherwise.</returns>
     /// <summary>
     /// Indicates whether <see cref="ExtractAsync"/> would write a sidecar for this file
     /// (embedded lyrics present and no <c>.lrc</c>/<c>.txt</c> sidecar yet). Lets callers
@@ -41,6 +37,11 @@ public partial class EmbeddedLyricsImporter(ILyricsService lyricsService, ILogge
         return lyricsService.CheckLyricsFileExists(file.FullPath) == ELyricsType.None;
     }
 
+    /// <summary>
+    /// Writes a lyrics sidecar from the embedded tag when appropriate (see <see cref="WouldWriteSidecar"/>):
+    /// a <c>.lrc</c> when the content carries <c>[mm:ss]</c> timestamps, a <c>.txt</c> otherwise.
+    /// </summary>
+    /// <returns><see langword="true"/> when a sidecar was written, <see langword="false"/> otherwise.</returns>
     public async Task<bool> ExtractAsync(TrackFile file, CancellationToken cancellationToken = default)
     {
         if (!WouldWriteSidecar(file))

--- a/src/Rok.Import/Services/FolderImportProcessor.cs
+++ b/src/Rok.Import/Services/FolderImportProcessor.cs
@@ -19,6 +19,7 @@ public class FolderImportProcessor(
     FileSystemService fileSystemService,
     TrackFileProcessor trackFileProcessor,
     TrackMetadataService metadataService,
+    EmbeddedLyricsImporter embeddedLyricsImporter,
     ImportTrackingService trackingService,
     ITagService tagService,
     ImportMessageThrottler messageThrottler,
@@ -33,6 +34,7 @@ public class FolderImportProcessor(
     private readonly FileSystemService _fileSystemService = Guard.NotNull(fileSystemService);
     private readonly TrackFileProcessor _trackFileProcessor = Guard.NotNull(trackFileProcessor);
     private readonly TrackMetadataService _metadataService = Guard.NotNull(metadataService);
+    private readonly EmbeddedLyricsImporter _embeddedLyricsImporter = Guard.NotNull(embeddedLyricsImporter);
     private readonly ImportTrackingService _trackingService = Guard.NotNull(trackingService);
     private readonly ITagService _tagService = Guard.NotNull(tagService);
     private readonly ImportMessageThrottler _messageThrottler = Guard.NotNull(messageThrottler);
@@ -88,6 +90,8 @@ public class FolderImportProcessor(
         UpdateStatisticsForTrack(track);
 
         await UpdateTrackAsync(track, statistics).ConfigureAwait(false);
+
+        await _embeddedLyricsImporter.ExtractAsync(file, cancellationToken).ConfigureAwait(false);
     }
 
     private long? DetermineGenreId(ArtistCacheItem? artist, GenreCacheItem? genre)

--- a/src/Rok.Import/Services/LibraryMetadataRefresher.cs
+++ b/src/Rok.Import/Services/LibraryMetadataRefresher.cs
@@ -27,6 +27,13 @@ public sealed record LibraryMetadataRefreshReport
 }
 
 /// <summary>
+/// Progress emitted by a <see cref="LibraryMetadataRefresher"/> run. <paramref name="Phase"/>
+/// is the current stage ("Tracks" or "Albums"), <paramref name="Processed"/> of
+/// <paramref name="Total"/> items done.
+/// </summary>
+public sealed record LibraryMetadataRefreshProgress(string Phase, int Processed, int Total);
+
+/// <summary>
 /// Re-reads the audio tag of every track already in the database and refreshes the
 /// extended metadata columns introduced by the import-enrichment work, plus the album
 /// MusicBrainz id, and replays the embedded-lyrics sidecar extraction. Iterates over
@@ -47,7 +54,10 @@ public class LibraryMetadataRefresher(
     IFileSystem fileSystem,
     ILogger<LibraryMetadataRefresher> logger)
 {
-    public async Task<LibraryMetadataRefreshReport> RefreshAsync(bool apply, CancellationToken cancellationToken = default)
+    public async Task<LibraryMetadataRefreshReport> RefreshAsync(
+        bool apply,
+        IProgress<LibraryMetadataRefreshProgress>? progress = null,
+        CancellationToken cancellationToken = default)
     {
         Dictionary<long, AlbumEntity> albums = (await albumRepository.GetAllAsync(RepositoryConnectionKind.Background))
             .ToDictionary(album => album.Id);
@@ -60,12 +70,17 @@ public class LibraryMetadataRefresher(
         int lyricsCreated = 0;
         int lyricsFailed = 0;
 
-        IEnumerable<TrackEntity> tracks = await trackRepository.GetAllAsync(RepositoryConnectionKind.Background);
+        List<TrackEntity> tracks = (await trackRepository.GetAllAsync(RepositoryConnectionKind.Background)).ToList();
+        int total = tracks.Count;
+        int reportEvery = Math.Max(1, total / 100);
 
         foreach (TrackEntity track in tracks)
         {
             cancellationToken.ThrowIfCancellationRequested();
             scanned++;
+
+            if (progress is not null && (scanned % reportEvery == 0 || scanned == total))
+                progress.Report(new LibraryMetadataRefreshProgress("Tracks", scanned, total));
 
             if (string.IsNullOrEmpty(track.MusicFile) || !fileSystem.FileExists(track.MusicFile))
             {
@@ -109,7 +124,7 @@ public class LibraryMetadataRefresher(
             }
         }
 
-        int albumsUpdated = await RefreshAlbumsAsync(albums, albumTagAggregates, apply);
+        int albumsUpdated = await RefreshAlbumsAsync(albums, albumTagAggregates, apply, progress);
 
         return new LibraryMetadataRefreshReport
         {
@@ -126,12 +141,21 @@ public class LibraryMetadataRefresher(
     private async Task<int> RefreshAlbumsAsync(
         Dictionary<long, AlbumEntity> albums,
         Dictionary<long, TrackFile> aggregates,
-        bool apply)
+        bool apply,
+        IProgress<LibraryMetadataRefreshProgress>? progress)
     {
         int updated = 0;
+        int processed = 0;
+        int total = aggregates.Count;
+        int reportEvery = Math.Max(1, total / 100);
 
         foreach ((long albumId, TrackFile aggregate) in aggregates)
         {
+            processed++;
+
+            if (progress is not null && (processed % reportEvery == 0 || processed == total))
+                progress.Report(new LibraryMetadataRefreshProgress("Albums", processed, total));
+
             if (!albums.TryGetValue(albumId, out AlbumEntity? album))
                 continue;
 

--- a/src/Rok.Import/Services/LibraryMetadataRefresher.cs
+++ b/src/Rok.Import/Services/LibraryMetadataRefresher.cs
@@ -1,4 +1,3 @@
-using CleanArch.DevKit.Guards;
 using Microsoft.Extensions.Logging;
 using Rok.Application.Interfaces;
 using Rok.Application.Interfaces.Repositories;
@@ -23,18 +22,22 @@ public sealed record LibraryMetadataRefreshReport
     public int AlbumsUpdated { get; init; }
 
     public int LyricsSidecarsCreated { get; init; }
+
+    public int LyricsSidecarsFailed { get; init; }
 }
 
 /// <summary>
 /// Re-reads the audio tag of every track already in the database and refreshes the
 /// extended metadata columns introduced by the import-enrichment work, plus the album
-/// MusicBrainz id. Iterates over database tracks (never discovers new files) and also
-/// replays the embedded-lyrics sidecar extraction.
+/// MusicBrainz id, and replays the embedded-lyrics sidecar extraction. Iterates over
+/// database tracks only (never discovers new files).
 ///
-/// Write policy: a value is written only when the tag actually provides one
-/// (non-null / non-empty / non-zero); an existing database value is never blanked.
-/// When <c>apply</c> is <see langword="false"/> the run is a dry-run that only counts
-/// what would change.
+/// Write policy (<see cref="MetadataWritePolicy.FillFromTag"/>): a value is written only
+/// when the tag actually provides one; an existing database value is never blanked, but a
+/// present-and-different tag value does overwrite (the tag is authoritative). Album-level
+/// fields are aggregated across all of the album's tracks (first non-empty value wins) so a
+/// gap on one track does not leave the album empty. When <c>apply</c> is <see langword="false"/>
+/// the run is a dry-run that only counts what would change.
 /// </summary>
 public class LibraryMetadataRefresher(
     ITrackRepository trackRepository,
@@ -46,13 +49,16 @@ public class LibraryMetadataRefresher(
 {
     public async Task<LibraryMetadataRefreshReport> RefreshAsync(bool apply, CancellationToken cancellationToken = default)
     {
+        Dictionary<long, AlbumEntity> albums = (await albumRepository.GetAllAsync(RepositoryConnectionKind.Background))
+            .ToDictionary(album => album.Id);
+
+        Dictionary<long, TrackFile> albumTagAggregates = [];
+
         int scanned = 0;
         int missing = 0;
         int tracksUpdated = 0;
-        int albumsUpdated = 0;
         int lyricsCreated = 0;
-
-        HashSet<long> processedAlbums = [];
+        int lyricsFailed = 0;
 
         IEnumerable<TrackEntity> tracks = await trackRepository.GetAllAsync(RepositoryConnectionKind.Background);
 
@@ -79,7 +85,7 @@ public class LibraryMetadataRefresher(
                 continue;
             }
 
-            if (ApplyTrackChanges(track, file))
+            if (TagMetadataMapper.ApplyTrackMetadata(track, file, MetadataWritePolicy.FillFromTag))
             {
                 tracksUpdated++;
 
@@ -87,12 +93,23 @@ public class LibraryMetadataRefresher(
                     await trackRepository.UpdateAsync(track, RepositoryConnectionKind.Background);
             }
 
-            if (track.AlbumId is long albumId && processedAlbums.Add(albumId) && await RefreshAlbumAsync(albumId, file, apply))
-                albumsUpdated++;
+            if (track.AlbumId is long albumId && albums.ContainsKey(albumId))
+                AccumulateAlbumTags(GetOrCreateAggregate(albumTagAggregates, albumId), file);
 
-            if (apply ? await embeddedLyricsImporter.ExtractAsync(file, cancellationToken) : embeddedLyricsImporter.WouldWriteSidecar(file))
+            if (apply)
+            {
+                if (await embeddedLyricsImporter.ExtractAsync(file, cancellationToken))
+                    lyricsCreated++;
+                else if (embeddedLyricsImporter.WouldWriteSidecar(file))
+                    lyricsFailed++;
+            }
+            else if (embeddedLyricsImporter.WouldWriteSidecar(file))
+            {
                 lyricsCreated++;
+            }
         }
+
+        int albumsUpdated = await RefreshAlbumsAsync(albums, albumTagAggregates, apply);
 
         return new LibraryMetadataRefreshReport
         {
@@ -101,81 +118,63 @@ public class LibraryMetadataRefresher(
             FilesMissing = missing,
             TracksUpdated = tracksUpdated,
             AlbumsUpdated = albumsUpdated,
-            LyricsSidecarsCreated = lyricsCreated
+            LyricsSidecarsCreated = lyricsCreated,
+            LyricsSidecarsFailed = lyricsFailed
         };
     }
 
-    private async Task<bool> RefreshAlbumAsync(long albumId, TrackFile file, bool apply)
+    private async Task<int> RefreshAlbumsAsync(
+        Dictionary<long, AlbumEntity> albums,
+        Dictionary<long, TrackFile> aggregates,
+        bool apply)
     {
-        AlbumEntity? album = await albumRepository.GetByIdAsync(albumId, RepositoryConnectionKind.Background);
+        int updated = 0;
 
-        if (album is null)
-            return false;
+        foreach ((long albumId, TrackFile aggregate) in aggregates)
+        {
+            if (!albums.TryGetValue(albumId, out AlbumEntity? album))
+                continue;
 
-        bool changed = false;
+            if (!TagMetadataMapper.ApplyAlbumMetadata(album, aggregate, MetadataWritePolicy.FillFromTag))
+                continue;
 
-        changed |= SetNullableInt(file.DiscCount, album.DiscCount, value => album.DiscCount = value);
-        changed |= SetNullableDouble(file.ReplayGainAlbumGain, album.ReplayGainAlbumGain, value => album.ReplayGainAlbumGain = value);
-        changed |= SetNullableDouble(file.ReplayGainAlbumPeak, album.ReplayGainAlbumPeak, value => album.ReplayGainAlbumPeak = value);
-        changed |= SetText(file.MusicBrainzReleaseType, album.MusicBrainzReleaseType, value => album.MusicBrainzReleaseType = value);
-        changed |= SetText(file.MusicBrainzReleaseCountry, album.MusicBrainzReleaseCountry, value => album.MusicBrainzReleaseCountry = value);
-        changed |= SetText(file.MusicbrainzAlbumID, album.MusicBrainzID, value => album.MusicBrainzID = value);
+            updated++;
 
-        if (changed && apply)
-            await albumRepository.UpdateAsync(album, RepositoryConnectionKind.Background);
+            if (apply)
+                await albumRepository.UpdateAsync(album, RepositoryConnectionKind.Background);
+        }
 
-        return changed;
+        return updated;
     }
 
-    private static bool ApplyTrackChanges(TrackEntity track, TrackFile file)
+    private static TrackFile GetOrCreateAggregate(Dictionary<long, TrackFile> aggregates, long albumId)
     {
-        bool changed = false;
+        if (!aggregates.TryGetValue(albumId, out TrackFile? aggregate))
+        {
+            aggregate = new TrackFile();
+            aggregates[albumId] = aggregate;
+        }
 
-        changed |= SetNullableInt(file.Disc, track.Disc, value => track.Disc = value);
-        changed |= SetNullableInt(file.Bpm, track.Bpm, value => track.Bpm = value);
-        changed |= SetText(file.Composers, track.Composers, value => track.Composers = value);
-        changed |= SetPositiveInt(file.SampleRate, track.SampleRate, value => track.SampleRate = value);
-        changed |= SetPositiveInt(file.BitsPerSample, track.BitsPerSample, value => track.BitsPerSample = value);
-        changed |= SetPositiveInt(file.Channels, track.Channels, value => track.Channels = value);
-        changed |= SetNullableDouble(file.ReplayGainTrackGain, track.ReplayGainTrackGain, value => track.ReplayGainTrackGain = value);
-        changed |= SetNullableDouble(file.ReplayGainTrackPeak, track.ReplayGainTrackPeak, value => track.ReplayGainTrackPeak = value);
-
-        return changed;
+        return aggregate;
     }
 
-    private static bool SetNullableInt(int? tagValue, int? current, Action<int?> setter)
+    /// <summary>
+    /// Folds one track's album-level tag values into the album aggregate, keeping the first
+    /// non-empty value seen for each field (so a later track never overwrites an earlier value).
+    /// </summary>
+    private static void AccumulateAlbumTags(TrackFile aggregate, TrackFile file)
     {
-        if (!tagValue.HasValue || tagValue == current)
-            return false;
+        aggregate.DiscCount ??= file.DiscCount;
+        aggregate.ReplayGainAlbumGain ??= file.ReplayGainAlbumGain;
+        aggregate.ReplayGainAlbumPeak ??= file.ReplayGainAlbumPeak;
 
-        setter(tagValue);
-        return true;
-    }
+        if (string.IsNullOrEmpty(aggregate.MusicBrainzReleaseType))
+            aggregate.MusicBrainzReleaseType = file.MusicBrainzReleaseType;
 
-    private static bool SetPositiveInt(int tagValue, int current, Action<int> setter)
-    {
-        if (tagValue <= 0 || tagValue == current)
-            return false;
+        if (string.IsNullOrEmpty(aggregate.MusicBrainzReleaseCountry))
+            aggregate.MusicBrainzReleaseCountry = file.MusicBrainzReleaseCountry;
 
-        setter(tagValue);
-        return true;
-    }
-
-    private static bool SetNullableDouble(double? tagValue, double? current, Action<double?> setter)
-    {
-        if (!tagValue.HasValue || tagValue == current)
-            return false;
-
-        setter(tagValue);
-        return true;
-    }
-
-    private static bool SetText(string? tagValue, string? current, Action<string?> setter)
-    {
-        if (string.IsNullOrEmpty(tagValue) || tagValue == current)
-            return false;
-
-        setter(tagValue);
-        return true;
+        if (string.IsNullOrEmpty(aggregate.MusicbrainzAlbumID))
+            aggregate.MusicbrainzAlbumID = file.MusicbrainzAlbumID;
     }
 }

--- a/src/Rok.Import/Services/LibraryMetadataRefresher.cs
+++ b/src/Rok.Import/Services/LibraryMetadataRefresher.cs
@@ -1,0 +1,181 @@
+using CleanArch.DevKit.Guards;
+using Microsoft.Extensions.Logging;
+using Rok.Application.Interfaces;
+using Rok.Application.Interfaces.Repositories;
+using Rok.Application.Tag;
+using Rok.Domain.Entities;
+
+namespace Rok.Import.Services;
+
+/// <summary>
+/// Outcome of a <see cref="LibraryMetadataRefresher"/> run.
+/// </summary>
+public sealed record LibraryMetadataRefreshReport
+{
+    public bool Applied { get; init; }
+
+    public int TracksScanned { get; init; }
+
+    public int FilesMissing { get; init; }
+
+    public int TracksUpdated { get; init; }
+
+    public int AlbumsUpdated { get; init; }
+
+    public int LyricsSidecarsCreated { get; init; }
+}
+
+/// <summary>
+/// Re-reads the audio tag of every track already in the database and refreshes the
+/// extended metadata columns introduced by the import-enrichment work, plus the album
+/// MusicBrainz id. Iterates over database tracks (never discovers new files) and also
+/// replays the embedded-lyrics sidecar extraction.
+///
+/// Write policy: a value is written only when the tag actually provides one
+/// (non-null / non-empty / non-zero); an existing database value is never blanked.
+/// When <c>apply</c> is <see langword="false"/> the run is a dry-run that only counts
+/// what would change.
+/// </summary>
+public class LibraryMetadataRefresher(
+    ITrackRepository trackRepository,
+    IAlbumRepository albumRepository,
+    ITagService tagService,
+    EmbeddedLyricsImporter embeddedLyricsImporter,
+    IFileSystem fileSystem,
+    ILogger<LibraryMetadataRefresher> logger)
+{
+    public async Task<LibraryMetadataRefreshReport> RefreshAsync(bool apply, CancellationToken cancellationToken = default)
+    {
+        int scanned = 0;
+        int missing = 0;
+        int tracksUpdated = 0;
+        int albumsUpdated = 0;
+        int lyricsCreated = 0;
+
+        HashSet<long> processedAlbums = [];
+
+        IEnumerable<TrackEntity> tracks = await trackRepository.GetAllAsync(RepositoryConnectionKind.Background);
+
+        foreach (TrackEntity track in tracks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            scanned++;
+
+            if (string.IsNullOrEmpty(track.MusicFile) || !fileSystem.FileExists(track.MusicFile))
+            {
+                missing++;
+                continue;
+            }
+
+            TrackFile file = new() { FullPath = track.MusicFile };
+
+            try
+            {
+                tagService.FillProperties(track.MusicFile, file);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to read tags from '{File}' - skipped", track.MusicFile);
+                continue;
+            }
+
+            if (ApplyTrackChanges(track, file))
+            {
+                tracksUpdated++;
+
+                if (apply)
+                    await trackRepository.UpdateAsync(track, RepositoryConnectionKind.Background);
+            }
+
+            if (track.AlbumId is long albumId && processedAlbums.Add(albumId) && await RefreshAlbumAsync(albumId, file, apply))
+                albumsUpdated++;
+
+            if (apply ? await embeddedLyricsImporter.ExtractAsync(file, cancellationToken) : embeddedLyricsImporter.WouldWriteSidecar(file))
+                lyricsCreated++;
+        }
+
+        return new LibraryMetadataRefreshReport
+        {
+            Applied = apply,
+            TracksScanned = scanned,
+            FilesMissing = missing,
+            TracksUpdated = tracksUpdated,
+            AlbumsUpdated = albumsUpdated,
+            LyricsSidecarsCreated = lyricsCreated
+        };
+    }
+
+    private async Task<bool> RefreshAlbumAsync(long albumId, TrackFile file, bool apply)
+    {
+        AlbumEntity? album = await albumRepository.GetByIdAsync(albumId, RepositoryConnectionKind.Background);
+
+        if (album is null)
+            return false;
+
+        bool changed = false;
+
+        changed |= SetNullableInt(file.DiscCount, album.DiscCount, value => album.DiscCount = value);
+        changed |= SetNullableDouble(file.ReplayGainAlbumGain, album.ReplayGainAlbumGain, value => album.ReplayGainAlbumGain = value);
+        changed |= SetNullableDouble(file.ReplayGainAlbumPeak, album.ReplayGainAlbumPeak, value => album.ReplayGainAlbumPeak = value);
+        changed |= SetText(file.MusicBrainzReleaseType, album.MusicBrainzReleaseType, value => album.MusicBrainzReleaseType = value);
+        changed |= SetText(file.MusicBrainzReleaseCountry, album.MusicBrainzReleaseCountry, value => album.MusicBrainzReleaseCountry = value);
+        changed |= SetText(file.MusicbrainzAlbumID, album.MusicBrainzID, value => album.MusicBrainzID = value);
+
+        if (changed && apply)
+            await albumRepository.UpdateAsync(album, RepositoryConnectionKind.Background);
+
+        return changed;
+    }
+
+    private static bool ApplyTrackChanges(TrackEntity track, TrackFile file)
+    {
+        bool changed = false;
+
+        changed |= SetNullableInt(file.Disc, track.Disc, value => track.Disc = value);
+        changed |= SetNullableInt(file.Bpm, track.Bpm, value => track.Bpm = value);
+        changed |= SetText(file.Composers, track.Composers, value => track.Composers = value);
+        changed |= SetPositiveInt(file.SampleRate, track.SampleRate, value => track.SampleRate = value);
+        changed |= SetPositiveInt(file.BitsPerSample, track.BitsPerSample, value => track.BitsPerSample = value);
+        changed |= SetPositiveInt(file.Channels, track.Channels, value => track.Channels = value);
+        changed |= SetNullableDouble(file.ReplayGainTrackGain, track.ReplayGainTrackGain, value => track.ReplayGainTrackGain = value);
+        changed |= SetNullableDouble(file.ReplayGainTrackPeak, track.ReplayGainTrackPeak, value => track.ReplayGainTrackPeak = value);
+
+        return changed;
+    }
+
+    private static bool SetNullableInt(int? tagValue, int? current, Action<int?> setter)
+    {
+        if (!tagValue.HasValue || tagValue == current)
+            return false;
+
+        setter(tagValue);
+        return true;
+    }
+
+    private static bool SetPositiveInt(int tagValue, int current, Action<int> setter)
+    {
+        if (tagValue <= 0 || tagValue == current)
+            return false;
+
+        setter(tagValue);
+        return true;
+    }
+
+    private static bool SetNullableDouble(double? tagValue, double? current, Action<double?> setter)
+    {
+        if (!tagValue.HasValue || tagValue == current)
+            return false;
+
+        setter(tagValue);
+        return true;
+    }
+
+    private static bool SetText(string? tagValue, string? current, Action<string?> setter)
+    {
+        if (string.IsNullOrEmpty(tagValue) || tagValue == current)
+            return false;
+
+        setter(tagValue);
+        return true;
+    }
+}

--- a/src/Rok.Import/Services/TagMetadataMapper.cs
+++ b/src/Rok.Import/Services/TagMetadataMapper.cs
@@ -1,0 +1,113 @@
+using Rok.Application.Tag;
+using Rok.Domain.Entities;
+
+namespace Rok.Import.Services;
+
+/// <summary>
+/// How tag-derived values are written onto an entity.
+/// </summary>
+public enum MetadataWritePolicy
+{
+    /// <summary>
+    /// Assign every field from the tag verbatim, including clearing a value to
+    /// <see langword="null"/>/0 when the tag carries none. Used when (re)building a row at import.
+    /// </summary>
+    Mirror,
+
+    /// <summary>
+    /// Assign a field only when the tag actually provides a value; never blank an existing
+    /// value. Used when refreshing an already-populated row from the tag.
+    /// </summary>
+    FillFromTag
+}
+
+/// <summary>
+/// Single source of truth for mapping the extended audio-tag metadata read into a
+/// <see cref="TrackFile"/> onto the track and album entities. Shared by the import pipeline
+/// (<see cref="MetadataWritePolicy.Mirror"/>) and the maintenance refresher
+/// (<see cref="MetadataWritePolicy.FillFromTag"/>) so the field set lives in one place.
+/// </summary>
+public static class TagMetadataMapper
+{
+    /// <summary>Applies the extended track-level tag metadata. Returns whether anything changed.</summary>
+    public static bool ApplyTrackMetadata(TrackEntity track, TrackFile file, MetadataWritePolicy policy)
+    {
+        bool changed = false;
+
+        changed |= SetNullableInt(file.Disc, () => track.Disc, value => track.Disc = value, policy);
+        changed |= SetNullableInt(file.Bpm, () => track.Bpm, value => track.Bpm = value, policy);
+        changed |= SetText(file.Composers, () => track.Composers, value => track.Composers = value, policy);
+        changed |= SetInt(file.SampleRate, () => track.SampleRate, value => track.SampleRate = value, policy);
+        changed |= SetInt(file.BitsPerSample, () => track.BitsPerSample, value => track.BitsPerSample = value, policy);
+        changed |= SetInt(file.Channels, () => track.Channels, value => track.Channels = value, policy);
+        changed |= SetNullableDouble(file.ReplayGainTrackGain, () => track.ReplayGainTrackGain, value => track.ReplayGainTrackGain = value, policy);
+        changed |= SetNullableDouble(file.ReplayGainTrackPeak, () => track.ReplayGainTrackPeak, value => track.ReplayGainTrackPeak = value, policy);
+
+        return changed;
+    }
+
+    /// <summary>Applies the extended album-level tag metadata. Returns whether anything changed.</summary>
+    public static bool ApplyAlbumMetadata(AlbumEntity album, TrackFile file, MetadataWritePolicy policy)
+    {
+        bool changed = false;
+
+        changed |= SetNullableInt(file.DiscCount, () => album.DiscCount, value => album.DiscCount = value, policy);
+        changed |= SetNullableDouble(file.ReplayGainAlbumGain, () => album.ReplayGainAlbumGain, value => album.ReplayGainAlbumGain = value, policy);
+        changed |= SetNullableDouble(file.ReplayGainAlbumPeak, () => album.ReplayGainAlbumPeak, value => album.ReplayGainAlbumPeak = value, policy);
+        changed |= SetText(file.MusicBrainzReleaseType, () => album.MusicBrainzReleaseType, value => album.MusicBrainzReleaseType = value, policy);
+        changed |= SetText(file.MusicBrainzReleaseCountry, () => album.MusicBrainzReleaseCountry, value => album.MusicBrainzReleaseCountry = value, policy);
+        changed |= SetText(file.MusicbrainzAlbumID, () => album.MusicBrainzID, value => album.MusicBrainzID = value, policy);
+
+        return changed;
+    }
+
+    private static bool SetNullableInt(int? tagValue, Func<int?> get, Action<int?> set, MetadataWritePolicy policy)
+    {
+        if (policy == MetadataWritePolicy.FillFromTag && !tagValue.HasValue)
+            return false;
+
+        if (tagValue == get())
+            return false;
+
+        set(tagValue);
+        return true;
+    }
+
+    private static bool SetInt(int tagValue, Func<int> get, Action<int> set, MetadataWritePolicy policy)
+    {
+        if (policy == MetadataWritePolicy.FillFromTag && tagValue <= 0)
+            return false;
+
+        if (tagValue == get())
+            return false;
+
+        set(tagValue);
+        return true;
+    }
+
+    private static bool SetNullableDouble(double? tagValue, Func<double?> get, Action<double?> set, MetadataWritePolicy policy)
+    {
+        if (policy == MetadataWritePolicy.FillFromTag && !tagValue.HasValue)
+            return false;
+
+        if (tagValue == get())
+            return false;
+
+        set(tagValue);
+        return true;
+    }
+
+    private static bool SetText(string? tagValue, Func<string?> get, Action<string?> set, MetadataWritePolicy policy)
+    {
+        string? normalized = string.IsNullOrEmpty(tagValue) ? null : tagValue;
+
+        if (policy == MetadataWritePolicy.FillFromTag && normalized is null)
+            return false;
+
+        if (normalized == get())
+            return false;
+
+        set(normalized);
+        return true;
+    }
+}

--- a/src/Rok.Import/Services/TrackMetadataService.cs
+++ b/src/Rok.Import/Services/TrackMetadataService.cs
@@ -77,6 +77,15 @@ public class TrackMetadataService(TrackImport importTrack, ILogger<TrackMetadata
         track.TrackNumber = file.TrackNumber;
         track.Duration = (long)Math.Round(file.Duration.TotalSeconds, 0);
         track.FileDate = file.FileDateModified.DateTime;
+
+        track.Disc = file.Disc;
+        track.Bpm = file.Bpm;
+        track.Composers = string.IsNullOrEmpty(file.Composers) ? null : file.Composers;
+        track.SampleRate = file.SampleRate;
+        track.BitsPerSample = file.BitsPerSample;
+        track.Channels = file.Channels;
+        track.ReplayGainTrackGain = file.ReplayGainTrackGain;
+        track.ReplayGainTrackPeak = file.ReplayGainTrackPeak;
     }
 
     private async Task UpdateTrackFileDateAsync(TrackEntity track, DateTime fileDate)

--- a/src/Rok.Import/Services/TrackMetadataService.cs
+++ b/src/Rok.Import/Services/TrackMetadataService.cs
@@ -78,14 +78,7 @@ public class TrackMetadataService(TrackImport importTrack, ILogger<TrackMetadata
         track.Duration = (long)Math.Round(file.Duration.TotalSeconds, 0);
         track.FileDate = file.FileDateModified.DateTime;
 
-        track.Disc = file.Disc;
-        track.Bpm = file.Bpm;
-        track.Composers = string.IsNullOrEmpty(file.Composers) ? null : file.Composers;
-        track.SampleRate = file.SampleRate;
-        track.BitsPerSample = file.BitsPerSample;
-        track.Channels = file.Channels;
-        track.ReplayGainTrackGain = file.ReplayGainTrackGain;
-        track.ReplayGainTrackPeak = file.ReplayGainTrackPeak;
+        TagMetadataMapper.ApplyTrackMetadata(track, file, MetadataWritePolicy.Mirror);
     }
 
     private async Task UpdateTrackFileDateAsync(TrackEntity track, DateTime fileDate)

--- a/src/Rok.Infrastructure/DependencyInjection.cs
+++ b/src/Rok.Infrastructure/DependencyInjection.cs
@@ -78,6 +78,7 @@ public static class DependencyInjection
         services.AddSingleton<IMigration, Migration11>();
         services.AddSingleton<IMigration, Migration12>();
         services.AddSingleton<IMigration, Migration13>();
+        services.AddSingleton<IMigration, Migration14>();
 
         services.AddScoped<IArtistRepository, ArtistRepository>();
         services.AddScoped<IAlbumRepository, AlbumRepository>();

--- a/src/Rok.Infrastructure/Migration/Migration14.cs
+++ b/src/Rok.Infrastructure/Migration/Migration14.cs
@@ -1,0 +1,31 @@
+namespace Rok.Infrastructure.Migration;
+
+/// <summary>
+/// Adds the extended audio-tag metadata read from TagLib during import.
+/// Track-level columns (per file): disc number, BPM, composers, technical audio
+/// characteristics (sample rate, bit depth, channels) and per-track ReplayGain.
+/// Album-level columns (one value per release): disc count, per-album ReplayGain
+/// and the MusicBrainz release type and country.
+/// </summary>
+public class Migration14 : IMigration
+{
+    public int TargetVersion => 14;
+
+    public void Apply(IDbConnection connection)
+    {
+        connection.Execute("ALTER TABLE Tracks ADD COLUMN disc INTEGER NULL;");
+        connection.Execute("ALTER TABLE Tracks ADD COLUMN bpm INTEGER NULL;");
+        connection.Execute("ALTER TABLE Tracks ADD COLUMN composers TEXT NULL;");
+        connection.Execute("ALTER TABLE Tracks ADD COLUMN sampleRate INTEGER NOT NULL DEFAULT 0;");
+        connection.Execute("ALTER TABLE Tracks ADD COLUMN bitsPerSample INTEGER NOT NULL DEFAULT 0;");
+        connection.Execute("ALTER TABLE Tracks ADD COLUMN channels INTEGER NOT NULL DEFAULT 0;");
+        connection.Execute("ALTER TABLE Tracks ADD COLUMN replayGainTrackGain REAL NULL;");
+        connection.Execute("ALTER TABLE Tracks ADD COLUMN replayGainTrackPeak REAL NULL;");
+
+        connection.Execute("ALTER TABLE Albums ADD COLUMN discCount INTEGER NULL;");
+        connection.Execute("ALTER TABLE Albums ADD COLUMN replayGainAlbumGain REAL NULL;");
+        connection.Execute("ALTER TABLE Albums ADD COLUMN replayGainAlbumPeak REAL NULL;");
+        connection.Execute("ALTER TABLE Albums ADD COLUMN musicBrainzReleaseType TEXT NULL;");
+        connection.Execute("ALTER TABLE Albums ADD COLUMN musicBrainzReleaseCountry TEXT NULL;");
+    }
+}

--- a/src/Rok.Infrastructure/Tag/TagService.cs
+++ b/src/Rok.Infrastructure/Tag/TagService.cs
@@ -39,7 +39,7 @@ public class TagService(ILogger<TagService> logger) : ITagService
             track.Duration = tag.Properties.Duration;
             track.Bitrate = tag.Properties.AudioBitrate * 1000;
 
-            track.MusicbrainzAlbumID = tag.Tag.MusicBrainzDiscId;
+            track.MusicbrainzAlbumID = tag.Tag.MusicBrainzReleaseId;
             track.MusicbrainzArtistID = tag.Tag.MusicBrainzArtistId;
             track.MusicbrainzTrackID = tag.Tag.MusicBrainzTrackId;
 

--- a/src/Rok.Infrastructure/Tag/TagService.cs
+++ b/src/Rok.Infrastructure/Tag/TagService.cs
@@ -44,6 +44,23 @@ public class TagService(ILogger<TagService> logger) : ITagService
             track.MusicbrainzTrackID = tag.Tag.MusicBrainzTrackId;
 
             track.Lyrics = tag.Tag.Lyrics;
+
+            track.Disc = tag.Tag.Disc > 0 ? (int)tag.Tag.Disc : null;
+            track.DiscCount = tag.Tag.DiscCount > 0 ? (int)tag.Tag.DiscCount : null;
+            track.Bpm = tag.Tag.BeatsPerMinute > 0 ? (int)tag.Tag.BeatsPerMinute : null;
+            track.Composers = tag.Tag.JoinedComposers?.Trim() ?? "";
+
+            track.SampleRate = tag.Properties.AudioSampleRate;
+            track.BitsPerSample = tag.Properties.BitsPerSample;
+            track.Channels = tag.Properties.AudioChannels;
+
+            track.ReplayGainTrackGain = double.IsNaN(tag.Tag.ReplayGainTrackGain) ? null : tag.Tag.ReplayGainTrackGain;
+            track.ReplayGainTrackPeak = double.IsNaN(tag.Tag.ReplayGainTrackPeak) ? null : tag.Tag.ReplayGainTrackPeak;
+            track.ReplayGainAlbumGain = double.IsNaN(tag.Tag.ReplayGainAlbumGain) ? null : tag.Tag.ReplayGainAlbumGain;
+            track.ReplayGainAlbumPeak = double.IsNaN(tag.Tag.ReplayGainAlbumPeak) ? null : tag.Tag.ReplayGainAlbumPeak;
+
+            track.MusicBrainzReleaseType = tag.Tag.MusicBrainzReleaseType?.Trim() ?? "";
+            track.MusicBrainzReleaseCountry = tag.Tag.MusicBrainzReleaseCountry?.Trim() ?? "";
         }
         catch (TagLib.CorruptFileException ex)
         {

--- a/tests/UnitTests/Rok.ImportTests/Services/EmbeddedLyricsImporterTests.cs
+++ b/tests/UnitTests/Rok.ImportTests/Services/EmbeddedLyricsImporterTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Rok.Application.Dto.Lyrics;
+using Rok.Application.Interfaces;
+using Rok.Application.Tag;
+using Rok.Import.Services;
+
+namespace Rok.ImportTests.Services;
+
+public class EmbeddedLyricsImporterTests
+{
+    private readonly Mock<ILyricsService> _lyricsService = new();
+
+    private EmbeddedLyricsImporter CreateSut() => new(_lyricsService.Object, NullLogger<EmbeddedLyricsImporter>.Instance);
+
+    [Fact(DisplayName = "when_the_tag_has_no_embedded_lyrics_no_sidecar_is_written")]
+    public async Task NoEmbeddedLyrics_WritesNothing()
+    {
+        // Arrange
+        EmbeddedLyricsImporter sut = CreateSut();
+        TrackFile file = new() { FullPath = @"C:\music\song.mp3", Lyrics = "   " };
+
+        // Act
+        await sut.ExtractAsync(file);
+
+        // Assert
+        _lyricsService.Verify(s => s.SaveLyricsAsync(It.IsAny<LyricsModel>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "when_a_sidecar_already_exists_no_sidecar_is_written")]
+    public async Task ExistingSidecar_WritesNothing()
+    {
+        // Arrange
+        _lyricsService.Setup(s => s.CheckLyricsFileExists(It.IsAny<string>())).Returns(ELyricsType.Plain);
+
+        EmbeddedLyricsImporter sut = CreateSut();
+        TrackFile file = new() { FullPath = @"C:\music\song.mp3", Lyrics = "Some embedded lyrics" };
+
+        // Act
+        await sut.ExtractAsync(file);
+
+        // Assert
+        _lyricsService.Verify(s => s.SaveLyricsAsync(It.IsAny<LyricsModel>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "when_embedded_lyrics_are_plain_text_a_txt_sidecar_is_written")]
+    public async Task PlainLyrics_WritesTxtSidecar()
+    {
+        // Arrange
+        const string content = "Hello world\nSecond line";
+
+        _lyricsService.Setup(s => s.CheckLyricsFileExists(It.IsAny<string>())).Returns(ELyricsType.None);
+        _lyricsService.Setup(s => s.GetPlainLyricsFileName(It.IsAny<string>())).Returns(@"C:\music\song.txt");
+
+        LyricsModel? saved = null;
+        _lyricsService.Setup(s => s.SaveLyricsAsync(It.IsAny<LyricsModel>()))
+                      .Callback<LyricsModel>(m => saved = m)
+                      .Returns(Task.CompletedTask);
+
+        EmbeddedLyricsImporter sut = CreateSut();
+        TrackFile file = new() { FullPath = @"C:\music\song.mp3", Lyrics = content };
+
+        // Act
+        await sut.ExtractAsync(file);
+
+        // Assert
+        Assert.NotNull(saved);
+        Assert.Equal(@"C:\music\song.txt", saved!.File);
+        Assert.Equal(content, saved.PlainLyrics);
+        Assert.Equal(ELyricsType.Plain, saved.LyricsType);
+        _lyricsService.Verify(s => s.GetSynchronizedLyricsFileName(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "when_embedded_lyrics_carry_timestamps_an_lrc_sidecar_is_written")]
+    public async Task SynchronizedLyrics_WritesLrcSidecar()
+    {
+        // Arrange
+        const string content = "[00:12.34]Hello\n[00:15.00]World";
+
+        _lyricsService.Setup(s => s.CheckLyricsFileExists(It.IsAny<string>())).Returns(ELyricsType.None);
+        _lyricsService.Setup(s => s.GetSynchronizedLyricsFileName(It.IsAny<string>())).Returns(@"C:\music\song.lrc");
+
+        LyricsModel? saved = null;
+        _lyricsService.Setup(s => s.SaveLyricsAsync(It.IsAny<LyricsModel>()))
+                      .Callback<LyricsModel>(m => saved = m)
+                      .Returns(Task.CompletedTask);
+
+        EmbeddedLyricsImporter sut = CreateSut();
+        TrackFile file = new() { FullPath = @"C:\music\song.mp3", Lyrics = content };
+
+        // Act
+        await sut.ExtractAsync(file);
+
+        // Assert
+        Assert.NotNull(saved);
+        Assert.Equal(@"C:\music\song.lrc", saved!.File);
+        Assert.Equal(content, saved.PlainLyrics);
+        Assert.Equal(ELyricsType.Synchronized, saved.LyricsType);
+        _lyricsService.Verify(s => s.GetPlainLyricsFileName(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/tests/UnitTests/Rok.ImportTests/Services/LibraryMetadataRefresherTests.cs
+++ b/tests/UnitTests/Rok.ImportTests/Services/LibraryMetadataRefresherTests.cs
@@ -17,6 +17,12 @@ public class LibraryMetadataRefresherTests
     private readonly Mock<ILyricsService> _lyricsService = new();
     private readonly Mock<IFileSystem> _fileSystem = new();
 
+    public LibraryMetadataRefresherTests()
+    {
+        _albumRepository.Setup(r => r.GetAllAsync(It.IsAny<RepositoryConnectionKind>())).ReturnsAsync([]);
+        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
+    }
+
     private LibraryMetadataRefresher CreateSut()
     {
         EmbeddedLyricsImporter lyricsImporter = new(_lyricsService.Object, NullLogger<EmbeddedLyricsImporter>.Instance);
@@ -32,25 +38,29 @@ public class LibraryMetadataRefresherTests
 
     private void SetupTracks(params TrackEntity[] tracks)
     {
-        _trackRepository.Setup(r => r.GetAllAsync(It.IsAny<RepositoryConnectionKind>()))
-                        .ReturnsAsync(tracks);
+        _trackRepository.Setup(r => r.GetAllAsync(It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(tracks);
     }
 
-    private void SetupTagReader(Action<TrackFile> configure)
+    private void SetupAlbums(params AlbumEntity[] albums)
+    {
+        _albumRepository.Setup(r => r.GetAllAsync(It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(albums);
+    }
+
+    // Each invocation of FillProperties gets the tag values for the matching file path.
+    private void SetupTagReader(Func<string, Action<TrackFile>> configureByPath)
     {
         _tagService.Setup(s => s.FillProperties(It.IsAny<string>(), It.IsAny<TrackFile>()))
-                   .Callback<string, TrackFile>((_, file) => configure(file));
+                   .Callback<string, TrackFile>((path, file) => configureByPath(path)(file));
     }
+
+    private void SetupTagReader(Action<TrackFile> configure) => SetupTagReader(_ => configure);
 
     [Fact(DisplayName = "dry_run_counts_changes_without_writing_to_the_repositories")]
     public async Task DryRun_DoesNotPersist()
     {
         // Arrange
-        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3", AlbumId = 10 };
-        SetupTracks(track);
-        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
-        _albumRepository.Setup(r => r.GetByIdAsync(10, It.IsAny<RepositoryConnectionKind>()))
-                        .ReturnsAsync(new AlbumEntity { Id = 10 });
+        SetupTracks(new TrackEntity { Id = 1, MusicFile = @"C:\music\song.mp3", AlbumId = 10 });
+        SetupAlbums(new AlbumEntity { Id = 10 });
         SetupTagReader(file =>
         {
             file.Disc = 2;
@@ -76,11 +86,8 @@ public class LibraryMetadataRefresherTests
     public async Task Apply_PersistsTrackAndAlbum()
     {
         // Arrange
-        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3", AlbumId = 10 };
-        SetupTracks(track);
-        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
-        _albumRepository.Setup(r => r.GetByIdAsync(10, It.IsAny<RepositoryConnectionKind>()))
-                        .ReturnsAsync(new AlbumEntity { Id = 10 });
+        SetupTracks(new TrackEntity { Id = 1, MusicFile = @"C:\music\song.mp3", AlbumId = 10 });
+        SetupAlbums(new AlbumEntity { Id = 10 });
         _trackRepository.Setup(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(true);
         _albumRepository.Setup(r => r.UpdateAsync(It.IsAny<AlbumEntity>(), It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(true);
         SetupTagReader(file =>
@@ -110,13 +117,14 @@ public class LibraryMetadataRefresherTests
             It.IsAny<RepositoryConnectionKind>()), Times.Once);
     }
 
-    [Fact(DisplayName = "missing_file_is_counted_and_skipped_without_reading_the_tag")]
-    public async Task MissingFile_IsSkipped()
+    [Fact(DisplayName = "a_present_tag_value_overwrites_a_different_existing_database_value")]
+    public async Task PresentTag_OverwritesDifferentValue()
     {
         // Arrange
-        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\gone.mp3", AlbumId = 10 };
+        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3", Disc = 5 };
         SetupTracks(track);
-        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+        _trackRepository.Setup(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(true);
+        SetupTagReader(file => file.Disc = 2);
 
         LibraryMetadataRefresher sut = CreateSut();
 
@@ -124,10 +132,9 @@ public class LibraryMetadataRefresherTests
         LibraryMetadataRefreshReport report = await sut.RefreshAsync(apply: true);
 
         // Assert
-        Assert.Equal(1, report.FilesMissing);
-        Assert.Equal(0, report.TracksUpdated);
-        _tagService.Verify(s => s.FillProperties(It.IsAny<string>(), It.IsAny<TrackFile>()), Times.Never);
-        _trackRepository.Verify(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>()), Times.Never);
+        Assert.Equal(1, report.TracksUpdated);
+        Assert.Equal(2, track.Disc);
+        _trackRepository.Verify(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>()), Times.Once);
     }
 
     [Fact(DisplayName = "an_existing_value_is_not_blanked_when_the_tag_has_no_value")]
@@ -136,7 +143,6 @@ public class LibraryMetadataRefresherTests
         // Arrange
         TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3", Disc = 5, SampleRate = 48000 };
         SetupTracks(track);
-        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
         SetupTagReader(_ => { /* tag carries no extended metadata */ });
 
         LibraryMetadataRefresher sut = CreateSut();
@@ -151,13 +157,53 @@ public class LibraryMetadataRefresherTests
         _trackRepository.Verify(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>()), Times.Never);
     }
 
+    [Fact(DisplayName = "album_metadata_is_aggregated_from_a_later_track_when_the_first_lacks_it")]
+    public async Task AlbumMetadata_AggregatedAcrossTracks()
+    {
+        // Arrange: first track has no album-level disc count, the second one does.
+        SetupTracks(
+            new TrackEntity { Id = 1, MusicFile = @"C:\music\d1.mp3", AlbumId = 10 },
+            new TrackEntity { Id = 2, MusicFile = @"C:\music\d2.mp3", AlbumId = 10 });
+        SetupAlbums(new AlbumEntity { Id = 10 });
+        _albumRepository.Setup(r => r.UpdateAsync(It.IsAny<AlbumEntity>(), It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(true);
+        SetupTagReader(path => path.EndsWith("d2.mp3", StringComparison.Ordinal)
+            ? file => file.DiscCount = 2
+            : _ => { });
+
+        LibraryMetadataRefresher sut = CreateSut();
+
+        // Act
+        LibraryMetadataRefreshReport report = await sut.RefreshAsync(apply: true);
+
+        // Assert
+        Assert.Equal(1, report.AlbumsUpdated);
+        _albumRepository.Verify(r => r.UpdateAsync(It.Is<AlbumEntity>(a => a.DiscCount == 2), It.IsAny<RepositoryConnectionKind>()), Times.Once);
+    }
+
+    [Fact(DisplayName = "missing_file_is_counted_and_skipped_without_reading_the_tag")]
+    public async Task MissingFile_IsSkipped()
+    {
+        // Arrange
+        SetupTracks(new TrackEntity { Id = 1, MusicFile = @"C:\music\gone.mp3", AlbumId = 10 });
+        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+
+        LibraryMetadataRefresher sut = CreateSut();
+
+        // Act
+        LibraryMetadataRefreshReport report = await sut.RefreshAsync(apply: true);
+
+        // Assert
+        Assert.Equal(1, report.FilesMissing);
+        Assert.Equal(0, report.TracksUpdated);
+        _tagService.Verify(s => s.FillProperties(It.IsAny<string>(), It.IsAny<TrackFile>()), Times.Never);
+        _trackRepository.Verify(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>()), Times.Never);
+    }
+
     [Fact(DisplayName = "embedded_lyrics_sidecar_is_counted_when_no_sidecar_exists")]
     public async Task EmbeddedLyrics_AreCounted()
     {
         // Arrange
-        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3" };
-        SetupTracks(track);
-        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
+        SetupTracks(new TrackEntity { Id = 1, MusicFile = @"C:\music\song.mp3" });
         _lyricsService.Setup(s => s.CheckLyricsFileExists(It.IsAny<string>())).Returns(ELyricsType.None);
         _lyricsService.Setup(s => s.GetPlainLyricsFileName(It.IsAny<string>())).Returns(@"C:\music\song.txt");
         _lyricsService.Setup(s => s.SaveLyricsAsync(It.IsAny<LyricsModel>())).Returns(Task.CompletedTask);

--- a/tests/UnitTests/Rok.ImportTests/Services/LibraryMetadataRefresherTests.cs
+++ b/tests/UnitTests/Rok.ImportTests/Services/LibraryMetadataRefresherTests.cs
@@ -218,4 +218,27 @@ public class LibraryMetadataRefresherTests
         Assert.Equal(1, report.LyricsSidecarsCreated);
         _lyricsService.Verify(s => s.SaveLyricsAsync(It.IsAny<LyricsModel>()), Times.Once);
     }
+
+    [Fact(DisplayName = "progress_is_reported_through_the_end_of_the_tracks_phase")]
+    public async Task Progress_IsReported()
+    {
+        // Arrange
+        SetupTracks(
+            new TrackEntity { Id = 1, MusicFile = @"C:\music\a.mp3" },
+            new TrackEntity { Id = 2, MusicFile = @"C:\music\b.mp3" });
+        SetupTagReader(_ => { });
+
+        List<LibraryMetadataRefreshProgress> reports = [];
+        Mock<IProgress<LibraryMetadataRefreshProgress>> progress = new();
+        progress.Setup(p => p.Report(It.IsAny<LibraryMetadataRefreshProgress>()))
+                .Callback<LibraryMetadataRefreshProgress>(reports.Add);
+
+        LibraryMetadataRefresher sut = CreateSut();
+
+        // Act
+        await sut.RefreshAsync(apply: false, progress.Object);
+
+        // Assert
+        Assert.Contains(reports, r => r.Phase == "Tracks" && r.Processed == 2 && r.Total == 2);
+    }
 }

--- a/tests/UnitTests/Rok.ImportTests/Services/LibraryMetadataRefresherTests.cs
+++ b/tests/UnitTests/Rok.ImportTests/Services/LibraryMetadataRefresherTests.cs
@@ -1,0 +1,175 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Rok.Application.Dto.Lyrics;
+using Rok.Application.Interfaces;
+using Rok.Application.Interfaces.Repositories;
+using Rok.Application.Tag;
+using Rok.Domain.Entities;
+using Rok.Import.Services;
+
+namespace Rok.ImportTests.Services;
+
+public class LibraryMetadataRefresherTests
+{
+    private readonly Mock<ITrackRepository> _trackRepository = new();
+    private readonly Mock<IAlbumRepository> _albumRepository = new();
+    private readonly Mock<ITagService> _tagService = new();
+    private readonly Mock<ILyricsService> _lyricsService = new();
+    private readonly Mock<IFileSystem> _fileSystem = new();
+
+    private LibraryMetadataRefresher CreateSut()
+    {
+        EmbeddedLyricsImporter lyricsImporter = new(_lyricsService.Object, NullLogger<EmbeddedLyricsImporter>.Instance);
+
+        return new LibraryMetadataRefresher(
+            _trackRepository.Object,
+            _albumRepository.Object,
+            _tagService.Object,
+            lyricsImporter,
+            _fileSystem.Object,
+            NullLogger<LibraryMetadataRefresher>.Instance);
+    }
+
+    private void SetupTracks(params TrackEntity[] tracks)
+    {
+        _trackRepository.Setup(r => r.GetAllAsync(It.IsAny<RepositoryConnectionKind>()))
+                        .ReturnsAsync(tracks);
+    }
+
+    private void SetupTagReader(Action<TrackFile> configure)
+    {
+        _tagService.Setup(s => s.FillProperties(It.IsAny<string>(), It.IsAny<TrackFile>()))
+                   .Callback<string, TrackFile>((_, file) => configure(file));
+    }
+
+    [Fact(DisplayName = "dry_run_counts_changes_without_writing_to_the_repositories")]
+    public async Task DryRun_DoesNotPersist()
+    {
+        // Arrange
+        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3", AlbumId = 10 };
+        SetupTracks(track);
+        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
+        _albumRepository.Setup(r => r.GetByIdAsync(10, It.IsAny<RepositoryConnectionKind>()))
+                        .ReturnsAsync(new AlbumEntity { Id = 10 });
+        SetupTagReader(file =>
+        {
+            file.Disc = 2;
+            file.SampleRate = 44100;
+            file.MusicbrainzAlbumID = "release-123";
+        });
+
+        LibraryMetadataRefresher sut = CreateSut();
+
+        // Act
+        LibraryMetadataRefreshReport report = await sut.RefreshAsync(apply: false);
+
+        // Assert
+        Assert.False(report.Applied);
+        Assert.Equal(1, report.TracksScanned);
+        Assert.Equal(1, report.TracksUpdated);
+        Assert.Equal(1, report.AlbumsUpdated);
+        _trackRepository.Verify(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>()), Times.Never);
+        _albumRepository.Verify(r => r.UpdateAsync(It.IsAny<AlbumEntity>(), It.IsAny<RepositoryConnectionKind>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "apply_persists_track_and_album_metadata_from_the_tag")]
+    public async Task Apply_PersistsTrackAndAlbum()
+    {
+        // Arrange
+        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3", AlbumId = 10 };
+        SetupTracks(track);
+        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
+        _albumRepository.Setup(r => r.GetByIdAsync(10, It.IsAny<RepositoryConnectionKind>()))
+                        .ReturnsAsync(new AlbumEntity { Id = 10 });
+        _trackRepository.Setup(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(true);
+        _albumRepository.Setup(r => r.UpdateAsync(It.IsAny<AlbumEntity>(), It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(true);
+        SetupTagReader(file =>
+        {
+            file.Disc = 2;
+            file.Bpm = 120;
+            file.SampleRate = 44100;
+            file.BitsPerSample = 16;
+            file.Channels = 2;
+            file.DiscCount = 2;
+            file.MusicbrainzAlbumID = "release-123";
+            file.MusicBrainzReleaseType = "album";
+        });
+
+        LibraryMetadataRefresher sut = CreateSut();
+
+        // Act
+        LibraryMetadataRefreshReport report = await sut.RefreshAsync(apply: true);
+
+        // Assert
+        Assert.True(report.Applied);
+        _trackRepository.Verify(r => r.UpdateAsync(
+            It.Is<TrackEntity>(t => t.Disc == 2 && t.Bpm == 120 && t.SampleRate == 44100 && t.BitsPerSample == 16 && t.Channels == 2),
+            It.IsAny<RepositoryConnectionKind>()), Times.Once);
+        _albumRepository.Verify(r => r.UpdateAsync(
+            It.Is<AlbumEntity>(a => a.DiscCount == 2 && a.MusicBrainzID == "release-123" && a.MusicBrainzReleaseType == "album"),
+            It.IsAny<RepositoryConnectionKind>()), Times.Once);
+    }
+
+    [Fact(DisplayName = "missing_file_is_counted_and_skipped_without_reading_the_tag")]
+    public async Task MissingFile_IsSkipped()
+    {
+        // Arrange
+        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\gone.mp3", AlbumId = 10 };
+        SetupTracks(track);
+        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+
+        LibraryMetadataRefresher sut = CreateSut();
+
+        // Act
+        LibraryMetadataRefreshReport report = await sut.RefreshAsync(apply: true);
+
+        // Assert
+        Assert.Equal(1, report.FilesMissing);
+        Assert.Equal(0, report.TracksUpdated);
+        _tagService.Verify(s => s.FillProperties(It.IsAny<string>(), It.IsAny<TrackFile>()), Times.Never);
+        _trackRepository.Verify(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "an_existing_value_is_not_blanked_when_the_tag_has_no_value")]
+    public async Task EmptyTag_DoesNotOverwriteExistingValue()
+    {
+        // Arrange
+        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3", Disc = 5, SampleRate = 48000 };
+        SetupTracks(track);
+        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
+        SetupTagReader(_ => { /* tag carries no extended metadata */ });
+
+        LibraryMetadataRefresher sut = CreateSut();
+
+        // Act
+        LibraryMetadataRefreshReport report = await sut.RefreshAsync(apply: true);
+
+        // Assert
+        Assert.Equal(0, report.TracksUpdated);
+        Assert.Equal(5, track.Disc);
+        Assert.Equal(48000, track.SampleRate);
+        _trackRepository.Verify(r => r.UpdateAsync(It.IsAny<TrackEntity>(), It.IsAny<RepositoryConnectionKind>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "embedded_lyrics_sidecar_is_counted_when_no_sidecar_exists")]
+    public async Task EmbeddedLyrics_AreCounted()
+    {
+        // Arrange
+        TrackEntity track = new() { Id = 1, MusicFile = @"C:\music\song.mp3" };
+        SetupTracks(track);
+        _fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
+        _lyricsService.Setup(s => s.CheckLyricsFileExists(It.IsAny<string>())).Returns(ELyricsType.None);
+        _lyricsService.Setup(s => s.GetPlainLyricsFileName(It.IsAny<string>())).Returns(@"C:\music\song.txt");
+        _lyricsService.Setup(s => s.SaveLyricsAsync(It.IsAny<LyricsModel>())).Returns(Task.CompletedTask);
+        SetupTagReader(file => file.Lyrics = "Hello world");
+
+        LibraryMetadataRefresher sut = CreateSut();
+
+        // Act
+        LibraryMetadataRefreshReport report = await sut.RefreshAsync(apply: true);
+
+        // Assert
+        Assert.Equal(1, report.LyricsSidecarsCreated);
+        _lyricsService.Verify(s => s.SaveLyricsAsync(It.IsAny<LyricsModel>()), Times.Once);
+    }
+}

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/SqliteDatabaseFixture.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/SqliteDatabaseFixture.cs
@@ -24,7 +24,7 @@ public class SqliteDatabaseFixture : IDisposable
         _sqliteConnection.Open();
         Connection = _sqliteConnection;
 
-        var migrations = new IMigration[] { new Migration2(), new Migration3(), new Migration4(), new Migration5(), new Migration6(), new Migration7(), new Migration8(), new Migration9(), new Migration10(), new Migration11(), new Migration12() };
+        var migrations = new IMigration[] { new Migration2(), new Migration3(), new Migration4(), new Migration5(), new Migration6(), new Migration7(), new Migration8(), new Migration9(), new Migration10(), new Migration11(), new Migration12(), new Migration13(), new Migration14() };
         MigrationService migrationService = new(Connection, migrations, NullLogger<MigrationService>.Instance);
         migrationService.Initial();
         migrationService.MigrateToLatest();

--- a/tools/Rok.MetadataTool/Program.cs
+++ b/tools/Rok.MetadataTool/Program.cs
@@ -76,7 +76,10 @@ try
     }
 
     LibraryMetadataRefresher refresher = provider.GetRequiredService<LibraryMetadataRefresher>();
-    LibraryMetadataRefreshReport report = await refresher.RefreshAsync(apply);
+    ConsoleProgressReporter reporter = new();
+    LibraryMetadataRefreshReport report = await refresher.RefreshAsync(apply, reporter);
+    reporter.Complete();
+    Console.WriteLine();
 
     PrintReport(report);
 }
@@ -165,5 +168,31 @@ static void PrintReport(LibraryMetadataRefreshReport report)
     {
         Console.WriteLine();
         Console.WriteLine("Run again with --apply to persist these changes.");
+    }
+}
+
+/// <summary>
+/// Renders refresh progress on a single console line that is rewritten in place, starting a
+/// new line whenever the phase changes so each completed phase stays visible.
+/// </summary>
+internal sealed class ConsoleProgressReporter : IProgress<LibraryMetadataRefreshProgress>
+{
+    private string? _phase;
+
+    public void Report(LibraryMetadataRefreshProgress value)
+    {
+        if (_phase is not null && _phase != value.Phase)
+            Console.WriteLine();
+
+        _phase = value.Phase;
+
+        int percent = value.Total == 0 ? 100 : (int)(value.Processed * 100L / value.Total);
+        Console.Write($"\r{value.Phase}: {value.Processed}/{value.Total} ({percent}%)   ");
+    }
+
+    public void Complete()
+    {
+        if (_phase is not null)
+            Console.WriteLine();
     }
 }

--- a/tools/Rok.MetadataTool/Program.cs
+++ b/tools/Rok.MetadataTool/Program.cs
@@ -4,10 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Rok.Application.Interfaces;
 using Rok.Application.Interfaces.Repositories;
 using Rok.Application.Tag;
-using Rok.Infrastructure;
 using Rok.Infrastructure.FileSystem;
 using Rok.Infrastructure.Lyrics;
-using Rok.Infrastructure.Migration;
 using Rok.Infrastructure.Repositories;
 using Rok.Infrastructure.Tag;
 using Rok.Import.Services;
@@ -35,49 +33,44 @@ string connectionString = new SqliteConnectionStringBuilder
     Pooling = false
 }.ToString();
 
-ServiceCollection services = new();
-services.AddLogging();
-services.AddSingleton(TimeProvider.System);
-services.AddSingleton<IDbConnection>(_ => new SqliteConnection(connectionString));
-services.AddKeyedSingleton<IDbConnection>("BackgroundConnection", (_, _) => new SqliteConnection(connectionString));
-services.AddSingleton<IFileSystem, DefaultFileSystem>();
-services.AddSingleton<ILyricsService, LyricsService>();
-services.AddSingleton<ITagService, TagService>();
-services.AddSingleton<ITrackRepository, TrackRepository>();
-services.AddSingleton<IAlbumRepository, AlbumRepository>();
-services.AddSingleton<EmbeddedLyricsImporter>();
-services.AddSingleton<LibraryMetadataRefresher>();
-
-services.AddSingleton<IMigrationService, MigrationService>();
-services.AddSingleton<IMigration, Migration2>();
-services.AddSingleton<IMigration, Migration3>();
-services.AddSingleton<IMigration, Migration4>();
-services.AddSingleton<IMigration, Migration5>();
-services.AddSingleton<IMigration, Migration6>();
-services.AddSingleton<IMigration, Migration7>();
-services.AddSingleton<IMigration, Migration8>();
-services.AddSingleton<IMigration, Migration9>();
-services.AddSingleton<IMigration, Migration10>();
-services.AddSingleton<IMigration, Migration11>();
-services.AddSingleton<IMigration, Migration12>();
-services.AddSingleton<IMigration, Migration13>();
-services.AddSingleton<IMigration, Migration14>();
-
-using ServiceProvider provider = services.BuildServiceProvider();
-
 Console.WriteLine($"Database : {databasePath}");
 Console.WriteLine($"Mode     : {(apply ? "APPLY (database will be modified)" : "dry-run (no changes written)")}");
 Console.WriteLine();
 
 try
 {
-    IMigrationService migrationService = provider.GetRequiredService<IMigrationService>();
-    migrationService.MigrateToLatest();
+    if (!TableExists(connectionString, "Tracks"))
+    {
+        Console.Error.WriteLine("This file does not look like a Rok database (no 'Tracks' table).");
+        return 1;
+    }
+
+    // The tool does not migrate; it expects an up-to-date schema (open the database once in Rok first).
+    if (!ColumnExists(connectionString, "Tracks", "disc"))
+    {
+        Console.Error.WriteLine("Database schema is out of date for this tool. Open the database once in Rok (which applies migrations), then retry.");
+        return 1;
+    }
+
+    ServiceCollection services = new();
+    services.AddLogging();
+    services.AddSingleton(TimeProvider.System);
+    services.AddSingleton<IDbConnection>(_ => new SqliteConnection(connectionString));
+    services.AddKeyedSingleton<IDbConnection>("BackgroundConnection", (_, _) => new SqliteConnection(connectionString));
+    services.AddSingleton<IFileSystem, DefaultFileSystem>();
+    services.AddSingleton<ILyricsService, LyricsService>();
+    services.AddSingleton<ITagService, TagService>();
+    services.AddSingleton<ITrackRepository, TrackRepository>();
+    services.AddSingleton<IAlbumRepository, AlbumRepository>();
+    services.AddSingleton<EmbeddedLyricsImporter>();
+    services.AddSingleton<LibraryMetadataRefresher>();
+
+    using ServiceProvider provider = services.BuildServiceProvider();
 
     if (apply)
     {
         string backupPath = $"{databasePath}.{DateTime.Now:yyyyMMdd_HHmmss}.bak";
-        File.Copy(databasePath, backupPath, overwrite: false);
+        BackupDatabase(databasePath, backupPath);
         Console.WriteLine($"Backup created: {backupPath}");
         Console.WriteLine();
     }
@@ -96,6 +89,49 @@ catch (SqliteException ex)
 
 return 0;
 
+static bool TableExists(string connectionString, string table)
+{
+    using SqliteConnection connection = new(connectionString);
+    connection.Open();
+
+    using SqliteCommand command = connection.CreateCommand();
+    command.CommandText = "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = $name;";
+    command.Parameters.AddWithValue("$name", table);
+
+    return Convert.ToInt64(command.ExecuteScalar()) > 0;
+}
+
+static bool ColumnExists(string connectionString, string table, string column)
+{
+    using SqliteConnection connection = new(connectionString);
+    connection.Open();
+
+    using SqliteCommand command = connection.CreateCommand();
+    command.CommandText = "SELECT count(*) FROM pragma_table_info($table) WHERE name = $column;";
+    command.Parameters.AddWithValue("$table", table);
+    command.Parameters.AddWithValue("$column", column);
+
+    return Convert.ToInt64(command.ExecuteScalar()) > 0;
+}
+
+static void BackupDatabase(string databasePath, string backupPath)
+{
+    using SqliteConnection source = new(new SqliteConnectionStringBuilder
+    {
+        DataSource = databasePath,
+        Mode = SqliteOpenMode.ReadOnly,
+        Pooling = false
+    }.ToString());
+    source.Open();
+
+    using SqliteConnection destination = new(new SqliteConnectionStringBuilder { DataSource = backupPath }.ToString());
+    destination.Open();
+
+    // SQLite online-backup API copies a consistent image including pending WAL pages,
+    // unlike a plain File.Copy of the main database file.
+    source.BackupDatabase(destination);
+}
+
 static void PrintUsage()
 {
     Console.WriteLine("Usage: Rok.MetadataTool <database.sqlite> [--apply]");
@@ -105,11 +141,12 @@ static void PrintUsage()
     Console.WriteLine("  the album MusicBrainz id and the embedded-lyrics sidecars.");
     Console.WriteLine();
     Console.WriteLine("  A value is written only when the tag provides one; existing values are");
-    Console.WriteLine("  never blanked. Without --apply the tool runs as a dry-run.");
+    Console.WriteLine("  never blanked. The tool does not migrate the schema: open the database once");
+    Console.WriteLine("  in Rok first. Without --apply it runs as a dry-run and writes nothing.");
     Console.WriteLine();
     Console.WriteLine("Arguments:");
-    Console.WriteLine("  <database.sqlite>  Path to the Rok SQLite database.");
-    Console.WriteLine("  --apply            Persist the changes (a timestamped .bak backup is created first).");
+    Console.WriteLine("  <database.sqlite>  Path to an up-to-date Rok SQLite database.");
+    Console.WriteLine("  --apply            Persist the changes (a timestamped .bak backup is taken first).");
 }
 
 static void PrintReport(LibraryMetadataRefreshReport report)
@@ -120,6 +157,9 @@ static void PrintReport(LibraryMetadataRefreshReport report)
     Console.WriteLine($"  Tracks {(report.Applied ? "updated" : "to update")}          : {report.TracksUpdated}");
     Console.WriteLine($"  Albums {(report.Applied ? "updated" : "to update")}          : {report.AlbumsUpdated}");
     Console.WriteLine($"  Lyrics sidecars {(report.Applied ? "created" : "to create")} : {report.LyricsSidecarsCreated}");
+
+    if (report.LyricsSidecarsFailed > 0)
+        Console.WriteLine($"  Lyrics sidecars failed  : {report.LyricsSidecarsFailed}");
 
     if (!report.Applied)
     {

--- a/tools/Rok.MetadataTool/Program.cs
+++ b/tools/Rok.MetadataTool/Program.cs
@@ -1,0 +1,129 @@
+using System.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Rok.Application.Interfaces;
+using Rok.Application.Interfaces.Repositories;
+using Rok.Application.Tag;
+using Rok.Infrastructure;
+using Rok.Infrastructure.FileSystem;
+using Rok.Infrastructure.Lyrics;
+using Rok.Infrastructure.Migration;
+using Rok.Infrastructure.Repositories;
+using Rok.Infrastructure.Tag;
+using Rok.Import.Services;
+
+if (args.Length < 1 || args.Contains("--help") || args.Contains("-h"))
+{
+    PrintUsage();
+    return args.Length < 1 ? 1 : 0;
+}
+
+string databasePath = args[0];
+bool apply = args.Contains("--apply");
+
+if (!File.Exists(databasePath))
+{
+    Console.Error.WriteLine($"Database not found: {databasePath}");
+    return 1;
+}
+
+string connectionString = new SqliteConnectionStringBuilder
+{
+    DataSource = databasePath,
+    Mode = SqliteOpenMode.ReadWrite,
+    Cache = SqliteCacheMode.Shared,
+    Pooling = false
+}.ToString();
+
+ServiceCollection services = new();
+services.AddLogging();
+services.AddSingleton(TimeProvider.System);
+services.AddSingleton<IDbConnection>(_ => new SqliteConnection(connectionString));
+services.AddKeyedSingleton<IDbConnection>("BackgroundConnection", (_, _) => new SqliteConnection(connectionString));
+services.AddSingleton<IFileSystem, DefaultFileSystem>();
+services.AddSingleton<ILyricsService, LyricsService>();
+services.AddSingleton<ITagService, TagService>();
+services.AddSingleton<ITrackRepository, TrackRepository>();
+services.AddSingleton<IAlbumRepository, AlbumRepository>();
+services.AddSingleton<EmbeddedLyricsImporter>();
+services.AddSingleton<LibraryMetadataRefresher>();
+
+services.AddSingleton<IMigrationService, MigrationService>();
+services.AddSingleton<IMigration, Migration2>();
+services.AddSingleton<IMigration, Migration3>();
+services.AddSingleton<IMigration, Migration4>();
+services.AddSingleton<IMigration, Migration5>();
+services.AddSingleton<IMigration, Migration6>();
+services.AddSingleton<IMigration, Migration7>();
+services.AddSingleton<IMigration, Migration8>();
+services.AddSingleton<IMigration, Migration9>();
+services.AddSingleton<IMigration, Migration10>();
+services.AddSingleton<IMigration, Migration11>();
+services.AddSingleton<IMigration, Migration12>();
+services.AddSingleton<IMigration, Migration13>();
+services.AddSingleton<IMigration, Migration14>();
+
+using ServiceProvider provider = services.BuildServiceProvider();
+
+Console.WriteLine($"Database : {databasePath}");
+Console.WriteLine($"Mode     : {(apply ? "APPLY (database will be modified)" : "dry-run (no changes written)")}");
+Console.WriteLine();
+
+try
+{
+    IMigrationService migrationService = provider.GetRequiredService<IMigrationService>();
+    migrationService.MigrateToLatest();
+
+    if (apply)
+    {
+        string backupPath = $"{databasePath}.{DateTime.Now:yyyyMMdd_HHmmss}.bak";
+        File.Copy(databasePath, backupPath, overwrite: false);
+        Console.WriteLine($"Backup created: {backupPath}");
+        Console.WriteLine();
+    }
+
+    LibraryMetadataRefresher refresher = provider.GetRequiredService<LibraryMetadataRefresher>();
+    LibraryMetadataRefreshReport report = await refresher.RefreshAsync(apply);
+
+    PrintReport(report);
+}
+catch (SqliteException ex)
+{
+    Console.Error.WriteLine($"SQLite error: {ex.Message}");
+    Console.Error.WriteLine("Make sure the Rok application is closed (the database must not be locked).");
+    return 1;
+}
+
+return 0;
+
+static void PrintUsage()
+{
+    Console.WriteLine("Usage: Rok.MetadataTool <database.sqlite> [--apply]");
+    Console.WriteLine();
+    Console.WriteLine("  Re-reads the audio tag of every track in the database and refreshes the");
+    Console.WriteLine("  extended metadata columns (disc, bpm, composers, audio specs, replaygain),");
+    Console.WriteLine("  the album MusicBrainz id and the embedded-lyrics sidecars.");
+    Console.WriteLine();
+    Console.WriteLine("  A value is written only when the tag provides one; existing values are");
+    Console.WriteLine("  never blanked. Without --apply the tool runs as a dry-run.");
+    Console.WriteLine();
+    Console.WriteLine("Arguments:");
+    Console.WriteLine("  <database.sqlite>  Path to the Rok SQLite database.");
+    Console.WriteLine("  --apply            Persist the changes (a timestamped .bak backup is created first).");
+}
+
+static void PrintReport(LibraryMetadataRefreshReport report)
+{
+    Console.WriteLine(report.Applied ? "Changes applied:" : "Changes that would be applied (dry-run):");
+    Console.WriteLine($"  Tracks scanned          : {report.TracksScanned}");
+    Console.WriteLine($"  Files missing on disk   : {report.FilesMissing}");
+    Console.WriteLine($"  Tracks {(report.Applied ? "updated" : "to update")}          : {report.TracksUpdated}");
+    Console.WriteLine($"  Albums {(report.Applied ? "updated" : "to update")}          : {report.AlbumsUpdated}");
+    Console.WriteLine($"  Lyrics sidecars {(report.Applied ? "created" : "to create")} : {report.LyricsSidecarsCreated}");
+
+    if (!report.Applied)
+    {
+        Console.WriteLine();
+        Console.WriteLine("Run again with --apply to persist these changes.");
+    }
+}

--- a/tools/Rok.MetadataTool/Rok.MetadataTool.csproj
+++ b/tools/Rok.MetadataTool/Rok.MetadataTool.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <RootNamespace>Rok.MetadataTool</RootNamespace>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rok.Infrastructure\Rok.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Rok.Import\Rok.Import.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Objectif

Intégrer davantage de métadonnées des tags audio (TagLib) lors de l'import, et permettre de backfiller l'existant.

## Contenu (5 commits)

- **`fix(import)`** — `TagService` lisait `MusicBrainzDiscId` (empreinte TOC du CD) au lieu de `MusicBrainzReleaseId` (édition album) pour `AlbumEntity.MusicBrainzID`.
- **`feat(import)` — lot schéma** — `Migration14` ajoute 13 colonnes (8 pistes : disc, bpm, composers, sampleRate, bitsPerSample, channels, ReplayGain piste ; 5 albums : discCount, ReplayGain album, MusicBrainz release type/country). Lecture des tags + mapping. Aucun repository modifié (Dapper.Contrib + `SELECT *`).
- **`feat(import)` — paroles embarquées** — à l'import, `tag.Tag.Lyrics` (jusqu'ici lu puis jeté) est écrit dans un sidecar `.lrc` (si timestamps) ou `.txt`, **uniquement si aucun n'existe** (n'écrase jamais l'API/manuel).
- **`feat(tools)` — `Rok.MetadataTool`** — outil console `<database.sqlite> [--apply]` qui re-lit les tags de toutes les pistes de la BDD et backfille les colonnes étendues + MusicBrainzID album + paroles. Dry-run par défaut.
- **`refactor(import)` — corrections de revue** — mapper partagé `TagMetadataMapper` (un seul site de mapping tag→entité, politique Mirror à l'import / FillFromTag au refresh) ; cache albums (fin du N+1) ; métadonnées album agrégées sur toutes les pistes ; regex LRC ancrée en début de ligne ; l'outil ne gère plus les migrations (BDD à jour attendue, garde sur colonne `disc`), backup WAL-safe via l'API SQLite avant `--apply`.

## Politique de l'outil

Le tag fait foi : une valeur n'est écrite que si le tag en fournit une ; une valeur existante en BDD n'est jamais vidée.

## Tests

Build solution vert (0 avertissement, TreatWarningsAsErrors). Import 112/112, suites Application/Infrastructure inchangées et vertes.

## Validations runtime manuelles restantes (avant merge)

- [ ] Importer un fichier ayant des paroles embarquées → vérifier la création du sidecar `.lrc`/`.txt`.
- [ ] `Rok.MetadataTool <db_à_jour> --apply` (app fermée) sur une vraie BDD → vérifier le rapport et le backup `.bak`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)