### PR TITLE
fix(presentation): homogenize navigation icons and fix Playlists glyph

### DIFF
--- a/src/Presentation/MainWindow.xaml
+++ b/src/Presentation/MainWindow.xaml
@@ -105,15 +105,19 @@
                                 <FontIcon Glyph="&#xe93c;" FontFamily="Segoe Fluent Icons" />
                             </NavigationViewItem.Icon>
                         </NavigationViewItem>
-                        <NavigationViewItem x:Uid="menuArtists" Tag="Artists" x:Name="artistsItem" Icon="People" />
+                        <NavigationViewItem x:Uid="menuArtists" Tag="Artists" x:Name="artistsItem">
+                            <NavigationViewItem.Icon>
+                                <FontIcon Glyph="&#xE716;" FontFamily="Segoe Fluent Icons" />
+                            </NavigationViewItem.Icon>
+                        </NavigationViewItem>
                         <NavigationViewItem x:Uid="menuTracks" Tag="Tracks" x:Name="tracksItem">
                             <NavigationViewItem.Icon>
-                                <SymbolIcon Symbol="Audio" />
+                                <FontIcon Glyph="&#xE8D6;" FontFamily="Segoe Fluent Icons" />
                             </NavigationViewItem.Icon>
                         </NavigationViewItem>
                         <NavigationViewItem x:Uid="menuPlaylists" Tag="Playlists" x:Name="playlistItem">
                             <NavigationViewItem.Icon>
-                                <SymbolIcon Symbol="Shop" />
+                                <FontIcon Glyph="&#xE8FD;" FontFamily="Segoe Fluent Icons" />
                             </NavigationViewItem.Icon>
                         </NavigationViewItem>
                         <NavigationViewItem x:Uid="menuRadios" Tag="Radios" x:Name="radiosItem">
@@ -122,7 +126,11 @@
                             </NavigationViewItem.Icon>
                         </NavigationViewItem>
 
-                        <NavigationViewItem x:Uid="menuInsight" Content="Insights" Tag="Insights" x:Name="insightsItem" Icon="OutlineStar" />
+                        <NavigationViewItem x:Uid="menuInsight" Content="Insights" Tag="Insights" x:Name="insightsItem">
+                            <NavigationViewItem.Icon>
+                                <FontIcon Glyph="&#xE1CE;" FontFamily="Segoe Fluent Icons" />
+                            </NavigationViewItem.Icon>
+                        </NavigationViewItem>
 
                     </NavigationView.MenuItems>
 

--- a/src/Presentation/Pages/PlaylistsPage.xaml
+++ b/src/Presentation/Pages/PlaylistsPage.xaml
@@ -120,7 +120,7 @@
                     <GridViewHeaderItem FontSize="{StaticResource FontSizeLarge}" FontWeight="Bold" HorizontalAlignment="Left">
                         <GridViewHeaderItem.Content>
                             <StackPanel Orientation="Horizontal">
-                                <SymbolIcon Symbol="Shop" Margin="4,0,4,0" />
+                                <FontIcon Glyph="&#xE8FD;" FontFamily="Segoe Fluent Icons" Margin="4,0,4,0" />
                                 <TextBlock x:Uid="playlistHeader" />
                             </StackPanel>
                         </GridViewHeaderItem.Content>


### PR DESCRIPTION
## Contexte
Lot **C4** de l'initiative d'amélioration UX/UI (axe *cohérence visuelle*).

## Changements
- **Playlists** : remplace le glyphe trompeur du panier (`Symbol="Shop"`) par une icône **liste** (`&#xE8FD;`), dans le `NavigationView` **et** l'entête de section de `PlaylistsPage`.
- Homogénéise toutes les entrées du menu en `FontIcon` + `Segoe Fluent Icons` (Artists, Tracks, Insights étaient en `SymbolIcon`/`Icon` raccourci). Les glyphes des items inchangés sont préservés à l'identique (People `E716`, Audio `E8D6`, OutlineStar `E1CE`).

## Vérification
- Build x64 : 0 erreur, 0 warning.
- Suite de tests : 1446 tests verts.
- Vérification visuelle par capture d'écran : glyphes distincts et pertinents (note de musique ≠ liste ≠ onde), plus aucun panier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)