### PR TITLE
refactor(presentation): tokenize recurring spacing into Thickness resources

### DIFF
--- a/src/Presentation/Pages/AlbumsPage.xaml
+++ b/src/Presentation/Pages/AlbumsPage.xaml
@@ -39,7 +39,7 @@
                     <common:PictureControl Style="{StaticResource PictureCoverStyle}" Cover="{x:Bind Picture, Mode=OneWay}" x:Phase="2" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                 </Border>
 
-                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="0,8,8,0">
+                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="{StaticResource CoverBadgeMargin}">
                     <common:BadgeControl x:Uid="badgeLive" Visibility="{x:Bind IsLive, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeLiveBrush}"/>
                     <common:BadgeControl x:Uid="badgeBestof" Visibility="{x:Bind IsBestOf, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeBestOfBrush}" />
                     <common:BadgeControl x:Uid="badgeCompilation" Visibility="{x:Bind IsCompilation, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeCompilationBrush}" />
@@ -59,7 +59,7 @@
 
                     <HyperlinkButton Content="{x:Bind Album.Name}" x:Phase="0" Command="{x:Bind AlbumOpenCommand}" Style="{StaticResource GridCoverButtonStyle}" />
                     
-                    <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="4,6,0,0" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
+                    <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="{StaticResource CoverSubtitleMargin}" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
                     <HyperlinkButton x:Name="artistName" Grid.Row="1" IsTabStop="False" Style="{StaticResource GridCoverButtonStyle}" Content="{x:Bind Album.ArtistName, Mode=OneWay}" Command="{x:Bind ArtistOpenCommand}" Opacity="0" x:Phase="1" />
 
                     <common:AnimatedButton x:Name="favoriteButton" x:Uid="albumFavoriteButton" Grid.Column="1" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Stretch" Opacity="{x:Bind IsFavorite, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}" Icon="{StaticResource HeartPath}" Color="{x:Bind IsFavorite, Converter={StaticResource FavoriteToColorConverter}, Mode=OneWay}" Command="{x:Bind AlbumFavoriteCommand}" CommandParameter="{x:Bind IsFavorite, Converter={StaticResource BoolToInvertBoolConverter}, Mode=OneWay}" />
@@ -68,7 +68,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="AlbumListTemplate" x:DataType="albums:AlbumViewModel">
-            <Grid Padding="12,4" HorizontalAlignment="Stretch" Background="Transparent" PointerEntered="gridBottom_PointerEntered" PointerExited="gridBottom_PointerExited">
+            <Grid Padding="{StaticResource ListItemPadding}" HorizontalAlignment="Stretch" Background="Transparent" PointerEntered="gridBottom_PointerEntered" PointerExited="gridBottom_PointerExited">
                 <Grid.Resources>
                     <Storyboard x:Key="ShowArtistNameStoryboard">
                         <DoubleAnimation Storyboard.TargetName="artistName" Storyboard.TargetProperty="Opacity" To="1" Duration="0:0:0.6" />
@@ -98,7 +98,7 @@
                     <common:PictureControl Cover="{x:Bind Picture, Mode=OneWay}" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                 </Border>
                 
-                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="12,0,0,0">
+                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="{StaticResource ListItemTextMargin}">
                     <StackPanel Orientation="Horizontal" Spacing="{StaticResource SpacingSmall}">
                         <HyperlinkButton Content="{x:Bind Album.Name}" Command="{x:Bind AlbumOpenCommand}" Style="{StaticResource HyperlinkSmallButtonStyle}" Margin="4,0,0,0" FontSize="{StaticResource FontSizeXMedium}" FontWeight="SemiBold" />
                         <common:AnimatedButton x:Name="favoriteButton" x:Uid="albumFavoriteButton" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Center" Icon="{StaticResource HeartPath}" Color="{x:Bind IsFavorite, Converter={StaticResource FavoriteToColorConverter}, Mode=OneWay}" Opacity="{x:Bind IsFavorite, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}" Command="{x:Bind AlbumFavoriteCommand}" CommandParameter="{x:Bind IsFavorite, Converter={StaticResource BoolToInvertBoolConverter}, Mode=OneWay}" />
@@ -175,7 +175,7 @@
                     <AppBarSeparator />
 
                     <!-- Info about albums count and duration -->
-                    <StackPanel Style="{StaticResource CommandBarStatInfoPanelStyle}" Margin="12,0,0,0">
+                    <StackPanel Style="{StaticResource CommandBarStatInfoPanelStyle}">
                         <FontIcon Glyph="&#xE93C;" Style="{StaticResource CommandBarStatInfoIconStyle}" />
                         <TextBlock Style="{StaticResource CommandBarStatInfoTextStyle}">
                             <Run x:Name="albumCountRun" FontWeight="SemiBold" />

--- a/src/Presentation/Pages/ArtistPage.xaml
+++ b/src/Presentation/Pages/ArtistPage.xaml
@@ -112,7 +112,7 @@
                                         <common:PictureControl Style="{StaticResource PictureCoverStyle}" Cover="{x:Bind Picture, Mode=OneWay}" x:Phase="2" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                                     </Border>
 
-                                    <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="0,8,8,0">
+                                    <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="{StaticResource CoverBadgeMargin}">
                                         <common:BadgeControl x:Uid="badgeLive" Visibility="{x:Bind IsLive, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeLiveBrush}"/>
                                         <common:BadgeControl x:Uid="badgeBestof" Visibility="{x:Bind IsBestOf, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeBestOfBrush}" />
                                         <common:BadgeControl x:Uid="badgeCompilation" Visibility="{x:Bind IsCompilation, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeCompilationBrush}" />
@@ -131,7 +131,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <HyperlinkButton Content="{x:Bind Album.Name}" x:Phase="0" Command="{x:Bind AlbumOpenCommand}" Style="{StaticResource GridCoverButtonStyle}" />
-                                        <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="4,6,0,0" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
+                                        <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="{StaticResource CoverSubtitleMargin}" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
 
                                         <common:AnimatedButton x:Name="favoriteButton" x:Uid="albumFavoriteButton" Grid.Column="1" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Stretch" Opacity="{x:Bind IsFavorite, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}" Icon="{StaticResource HeartPath}" Color="{x:Bind IsFavorite, Converter={StaticResource FavoriteToColorConverter}, Mode=OneWay}" Command="{x:Bind AlbumFavoriteCommand}" CommandParameter="{x:Bind IsFavorite, Converter={StaticResource BoolToInvertBoolConverter}, Mode=OneWay}" />
                                     </Grid>

--- a/src/Presentation/Pages/ArtistsPage.xaml
+++ b/src/Presentation/Pages/ArtistsPage.xaml
@@ -37,7 +37,7 @@
                     <common:PictureControl Style="{StaticResource PictureCoverStyle}" Cover="{x:Bind Picture, Mode=OneWay}" x:Phase="2" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                 </Border>
 
-                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="0,8,8,0">
+                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="{StaticResource CoverBadgeMargin}">
                     <common:BadgeControl x:Uid="badgeNew" Visibility="{x:Bind ShowNewBadge, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeNewBrush}" />
                 </StackPanel>
 
@@ -54,7 +54,7 @@
 
                     <HyperlinkButton Content="{x:Bind Artist.Name}" x:Phase="0" Command="{x:Bind ArtistOpenCommand}" Style="{StaticResource GridCoverButtonStyle}" />
                     
-                    <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="4,6,0,0" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
+                    <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="{StaticResource CoverSubtitleMargin}" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
                     <HyperlinkButton x:Name="genreName" Grid.Row="1" IsTabStop="False" Style="{StaticResource GridCoverButtonStyle}" Content="{x:Bind Artist.GenreName, Mode=OneWay}" Command="{x:Bind GenreOpenCommand}" Opacity="0" x:Phase="1" />
 
                     <common:AnimatedButton x:Name="favoriteButton"
@@ -72,7 +72,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="ArtistListTemplate" x:DataType="artists:ArtistViewModel">
-            <Grid Padding="12,4" HorizontalAlignment="Stretch" Background="Transparent" PointerEntered="gridBottom_PointerEntered" PointerExited="gridBottom_PointerExited">
+            <Grid Padding="{StaticResource ListItemPadding}" HorizontalAlignment="Stretch" Background="Transparent" PointerEntered="gridBottom_PointerEntered" PointerExited="gridBottom_PointerExited">
                 <Grid.Resources>
                     <Storyboard x:Key="ShowGenreNameStoryboard">
                         <DoubleAnimation Storyboard.TargetName="genreName" Storyboard.TargetProperty="Opacity" To="1" Duration="0:0:0.6" />
@@ -100,7 +100,7 @@
                     <common:PictureControl Cover="{x:Bind Picture, Mode=OneWay}" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                 </Border>
 
-                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="12,0,0,0">
+                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="{StaticResource ListItemTextMargin}">
                     <StackPanel Orientation="Horizontal" Spacing="{StaticResource SpacingSmall}">
                         <HyperlinkButton Content="{x:Bind Artist.Name}" Command="{x:Bind ArtistOpenCommand}" Style="{StaticResource HyperlinkSmallButtonStyle}" Margin="4,0,0,0" FontSize="{StaticResource FontSizeXMedium}" FontWeight="SemiBold" />
                         <common:AnimatedButton x:Name="favoriteButton" x:Uid="artistFavoriteButton" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Center" Icon="{StaticResource HeartPath}" Color="{x:Bind IsFavorite, Converter={StaticResource FavoriteToColorConverter}, Mode=OneWay}" Opacity="{x:Bind IsFavorite, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}" Command="{x:Bind ArtistFavoriteCommand}" CommandParameter="{x:Bind IsFavorite, Converter={StaticResource BoolToInvertBoolConverter}, Mode=OneWay}" />
@@ -178,7 +178,7 @@
                     <AppBarSeparator />
 
                     <!-- Info about albums count and duration -->
-                    <StackPanel Style="{StaticResource CommandBarStatInfoPanelStyle}" Margin="12,0,0,0">
+                    <StackPanel Style="{StaticResource CommandBarStatInfoPanelStyle}">
                         <FontIcon Glyph="&#xE93C;" Style="{StaticResource CommandBarStatInfoIconStyle}" />
                         <TextBlock Style="{StaticResource CommandBarStatInfoTextStyle}">
                              <Run x:Name="artistCountRun" FontWeight="SemiBold" />

--- a/src/Presentation/Pages/GenrePage.xaml
+++ b/src/Presentation/Pages/GenrePage.xaml
@@ -74,7 +74,7 @@
                                 <common:PictureControl Style="{StaticResource PictureCoverStyle}" Cover="{x:Bind Picture, Mode=OneWay}" x:Phase="2" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                             </Border>
 
-                            <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="0,8,8,0">
+                            <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="{StaticResource CoverBadgeMargin}">
                                 <common:BadgeControl x:Uid="badgeLive" Visibility="{x:Bind IsLive, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeLiveBrush}"/>
                                 <common:BadgeControl x:Uid="badgeBestof" Visibility="{x:Bind IsBestOf, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeBestOfBrush}" />
                                 <common:BadgeControl x:Uid="badgeCompilation" Visibility="{x:Bind IsCompilation, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeCompilationBrush}" />
@@ -94,7 +94,7 @@
 
                                 <HyperlinkButton Content="{x:Bind Album.Name}" x:Phase="0" Command="{x:Bind AlbumOpenCommand}" Style="{StaticResource GridCoverButtonStyle}" />
 
-                                <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="4,6,0,0" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
+                                <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="{StaticResource CoverSubtitleMargin}" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
                                 <HyperlinkButton x:Name="artistName" Grid.Row="1" IsTabStop="False" Style="{StaticResource GridCoverButtonStyle}" Content="{x:Bind Album.ArtistName, Mode=OneWay}" Command="{x:Bind ArtistOpenCommand}" Opacity="0" x:Phase="1" />
 
                                 <common:AnimatedButton x:Name="favoriteButton" x:Uid="albumFavoriteButton" Grid.Column="1" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Stretch" Opacity="{x:Bind IsFavorite, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}" Icon="{StaticResource HeartPath}" Color="{x:Bind IsFavorite, Converter={StaticResource FavoriteToColorConverter}, Mode=OneWay}" Command="{x:Bind AlbumFavoriteCommand}" CommandParameter="{x:Bind IsFavorite, Converter={StaticResource BoolToInvertBoolConverter}, Mode=OneWay}" />

--- a/src/Presentation/Pages/PlaylistsPage.xaml
+++ b/src/Presentation/Pages/PlaylistsPage.xaml
@@ -39,7 +39,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="PlaylistListTemplate" x:DataType="a:PlaylistViewModel">
-            <Grid Padding="12,4" HorizontalAlignment="Stretch" Background="Transparent">
+            <Grid Padding="{StaticResource ListItemPadding}" HorizontalAlignment="Stretch" Background="Transparent">
                 <Grid.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem x:Uid="playlistFlyoutExport"
@@ -54,7 +54,7 @@
                     <common:PictureControl Cover="{x:Bind Picture, Mode=OneWay}" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                 </Border>
 
-                <StackPanel VerticalAlignment="Center" Margin="12,0,0,0">
+                <StackPanel VerticalAlignment="Center" Margin="{StaticResource ListItemTextMargin}">
                     <HyperlinkButton Content="{x:Bind Playlist.Name}" Command="{x:Bind PlaylistOpenCommand}" Style="{StaticResource HyperlinkSmallButtonStyle}" Margin="4,0,0,0" FontSize="{StaticResource FontSizeXMedium}" FontWeight="SemiBold" />
 
                     <Grid Height="20">

--- a/src/Presentation/Pages/RadiosPage.xaml
+++ b/src/Presentation/Pages/RadiosPage.xaml
@@ -60,7 +60,7 @@
                 <Border Background="{ThemeResource BadgeLiveBrush}"
                         CornerRadius="4"
                         HorizontalAlignment="Right" VerticalAlignment="Top"
-                        Margin="0,8,8,0" Padding="6,2">
+                        Margin="{StaticResource CoverBadgeMargin}" Padding="6,2">
                     <TextBlock Text="LIVE" Foreground="White" FontSize="10" FontWeight="Bold" />
                 </Border>
 
@@ -87,7 +87,7 @@
                     <TextBlock Grid.Row="1"
                                Text="{x:Bind common:RadioDisplay.FormatTechnical(Codec, Bitrate)}"
                                Style="{StaticResource GridCoverBottomSecondLineStyle}"
-                               Margin="4,6,0,0" />
+                               Margin="{StaticResource CoverSubtitleMargin}" />
                 </Grid>
             </Grid>
         </DataTemplate>

--- a/src/Presentation/Pages/SearchPage.xaml
+++ b/src/Presentation/Pages/SearchPage.xaml
@@ -70,7 +70,7 @@
                                     <common:PictureControl Style="{StaticResource PictureCoverStyle}" Cover="{x:Bind Picture, Mode=OneWay}" x:Phase="2" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                                 </Border>
 
-                                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="0,8,8,0">
+                                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="{StaticResource CoverBadgeMargin}">
                                     <common:BadgeControl x:Uid="badgeNew" Visibility="{x:Bind ShowNewBadge, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeNewBrush}" />
                                 </StackPanel>
 
@@ -87,7 +87,7 @@
 
                                     <HyperlinkButton Content="{x:Bind Artist.Name}" x:Phase="0" Command="{x:Bind ArtistOpenCommand}" Style="{StaticResource GridCoverButtonStyle}" />
 
-                                    <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="4,6,0,0" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
+                                    <TextBlock x:Name="subTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="{StaticResource CoverSubtitleMargin}" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
                                     <HyperlinkButton x:Name="genreName" Grid.Row="1" IsTabStop="False" Style="{StaticResource GridCoverButtonStyle}" Content="{x:Bind Artist.GenreName, Mode=OneWay}" Command="{x:Bind GenreOpenCommand}" Opacity="0" x:Phase="1" />
 
                                     <common:AnimatedButton x:Name="favoriteButton" x:Uid="artistFavoriteButton" Grid.Row="0" Grid.Column="1" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Stretch" Opacity="{x:Bind IsFavorite, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}" Icon="{StaticResource HeartPath}" Color="{x:Bind IsFavorite, Converter={StaticResource FavoriteToColorConverter}, Mode=OneWay}" Command="{x:Bind ArtistFavoriteCommand}" CommandParameter="{x:Bind IsFavorite, Converter={StaticResource BoolToInvertBoolConverter}, Mode=OneWay}" />
@@ -139,7 +139,7 @@
                                     <common:PictureControl Style="{StaticResource PictureCoverStyle}" Cover="{x:Bind Picture, Mode=OneWay}" x:Phase="2" PlayButtonVisibility="Visible" Command="{x:Bind ListenCommand}" />
                                 </Border>
 
-                                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="0,8,8,0">
+                                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Vertical" Spacing="{StaticResource SpacingXSmall}" Margin="{StaticResource CoverBadgeMargin}">
                                     <common:BadgeControl x:Uid="badgeLive" Visibility="{x:Bind IsLive, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeLiveBrush}"/>
                                     <common:BadgeControl x:Uid="badgeBestof" Visibility="{x:Bind IsBestOf, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeBestOfBrush}" />
                                     <common:BadgeControl x:Uid="badgeCompilation" Visibility="{x:Bind IsCompilation, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeCompilationBrush}" />
@@ -159,7 +159,7 @@
 
                                     <HyperlinkButton Content="{x:Bind Album.Name}" x:Phase="0" Command="{x:Bind AlbumOpenCommand}" Style="{StaticResource GridCoverButtonStyle}" />
 
-                                    <TextBlock x:Name="albumSubTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="4,6,0,0" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
+                                    <TextBlock x:Name="albumSubTitle" Grid.Row="1" Style="{StaticResource GridCoverBottomSecondLineStyle}" Margin="{StaticResource CoverSubtitleMargin}" Text="{x:Bind SubTitle, Mode=OneWay}" Opacity="1" x:Phase="1" />
                                     <HyperlinkButton x:Name="albumArtistName" Grid.Row="1" IsTabStop="False" Style="{StaticResource GridCoverButtonStyle}" Content="{x:Bind Album.ArtistName, Mode=OneWay}" Command="{x:Bind ArtistOpenCommand}" Opacity="0" x:Phase="1" />
 
                                     <common:AnimatedButton x:Name="albumFavoriteButton" x:Uid="albumFavoriteButton" Grid.Column="1" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Stretch" Opacity="{x:Bind IsFavorite, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}" Icon="{StaticResource HeartPath}" Color="{x:Bind IsFavorite, Converter={StaticResource FavoriteToColorConverter}, Mode=OneWay}" Command="{x:Bind AlbumFavoriteCommand}" CommandParameter="{x:Bind IsFavorite, Converter={StaticResource BoolToInvertBoolConverter}, Mode=OneWay}" />

--- a/src/Presentation/Pages/TracksPage.xaml
+++ b/src/Presentation/Pages/TracksPage.xaml
@@ -58,7 +58,7 @@
                     <AppBarSeparator />
 
                     <!-- Info about tracks count and duration -->
-                    <StackPanel Style="{StaticResource CommandBarStatInfoPanelStyle}" Margin="12,0,0,0">
+                    <StackPanel Style="{StaticResource CommandBarStatInfoPanelStyle}">
                         <FontIcon Glyph="&#xE8D6;" Style="{StaticResource CommandBarStatInfoIconStyle}" />
                         <TextBlock Style="{StaticResource CommandBarStatInfoTextStyle}">
                             <Run x:Name="trackCountRun" FontWeight="SemiBold" />

--- a/src/Presentation/Styles/Components/ControlsStyles.xaml
+++ b/src/Presentation/Styles/Components/ControlsStyles.xaml
@@ -810,6 +810,7 @@
         <Setter Property="Orientation" Value="Horizontal" />
         <Setter Property="Spacing" Value="{StaticResource SpacingXSmall}" />
         <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Margin" Value="12,0,0,0" />
     </Style>
 
     <Style x:Key="CommandBarStatInfoIconStyle" TargetType="FontIcon">

--- a/src/Presentation/Styles/Tokens/Spacing.xaml
+++ b/src/Presentation/Styles/Tokens/Spacing.xaml
@@ -54,4 +54,10 @@
     <x:Double x:Key="GridCoverBottomFirstLineWidth">310</x:Double>
     <x:Double x:Key="GridCoverBottomSecondLineWidth">310</x:Double>
     <x:Double x:Key="GridCoverBottomLineHeight">60</x:Double>
+
+    <!-- Semantic spacing (Thickness) — recurring cross-page patterns -->
+    <Thickness x:Key="CoverBadgeMargin">0,8,8,0</Thickness>
+    <Thickness x:Key="CoverSubtitleMargin">4,6,0,0</Thickness>
+    <Thickness x:Key="ListItemPadding">12,4</Thickness>
+    <Thickness x:Key="ListItemTextMargin">12,0,0,0</Thickness>
 </ResourceDictionary>


### PR DESCRIPTION
## Contexte
Lot **C1** de l'initiative d'amélioration UX/UI (axe *cohérence visuelle*).

## Changements
Introduit 4 tokens `Thickness` sémantiques dans `Styles/Tokens/Spacing.xaml`, reprenant les **valeurs exactes** actuelles (aucun changement visuel) :
- `CoverBadgeMargin` (`0,8,8,0`), `CoverSubtitleMargin` (`4,6,0,0`), `ListItemPadding` (`12,4`), `ListItemTextMargin` (`12,0,0,0`).

Appliqués aux motifs récurrents inter-pages (badges de pochette, sous-titres de tuiles, padding/marge des templates liste) sur Albums, Artists, Artist, Genre, Playlists, Radios, Search.

La marge du panneau de stats du CommandBar (`12,0,0,0`, répétée sur 3 pages) est remontée dans le style partagé `CommandBarStatInfoPanelStyle`.

> Périmètre volontairement limité aux motifs **récurrents** : les valeurs one-off légitimes (OptionsPage, positionnement absolu de FullScreenControl) ne sont pas touchées.

## Note technique
`Margin`/`Padding` sont de type `Thickness` : on ne peut pas y lier un token `x:Double` — d'où des ressources `<Thickness>` dédiées (et non la réutilisation des doubles `Spacing*`).

## Vérification
- Build x64 : 0 erreur, 0 warning. Suite de tests : 1446 tests verts.
- Smoke test runtime : pages Albums (grille+liste), Artists, Tracks, Playlists, Radios rendues sans erreur (rendu pixel-perfect, valeurs identiques).

🤖 Generated with [Claude Code](https://claude.com/claude-code)