### PR TITLE
chore(deps): bump Microsoft.WindowsAppSDK to 2.1.3

### DIFF
--- a/src/Presentation/Rok.csproj
+++ b/src/Presentation/Rok.csproj
@@ -134,7 +134,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
 		<PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
 		<PackageReference Include="MiF.RelayCommand" Version="1.0.0" />
 	</ItemGroup>

--- a/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
+++ b/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
@@ -21,7 +21,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
@
## Résumé

Bump majeur de `Microsoft.WindowsAppSDK` **1.8.260317003 → 2.1.3** (Rok.csproj + Rok.PresentationTests.csproj). Première version majeure depuis 1.0 sous le nouveau schéma SemVer — frontière où les breaking changes sont autorisés. Différé de la PR #332 pour validation runtime dédiée.

## Validation compile-time

- Build `/p:Platform=x64` : 12 projets, **0 erreur, 0 warning** sous `TreatWarningsAsErrors` → aucune API supprimée/renommée/dépréciée utilisée.
- Tests : **1446 passent**, 0 échec.
- Vérif des dépréciations WinUI 2.x annoncées :
  - `FocusManager.GetFocusedElement(XamlRoot)` (PlayerView) utilise la surcharge `XamlRoot` recommandée, pas la surcharge sans paramètre dépréciée.
  - `Window.Current`, `DependencyObject.Dispatcher`, `SystemBackdropHost` (renommé) : non utilisés.

## Validation runtime (smoke test manuel)

Déploiement loose AppX redéployé proprement (rebuild complet pour purger les DLL runtime 1.8 stale ; tout le runtime confirmé en 2.x), package dev ré-enregistré. App lancée :

- Démarrage sain : bootstrap WinAppSDK 2.1.3, caches DB, SMTC, Discord, Web API — **aucune exception** au log.
- **Navigation fluide** Artists/Albums/Tracks/Playlists (zone du crash `MeasureOverride` connu en 1.8 — pas de régression observée).
- **Lecture audio OK**.
- **Drag de la barre de titre fonctionnel** (comportement des drag regions modifié en 2.x — validé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@