### PR TITLE
feat(presentation): add consistent empty states across pages

### DIFF
--- a/src/Presentation/Pages/AlbumPage.xaml
+++ b/src/Presentation/Pages/AlbumPage.xaml
@@ -147,6 +147,9 @@
                 </ListView.ItemTemplate>
             </ListView>
 
+            <common:EmptyStateControl x:Uid="albumPageNoTracks" Glyph="&#xE8D6;" Grid.Row="1"
+                                      Visibility="{x:Bind ViewModel.HasNoTracks, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+
             <!-- Listening statistics panel -->
             <common:ListeningStatsPanel x:Name="statsPanel" x:Uid="albumStatsPanel" Grid.Column="1" Grid.RowSpan="2" Width="250" Margin="0,8,12,12"
                                         Stats="{x:Bind ViewModel.ListeningStats, Mode=OneWay}"

--- a/src/Presentation/Pages/ArtistPage.xaml
+++ b/src/Presentation/Pages/ArtistPage.xaml
@@ -95,6 +95,7 @@
             <Pivot>
                 <!-- Albums -->
                 <PivotItem x:Uid="artistViewTabAlbums">
+                    <Grid>
                     <common:GridViewExtended x:Name="grid" ItemsPanel="{StaticResource GridPanelTemplate}" ItemsSource="{x:Bind ViewModel.Albums}" ContainerContentChanging="grid_ContainerContentChanging" ScrollViewer.VerticalScrollMode="Enabled" ScrollViewer.VerticalScrollBarVisibility="Auto">
                         <GridView.ItemTemplate>
                             <DataTemplate x:DataType="albums:AlbumViewModel">
@@ -139,6 +140,10 @@
                             </DataTemplate>
                         </GridView.ItemTemplate>
                     </common:GridViewExtended>
+
+                        <common:EmptyStateControl x:Uid="artistPageNoAlbums" Glyph="&#xE93C;"
+                                                  Visibility="{x:Bind ViewModel.HasNoAlbums, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                    </Grid>
                 </PivotItem>
 
                 <!-- Tracks-->
@@ -204,6 +209,9 @@
                                 </DataTemplate>
                             </ListView.ItemTemplate>
                         </ListView>
+
+                        <common:EmptyStateControl x:Uid="artistPageNoTracks" Glyph="&#xE8D6;" Grid.Row="1"
+                                                  Visibility="{x:Bind ViewModel.HasNoTracks, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                     </Grid>
                 </PivotItem>
             </Pivot>

--- a/src/Presentation/Pages/GenrePage.xaml
+++ b/src/Presentation/Pages/GenrePage.xaml
@@ -103,6 +103,9 @@
                     </DataTemplate>
                 </GridView.ItemTemplate>
             </common:GridViewExtended>
+
+            <common:EmptyStateControl x:Uid="genrePageNoAlbums" Glyph="&#xE93C;"
+                                      Visibility="{x:Bind ViewModel.HasNoAlbums, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
         </Grid>
     </Grid>
 </Page>

--- a/src/Presentation/Pages/PlaylistPage.xaml
+++ b/src/Presentation/Pages/PlaylistPage.xaml
@@ -142,6 +142,9 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </common:ListViewExtended>
+
+            <common:EmptyStateControl x:Uid="playlistPageNoTracks" Glyph="&#xE8D6;" Grid.Row="1"
+                                      Visibility="{x:Bind ViewModel.IsTracksEmpty, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
         </Grid>
     </Grid>
 </Page>

--- a/src/Presentation/Pages/PlaylistsPage.xaml
+++ b/src/Presentation/Pages/PlaylistsPage.xaml
@@ -145,6 +145,9 @@
                               IsItemClickEnabled="True" />
                 </StackPanel>
             </ScrollViewer>
+
+            <common:EmptyStateControl x:Uid="playlistsViewNoData" Glyph="&#xE8D6;"
+                                      Visibility="{x:Bind ViewModel.HasNoData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
         </Grid>
     </Grid>
 </Page>

--- a/src/Presentation/Pages/SearchPage.xaml
+++ b/src/Presentation/Pages/SearchPage.xaml
@@ -249,5 +249,8 @@
                 </Grid>
             </StackPanel>
         </ScrollViewer>
+
+        <common:EmptyStateControl x:Uid="searchViewNoResults" Glyph="&#xE721;" Grid.Row="1"
+                                  Visibility="{x:Bind ViewModel.HasNoResults, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
     </Grid>
 </Page>

--- a/src/Presentation/Pages/SearchPage.xaml.cs
+++ b/src/Presentation/Pages/SearchPage.xaml.cs
@@ -50,6 +50,8 @@ public sealed partial class SearchPage : Page
         ArtistsViewModel.SetData(openArgs.SearchResult.Artists);
         AlbumsViewModel.SetData(openArgs.SearchResult.Albums);
         TracksViewModel.SetData(openArgs.SearchResult.Tracks);
+
+        ViewModel.HasNoResults = TrackCount == 0 && ArtistCount == 0 && AlbumCount == 0;
     }
 
     private void grid_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)

--- a/src/Presentation/Pages/SmartPlaylistPage.xaml
+++ b/src/Presentation/Pages/SmartPlaylistPage.xaml
@@ -178,14 +178,8 @@
                     </common:ListViewExtended>
 
                     <!-- Empty state -->
-                    <StackPanel Grid.Row="1"
-                                Visibility="{x:Bind ViewModel.IsTracksEmpty, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                                HorizontalAlignment="Center" VerticalAlignment="Center"
-                                Spacing="12">
-                        <TextBlock Text="🎵" FontSize="48" HorizontalAlignment="Center" />
-                        <TextBlock x:Uid="SmartPlaylist_EmptyTracksTitle" Style="{StaticResource SubtitleTextBlockStyle}" HorizontalAlignment="Center" />
-                        <TextBlock x:Uid="SmartPlaylist_EmptyTracksDescription" Style="{ThemeResource BodyTextBlockStyle}" HorizontalAlignment="Center" Opacity="0.7" />
-                    </StackPanel>
+                    <common:EmptyStateControl x:Uid="smartPlaylistNoTracks" Glyph="&#xE8D6;" Grid.Row="1"
+                                              Visibility="{x:Bind ViewModel.IsTracksEmpty, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                 </Grid>
             </PivotItem>
         </Pivot>

--- a/src/Presentation/Strings/en-US/Resources.resw
+++ b/src/Presentation/Strings/en-US/Resources.resw
@@ -1192,6 +1192,30 @@
   <data name="artistsPageArtists.Text" xml:space="preserve">
     <value>artists</value>
   </data>
+  <data name="playlistsViewNoData.Message" xml:space="preserve">
+    <value>No playlists yet</value>
+  </data>
+  <data name="searchViewNoResults.Message" xml:space="preserve">
+    <value>No results found</value>
+  </data>
+  <data name="albumPageNoTracks.Message" xml:space="preserve">
+    <value>No tracks in this album</value>
+  </data>
+  <data name="artistPageNoAlbums.Message" xml:space="preserve">
+    <value>No albums</value>
+  </data>
+  <data name="artistPageNoTracks.Message" xml:space="preserve">
+    <value>No tracks</value>
+  </data>
+  <data name="genrePageNoAlbums.Message" xml:space="preserve">
+    <value>No albums</value>
+  </data>
+  <data name="playlistPageNoTracks.Message" xml:space="preserve">
+    <value>This playlist is empty</value>
+  </data>
+  <data name="smartPlaylistNoTracks.Message" xml:space="preserve">
+    <value>No matching tracks</value>
+  </data>
   <data name="albumsViewNoData.Message" xml:space="preserve">
     <value>No albums found</value>
   </data>

--- a/src/Presentation/Strings/es-ES/Resources.resw
+++ b/src/Presentation/Strings/es-ES/Resources.resw
@@ -1075,6 +1075,30 @@
   <data name="artistsPageArtists.Text" xml:space="preserve">
     <value>artistas</value>
   </data>
+  <data name="playlistsViewNoData.Message" xml:space="preserve">
+    <value>No hay listas de reproducción</value>
+  </data>
+  <data name="searchViewNoResults.Message" xml:space="preserve">
+    <value>No se encontraron resultados</value>
+  </data>
+  <data name="albumPageNoTracks.Message" xml:space="preserve">
+    <value>No hay canciones en este álbum</value>
+  </data>
+  <data name="artistPageNoAlbums.Message" xml:space="preserve">
+    <value>Sin álbumes</value>
+  </data>
+  <data name="artistPageNoTracks.Message" xml:space="preserve">
+    <value>Sin canciones</value>
+  </data>
+  <data name="genrePageNoAlbums.Message" xml:space="preserve">
+    <value>Sin álbumes</value>
+  </data>
+  <data name="playlistPageNoTracks.Message" xml:space="preserve">
+    <value>Esta lista está vacía</value>
+  </data>
+  <data name="smartPlaylistNoTracks.Message" xml:space="preserve">
+    <value>No hay canciones coincidentes</value>
+  </data>
   <data name="albumsViewNoData.Message" xml:space="preserve">
     <value>No se encontraron álbumes</value>
   </data>

--- a/src/Presentation/Strings/fr-FR/Resources.resw
+++ b/src/Presentation/Strings/fr-FR/Resources.resw
@@ -1191,6 +1191,30 @@
   <data name="artistsPageArtists.Text" xml:space="preserve">
     <value>artistes</value>
   </data>
+  <data name="playlistsViewNoData.Message" xml:space="preserve">
+    <value>Aucune playlist</value>
+  </data>
+  <data name="searchViewNoResults.Message" xml:space="preserve">
+    <value>Aucun résultat</value>
+  </data>
+  <data name="albumPageNoTracks.Message" xml:space="preserve">
+    <value>Aucune piste dans cet album</value>
+  </data>
+  <data name="artistPageNoAlbums.Message" xml:space="preserve">
+    <value>Aucun album</value>
+  </data>
+  <data name="artistPageNoTracks.Message" xml:space="preserve">
+    <value>Aucune piste</value>
+  </data>
+  <data name="genrePageNoAlbums.Message" xml:space="preserve">
+    <value>Aucun album</value>
+  </data>
+  <data name="playlistPageNoTracks.Message" xml:space="preserve">
+    <value>Cette playlist est vide</value>
+  </data>
+  <data name="smartPlaylistNoTracks.Message" xml:space="preserve">
+    <value>Aucune piste correspondante</value>
+  </data>
   <data name="albumsViewNoData.Message" xml:space="preserve">
     <value>Aucun album trouvé</value>
   </data>

--- a/src/Presentation/Strings/uk-UA/Resources.resw
+++ b/src/Presentation/Strings/uk-UA/Resources.resw
@@ -1133,6 +1133,30 @@
   <data name="artistsPageArtists.Text" xml:space="preserve">
     <value>Митці</value>
   </data>
+  <data name="playlistsViewNoData.Message" xml:space="preserve">
+    <value>Немає плейлистів</value>
+  </data>
+  <data name="searchViewNoResults.Message" xml:space="preserve">
+    <value>Нічого не знайдено</value>
+  </data>
+  <data name="albumPageNoTracks.Message" xml:space="preserve">
+    <value>У цьому альбомі немає треків</value>
+  </data>
+  <data name="artistPageNoAlbums.Message" xml:space="preserve">
+    <value>Немає альбомів</value>
+  </data>
+  <data name="artistPageNoTracks.Message" xml:space="preserve">
+    <value>Немає треків</value>
+  </data>
+  <data name="genrePageNoAlbums.Message" xml:space="preserve">
+    <value>Немає альбомів</value>
+  </data>
+  <data name="playlistPageNoTracks.Message" xml:space="preserve">
+    <value>Цей плейлист порожній</value>
+  </data>
+  <data name="smartPlaylistNoTracks.Message" xml:space="preserve">
+    <value>Немає відповідних треків</value>
+  </data>
   <data name="albumsViewNoData.Message" xml:space="preserve">
     <value>Альбомів не знайдено</value>
   </data>

--- a/src/Presentation/ViewModels/Album/AlbumViewModel.cs
+++ b/src/Presentation/ViewModels/Album/AlbumViewModel.cs
@@ -40,6 +40,8 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
     public RangeObservableCollection<TrackViewModel> Tracks { get; set; } = [];
     private IEnumerable<TrackDto>? _tracks = null;
 
+    public bool HasNoTracks => Tracks.Count == 0;
+
     public AlbumDto Album { get; private set; } = new();
     public IPlaylistMenuService PlaylistMenuService { get; }
 
@@ -319,6 +321,7 @@ public partial class AlbumViewModel : ObservableObject, IFilterableAlbum, IGroup
 
         _tracks = tracks.Select(t => t.Track);
         Tracks.InitWithAddRange(tracks);
+        OnPropertyChanged(nameof(HasNoTracks));
     }
 
     private async Task<bool> LoadAlbumAsync(long albumId)

--- a/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
+++ b/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
@@ -49,6 +49,9 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
     public RangeObservableCollection<TrackViewModel> Tracks { get; set; } = [];
     public RangeObservableCollection<AlbumViewModel> Albums { get; set; } = [];
 
+    public bool HasNoAlbums => Albums.Count == 0;
+    public bool HasNoTracks => Tracks.Count == 0;
+
     public ListeningStatsViewModel ListeningStats { get; } = new();
 
 
@@ -456,6 +459,7 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
             return;
 
         Albums.InitWithAddRange(albums);
+        OnPropertyChanged(nameof(HasNoAlbums));
     }
 
     private async Task LoadTracksAsync(long artistId, CancellationToken cancellationToken)
@@ -468,6 +472,7 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
         _tracks = tracks.Select(t => t.Track);
         Tracks.InitWithAddRange(tracks);
 
+        OnPropertyChanged(nameof(HasNoTracks));
         OnPropertyChanged(nameof(DurationTotal));
     }
 

--- a/src/Presentation/ViewModels/Genre/GenreViewModel.cs
+++ b/src/Presentation/ViewModels/Genre/GenreViewModel.cs
@@ -26,6 +26,8 @@ public partial class GenreViewModel : ObservableObject
     public RangeObservableCollection<AlbumViewModel> Albums { get; set; } = [];
     public GenreDto Genre { get; private set; } = new();
 
+    public bool HasNoAlbums => Albums.Count == 0;
+
     public bool IsFavorite
     {
         get => Genre.IsFavorite;
@@ -208,6 +210,7 @@ public partial class GenreViewModel : ObservableObject
             return;
 
         Albums.InitWithAddRange(albums);
+        OnPropertyChanged(nameof(HasNoAlbums));
 
         if (albums.Count == 0)
             return;

--- a/src/Presentation/ViewModels/Playlists/PlaylistsViewModel.cs
+++ b/src/Presentation/ViewModels/Playlists/PlaylistsViewModel.cs
@@ -27,6 +27,8 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
 
     public RangeObservableCollection<PlaylistViewModel> SmartPlaylists { get; private set; } = [];
 
+    public bool HasNoData => Playlists.Count == 0 && SmartPlaylists.Count == 0;
+
     [ObservableProperty]
     public partial bool IsGridView { get; set; }
     partial void OnIsGridViewChanged(bool value)
@@ -107,6 +109,8 @@ public partial class PlaylistsViewModel : ObservableObject, IDisposable
 
         SmartPlaylists.Clear();
         SmartPlaylists.AddRange(_dataLoader.ViewModels.Where(c => c.Playlist.IsSmart));
+
+        OnPropertyChanged(nameof(HasNoData));
     }
 
     [RelayCommand]

--- a/src/Presentation/ViewModels/Search/SearchViewModel.cs
+++ b/src/Presentation/ViewModels/Search/SearchViewModel.cs
@@ -1,7 +1,12 @@
-﻿namespace Rok.ViewModels.Search;
+using CommunityToolkit.Mvvm.ComponentModel;
 
-public class SearchViewModel
+namespace Rok.ViewModels.Search;
+
+public partial class SearchViewModel : ObservableObject
 {
+    [ObservableProperty]
+    public partial bool HasNoResults { get; set; }
+
     public void LoadData(SearchOpenArgs openArgs)
     {
         Guard.NotNull(openArgs, nameof(openArgs));


### PR DESCRIPTION
## Contexte
Lot **E1** de l'initiative d'amélioration UX/UI (axe *états & feedback*).

## Changements
Réutilise le contrôle existant `EmptyStateControl` sur les pages qui en manquaient, pour un état vide homogène partout :
- **SearchPage** (aucun résultat), **PlaylistsPage** (aucune playlist), **AlbumPage** (aucune piste), **ArtistPage** (aucun album / aucune piste, sur les deux onglets du Pivot), **GenrePage** (aucun album), **PlaylistPage** (playlist vide).
- **SmartPlaylistPage** : remplace l'état vide custom (StackPanel + emoji) par le contrôle réutilisable.

Côté ViewModels :
- Ajout des propriétés notifiées `HasNoData` / `HasNoAlbums` / `HasNoTracks` (Genre, Playlists, Album, Artist), notifiées au point de peuplement des collections.
- `SearchViewModel` passe en `ObservableObject` avec `HasNoResults` (rempli dans `OnNavigatedTo`).
- `PlaylistViewModel.IsTracksEmpty` réutilisé (existait déjà).

Messages localisés ajoutés dans les **4 langues** (`en-US`, `fr-FR`, `es-ES`, `uk-UA`).

## Vérification
- Build x64 : 0 erreur, 0 warning. Suite de tests : 1446 tests verts.
- Smoke test runtime : navigation Albums/Artist/Playlists + détails sans crash (le `MeasureOverride` COMException observé est un crash framework **flaky préexistant**, reproductible aussi sur master — non lié à ce lot).

> Note : les états vides n'ont pas pu être déclenchés visuellement (BDD de dev peuplée), mais le mécanisme est identique aux états vides déjà fonctionnels (`radiosNoData`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)