### PR TITLE
chore(deps): bump low/moderate-risk NuGet packages

### DIFF
--- a/src/Presentation/Rok.csproj
+++ b/src/Presentation/Rok.csproj
@@ -129,11 +129,11 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
+		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
 		<PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
 		<PackageReference Include="MiF.RelayCommand" Version="1.0.0" />

--- a/src/Presentation/Rok.csproj
+++ b/src/Presentation/Rok.csproj
@@ -122,13 +122,13 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.Controls.TokenizingTextBox" Version="8.2.251219" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Rok.Application/Rok.Application.csproj
+++ b/src/Rok.Application/Rok.Application.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="CleanArch.DevKit.Mediator.Results" Version="1.1.1" />
     <PackageReference Include="CleanArch.DevKit.Mediator.Validation" Version="1.1.1" />
     <PackageReference Include="Dapper" Version="2.1.72" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="CleanArch.DevKit.Messaging" Version="1.1.1" />
     <PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
   </ItemGroup>

--- a/src/Rok.Application/Rok.Application.csproj
+++ b/src/Rok.Application/Rok.Application.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="CleanArch.DevKit.Mediator.Behaviors" Version="1.1.1" />
     <PackageReference Include="CleanArch.DevKit.Mediator.Results" Version="1.1.1" />
     <PackageReference Include="CleanArch.DevKit.Mediator.Validation" Version="1.1.1" />
-    <PackageReference Include="Dapper" Version="2.1.72" />
+    <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="CleanArch.DevKit.Messaging" Version="1.1.1" />

--- a/src/Rok.Domain/Rok.Domain.csproj
+++ b/src/Rok.Domain/Rok.Domain.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
   </ItemGroup>
 

--- a/src/Rok.Infrastructure/Migration/Migration7.cs
+++ b/src/Rok.Infrastructure/Migration/Migration7.cs
@@ -6,8 +6,8 @@ public class Migration7 : IMigration
 
     public void Apply(IDbConnection connection)
     {
-        connection.ExecuteAsync("UPDATE artists SET totalDurationSeconds = (SELECT COALESCE(SUM(duration), 0) FROM tracks WHERE tracks.artistId = artists.id);");
-        connection.ExecuteAsync("UPDATE genres SET totalDurationSeconds = (SELECT COALESCE(SUM(duration), 0) FROM tracks WHERE tracks.genreId = genres.id);");
-        connection.ExecuteAsync("UPDATE albums SET duration = (SELECT COALESCE(SUM(duration), 0) FROM tracks WHERE tracks.albumId = albums.id);");
+        connection.Execute("UPDATE artists SET totalDurationSeconds = (SELECT COALESCE(SUM(duration), 0) FROM tracks WHERE tracks.artistId = artists.id);");
+        connection.Execute("UPDATE genres SET totalDurationSeconds = (SELECT COALESCE(SUM(duration), 0) FROM tracks WHERE tracks.genreId = genres.id);");
+        connection.Execute("UPDATE albums SET duration = (SELECT COALESCE(SUM(duration), 0) FROM tracks WHERE tracks.albumId = albums.id);");
     }
 }

--- a/src/Rok.Infrastructure/Rok.Infrastructure.csproj
+++ b/src/Rok.Infrastructure/Rok.Infrastructure.csproj
@@ -8,11 +8,11 @@
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.72" />
 		<PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
 		<PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
 		<PackageReference Include="NAudio" Version="2.3.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/src/Rok.Infrastructure/Rok.Infrastructure.csproj
+++ b/src/Rok.Infrastructure/Rok.Infrastructure.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Dapper" Version="2.1.72" />
+		<PackageReference Include="Dapper" Version="2.1.79" />
 		<PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />

--- a/src/Rok.Shared/Rok.Shared.csproj
+++ b/src/Rok.Shared/Rok.Shared.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
   </ItemGroup>
 

--- a/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
+++ b/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
@@ -13,7 +13,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Dapper" Version="2.1.72" />
+		<PackageReference Include="Dapper" Version="2.1.79" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />

--- a/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
+++ b/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
@@ -9,14 +9,14 @@
 	<ItemGroup>
 		<PackageReference Include="CleanArch.DevKit.Mediator.Results.Testing" Version="1.1.1" />
 		<PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.1.1" />
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Dapper" Version="2.1.79" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
+++ b/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
@@ -14,7 +14,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Dapper" Version="2.1.72" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />

--- a/tests/UnitTests/Rok.ImportTests/Rok.ImportTests.csproj
+++ b/tests/UnitTests/Rok.ImportTests/Rok.ImportTests.csproj
@@ -7,12 +7,12 @@
 
   <ItemGroup>
     <PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.1.1" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Rok.Infrastructure.UnitTests.csproj
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Rok.Infrastructure.UnitTests.csproj
@@ -7,12 +7,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
+++ b/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
@@ -16,11 +16,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="CleanArch.DevKit.Mediator.Testing" Version="1.1.1" />
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
@
## Résumé

Bump des paquets NuGet par lots, classés par risque. Chaque lot a été validé par un build `/p:Platform=x64` sans warning + la suite de tests complète (1446 tests) avant commit.

## Lots inclus

| Lot | Paquets | Version |
|---|---|---|
| 1 | `Microsoft.Extensions.*`, `Microsoft.Data.Sqlite` | 10.0.5 → 10.0.9 |
| 2 | `Dapper` | 2.1.72 → 2.1.79 |
| 3 | `Microsoft.NET.Test.Sdk`, `coverlet.collector`, `Microsoft.Extensions.TimeProvider.Testing` | 18.4.0→18.6.0, 10.0.0→10.0.1, 10.4.0→10.7.0 |
| 5 | `Microsoft.Windows.CsWin32`, `Microsoft.Windows.SDK.BuildTools` | 0.3.269→0.3.275, …1721→…1839 |

### Fix opportuniste (hors bump)

- `fix(infrastructure)`: `Migration7` exécutait ses `UPDATE` de backfill via `connection.ExecuteAsync(...)` dans la méthode **synchrone** `IMigration.Apply` → tâches fire-and-forget non observées, sans garantie de complétion. Passé à `connection.Execute` synchrone, comme toutes les autres migrations. Révélé par VSTHRD110 pendant le Lot 4.

## Lots NON inclus (décisions explicites)

- **Lot 4 — Analyseurs** (`IDisposableAnalyzers`, `Microsoft.VisualStudio.Threading.Analyzers`, `Roslynator.Analyzers`) : **abandonné**. Les bumps majeurs révélaient 34 findings de dette préexistante (`VSTHRD110/200/003`, `IDISP024/025`) qui auraient transformé le bump en chantier de nettoyage. À traiter séparément.
- **Lot 6 — `Microsoft.WindowsAppSDK` 1.8 → 2.1.3** : **différé**. Première version majeure depuis 1.0 (frontière breaking SemVer), sortie le 21 mai 2026 (~3 semaines), nécessite un smoke test runtime dédié. Mérite sa propre session.

## Validation

- Build `/p:Platform=x64` : 12 projets, 0 erreur, 0 warning.
- Tests : 1446 passent (Import 113, Application 600, Infrastructure 394, Presentation 339), 0 échec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@