### PR TITLE
refactor(deps): bump analyzers (IDisposable, Roslynator, VS.Threading) and fix findings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.2.2">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="IDisposableAnalyzers" Version="2.0.6">
+    <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.5.32">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Presentation/App.xaml.cs
+++ b/src/Presentation/App.xaml.cs
@@ -138,7 +138,7 @@ public partial class App : Microsoft.UI.Xaml.Application
     private void HandleCliCommand(string? arguments)
     {
         IPlayerCommandHandler handler = ServiceProvider.GetRequiredService<IPlayerCommandHandler>();
-        MainWindow?.DispatcherQueue.TryEnqueue(() => handler.HandleAsync(arguments));
+        MainWindow?.DispatcherQueue.TryEnqueue(() => _ = handler.HandleAsync(arguments));
     }
 
     [Conditional("DEBUG")]

--- a/src/Presentation/Commons/ListViewExtended.cs
+++ b/src/Presentation/Commons/ListViewExtended.cs
@@ -125,22 +125,12 @@ public sealed partial class ListViewExtended : ListView, IDisposable
         }
     }
 
-    private void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                SelectionChanged -= OnSelectionChanged;
-            }
-
-            disposedValue = true;
-        }
-    }
-
     public void Dispose()
     {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
+        if (disposedValue)
+            return;
+
+        SelectionChanged -= OnSelectionChanged;
+        disposedValue = true;
     }
 }

--- a/src/Presentation/Commons/MenuFlyoutExtensions.cs
+++ b/src/Presentation/Commons/MenuFlyoutExtensions.cs
@@ -311,7 +311,7 @@ public static class MenuFlyoutExtensions
                 SetAlbumId(menuItem, albumId);
                 SetArtistId(menuItem, artistId);
 
-                RoutedEventHandler handler = MenuItemStaticClickHandlerAsync;
+                RoutedEventHandler handler = MenuItemStaticClickHandler;
                 menuItem.Click += handler;
                 SetMenuItemClickHandler(menuItem, handler);
 
@@ -340,7 +340,7 @@ public static class MenuFlyoutExtensions
         SetAlbumId(newPlaylistItem, albumId);
         SetArtistId(newPlaylistItem, artistId);
 
-        RoutedEventHandler newHandler = NewPlaylistStaticClickHandlerAsync;
+        RoutedEventHandler newHandler = NewPlaylistStaticClickHandler;
         newPlaylistItem.Click += newHandler;
         SetMenuItemClickHandler(newPlaylistItem, newHandler);
 
@@ -359,7 +359,7 @@ public static class MenuFlyoutExtensions
         SetAlbumId(addToCurrentListeningItem, albumId);
         SetArtistId(addToCurrentListeningItem, artistId);
 
-        RoutedEventHandler addToCurrentListeningHandler = AddToCurrentListeningStaticClickHandlerAsync;
+        RoutedEventHandler addToCurrentListeningHandler = AddToCurrentListeningStaticClickHandler;
         addToCurrentListeningItem.Click += addToCurrentListeningHandler;
         SetMenuItemClickHandler(addToCurrentListeningItem, addToCurrentListeningHandler);
 
@@ -381,7 +381,7 @@ public static class MenuFlyoutExtensions
         }
     }
 
-    private static async void MenuItemStaticClickHandlerAsync(object? sender, RoutedEventArgs e)
+    private static async void MenuItemStaticClickHandler(object? sender, RoutedEventArgs e)
     {
         if (sender is not MenuFlyoutItem mi)
             return;
@@ -413,7 +413,7 @@ public static class MenuFlyoutExtensions
         }
     }
 
-    private static async void NewPlaylistStaticClickHandlerAsync(object? sender, RoutedEventArgs e)
+    private static async void NewPlaylistStaticClickHandler(object? sender, RoutedEventArgs e)
     {
         if (sender is not MenuFlyoutItem mi)
             return;
@@ -449,7 +449,7 @@ public static class MenuFlyoutExtensions
     }
 
 
-    private static async void AddToCurrentListeningStaticClickHandlerAsync(object? sender, RoutedEventArgs e)
+    private static async void AddToCurrentListeningStaticClickHandler(object? sender, RoutedEventArgs e)
     {
         if (sender is not MenuFlyoutItem mi)
             return;

--- a/src/Presentation/Commons/ReviewPromptControl.xaml.cs
+++ b/src/Presentation/Commons/ReviewPromptControl.xaml.cs
@@ -29,7 +29,12 @@ public sealed partial class ReviewPromptControl : UserControl
         ((Storyboard)Resources["ShowStoryboard"]).Begin();
 
         _tcs = new TaskCompletionSource<bool?>();
+
+        // The TCS is completed by button clicks / storyboard callbacks on the UI thread;
+        // returning its Task is the intended dialog-result pattern, no cross-context deadlock.
+#pragma warning disable VSTHRD003
         return _tcs.Task;
+#pragma warning restore VSTHRD003
     }
 
     private async Task HideAsync()

--- a/src/Presentation/Services/DialogService.cs
+++ b/src/Presentation/Services/DialogService.cs
@@ -268,7 +268,7 @@ public sealed class DialogService(ResourceLoader resourceLoader, ITranslateServi
         bool enqueued = App.MainWindow.DispatcherQueue.TryEnqueue(() =>
         {
             Task task = func();
-            task.ContinueWith(t =>
+            _ = task.ContinueWith(t =>
             {
                 if (t.IsFaulted)
                     tcs.SetException(t.Exception!.Flatten());

--- a/src/Presentation/Services/PlayerCommand/Api/PlayerWebApiService.cs
+++ b/src/Presentation/Services/PlayerCommand/Api/PlayerWebApiService.cs
@@ -52,7 +52,7 @@ public sealed partial class PlayerWebApiService(
 
             logger.LogInformation("Player Web API started on http://localhost:{Port}", ActivePort);
 
-            Task.Run(() => ListenAsync(_cts.Token), _cts.Token);
+            _ = Task.Run(() => ListenAsync(_cts.Token), _cts.Token);
         }
         catch (HttpListenerException ex)
         {

--- a/src/Presentation/Services/PlaylistMenuService.cs
+++ b/src/Presentation/Services/PlaylistMenuService.cs
@@ -6,7 +6,7 @@ using Rok.Application.Player;
 
 namespace Rok.Services;
 
-public partial class PlaylistMenuService : IPlaylistMenuService, IDisposable
+public sealed partial class PlaylistMenuService : IPlaylistMenuService, IDisposable
 {
     private readonly IMediator _mediator;
     private readonly IMessenger _messenger;
@@ -314,6 +314,5 @@ public partial class PlaylistMenuService : IPlaylistMenuService, IDisposable
         _subscriptions.Clear();
 
         _cacheSemaphore?.Dispose();
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Presentation/ViewModels/Listening/ListeningViewModel.cs
+++ b/src/Presentation/ViewModels/Listening/ListeningViewModel.cs
@@ -9,7 +9,7 @@ using ResourceLoader = Windows.ApplicationModel.Resources.ResourceLoader;
 
 namespace Rok.ViewModels.Listening;
 
-public partial class ListeningViewModel : ObservableObject, IDisposable
+public sealed partial class ListeningViewModel : ObservableObject, IDisposable
 {
     private readonly ILogger<ListeningViewModel> _logger;
     private readonly IPlayerService _playerService;
@@ -182,6 +182,5 @@ public partial class ListeningViewModel : ObservableObject, IDisposable
             subscription.Dispose();
         _subscriptions.Clear();
         _disposed = true;
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Presentation/ViewModels/Listening/ListeningViewModel.cs
+++ b/src/Presentation/ViewModels/Listening/ListeningViewModel.cs
@@ -79,9 +79,7 @@ public sealed partial class ListeningViewModel : ObservableObject, IDisposable
         if (_playerService.Playlist != null)
         {
             _playlistManager.LoadTracksList(_playerService.Playlist);
-#pragma warning disable CS4014
-            _playlistManager.SetCurrentTrackAsync(_playerService.CurrentTrack);
-#pragma warning restore CS4014
+            _ = _playlistManager.SetCurrentTrackAsync(_playerService.CurrentTrack);
         }
     }
 

--- a/src/Presentation/ViewModels/Main/MainViewModel.cs
+++ b/src/Presentation/ViewModels/Main/MainViewModel.cs
@@ -6,7 +6,7 @@ using Rok.ViewModels.Search;
 
 namespace Rok.ViewModels.Main;
 
-public partial class MainViewModel : ObservableObject, IDisposable
+public sealed partial class MainViewModel : ObservableObject, IDisposable
 {
     private DispatcherQueue? _dispatcherQueue;
     private DispatcherQueue DispatcherQueue => _dispatcherQueue ??= DispatcherQueue.GetForCurrentThread();
@@ -137,6 +137,5 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _mediaChangedSubscription.Dispose();
         _radioStationChangedSubscription.Dispose();
         _disposed = true;
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Presentation/ViewModels/Main/MainViewModel.cs
+++ b/src/Presentation/ViewModels/Main/MainViewModel.cs
@@ -67,7 +67,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         {
             string message = _resourceLoader.GetString("NoLibraryFoldersMessage");
             string title = _resourceLoader.GetString("NoLibraryFoldersTitleMessage");
-            _dialogService.ShowTextAsync(title, message);
+            _ = _dialogService.ShowTextAsync(title, message);
             return false;
         }
 

--- a/src/Presentation/ViewModels/Main/SearchSuggestionsViewModel.cs
+++ b/src/Presentation/ViewModels/Main/SearchSuggestionsViewModel.cs
@@ -5,7 +5,7 @@ using Rok.Application.Services;
 
 namespace Rok.ViewModels.Main;
 
-public partial class SearchSuggestionsViewModel : ObservableObject, IDisposable
+public sealed partial class SearchSuggestionsViewModel : ObservableObject, IDisposable
 {
     private readonly IMediator _mediator;
     private readonly IDisposable _libraryRefreshSubscription;
@@ -110,7 +110,6 @@ public partial class SearchSuggestionsViewModel : ObservableObject, IDisposable
         _libraryRefreshSubscription.Dispose();
         _debounceCts?.Dispose();
         _disposed = true;
-        GC.SuppressFinalize(this);
     }
 
 

--- a/src/Presentation/ViewModels/Start/StartViewModel.cs
+++ b/src/Presentation/ViewModels/Start/StartViewModel.cs
@@ -9,7 +9,7 @@ using Windows.Storage.AccessCache;
 
 namespace Rok.ViewModels.Start;
 
-public partial class StartViewModel : ObservableObject, IDisposable
+public sealed partial class StartViewModel : ObservableObject, IDisposable
 {
     private const int KDisplayIntervalMs = 300;
 
@@ -125,7 +125,6 @@ public partial class StartViewModel : ObservableObject, IDisposable
 
         UnregisterEvents();
         _disposed = true;
-        GC.SuppressFinalize(this);
     }
 
     private async Task LibraryRefreshChangeAsync(LibraryRefreshMessage message)

--- a/src/Presentation/ViewModels/Track/TrackViewModel.cs
+++ b/src/Presentation/ViewModels/Track/TrackViewModel.cs
@@ -57,9 +57,7 @@ public partial class TrackViewModel : ObservableObject, IDisposable, IFilterable
 
             OnPropertyChanged(nameof(Score));
 
-#pragma warning disable 4014
-            SetScoreAsync(Track.Score);
-#pragma warning restore 4014
+            _ = SetScoreAsync(Track.Score);
         }
     }
 

--- a/src/Rok.Application/Player/PlayerService.cs
+++ b/src/Rok.Application/Player/PlayerService.cs
@@ -81,7 +81,7 @@ public sealed class PlayerService : IPlayerService, IDisposable
             if (_mode == EPlaybackMode.Radio)
                 return;
 
-            Task.Run(() =>
+            _ = Task.Run(() =>
             {
                 double seek = Math.Max(0, value);
 

--- a/src/Rok.Application/Player/PlayerService.cs
+++ b/src/Rok.Application/Player/PlayerService.cs
@@ -8,7 +8,7 @@ using Rok.Services.Player;
 
 namespace Rok.Application.Player;
 
-public class PlayerService : IPlayerService, IDisposable
+public sealed class PlayerService : IPlayerService, IDisposable
 {
     private EPlaybackState _playerState = EPlaybackState.Stopped;
 

--- a/src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs
+++ b/src/Rok.Infrastructure/Player/NAudioMediaPlayer.cs
@@ -276,7 +276,7 @@ public class NAudioMediaPlayer : IPlayerEngine, IDisposable
         _isLive = true;
         _length = 0;
 
-        Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
             try
             {

--- a/src/Rok.Infrastructure/Social/DiscordRichPresenceService.cs
+++ b/src/Rok.Infrastructure/Social/DiscordRichPresenceService.cs
@@ -8,7 +8,7 @@ using Rok.Application.Options;
 
 namespace Rok.Infrastructure.Social;
 
-public class DiscordRichPresenceService : IDisposable, IDiscordRichPresenceService
+public sealed class DiscordRichPresenceService : IDisposable, IDiscordRichPresenceService
 {
     private readonly DiscordRpcClient? _client;
     private readonly ILogger<DiscordRichPresenceService> _logger;
@@ -200,18 +200,12 @@ public class DiscordRichPresenceService : IDisposable, IDiscordRichPresenceServi
 
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    protected virtual void Dispose(bool disposing)
-    {
         lock (_lock)
         {
             if (_disposed)
                 return;
 
-            if (disposing && _client != null)
+            if (_client != null)
             {
                 try
                 {

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/ImportPlaylistCommandHandlerTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/ImportPlaylistCommandHandlerTests.cs
@@ -11,7 +11,7 @@ using Rok.Application.Interfaces.Repositories;
 
 namespace Rok.ApplicationTests.Features.Playlists.Requests;
 
-public class ImportPlaylistRequestHandlerTests : IDisposable
+public sealed class ImportPlaylistRequestHandlerTests : IDisposable
 {
     private readonly SqliteConnection _connection;
     private readonly Mock<IPlaylistFormatResolver> _resolver = new();

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/SqliteDatabaseFixture.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/SqliteDatabaseFixture.cs
@@ -7,7 +7,7 @@ using Rok.Infrastructure.Repositories;
 
 namespace Rok.Infrastructure.UnitTests;
 
-public class SqliteDatabaseFixture : IDisposable
+public sealed class SqliteDatabaseFixture : IDisposable
 {
     static SqliteDatabaseFixture()
     {

--- a/tests/UnitTests/Rok.PresentationTests/Services/TagsProviderTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/Services/TagsProviderTests.cs
@@ -66,9 +66,11 @@ public class TagsProviderTests
         // Arrange
         TagsProvider sut = new(_mediator, new Messenger());
 
-        // Act
+        // Act — deliberate double dispose to verify idempotency; using-declaration would defeat the test
+#pragma warning disable IDISP017
         sut.Dispose();
         sut.Dispose();
+#pragma warning restore IDISP017
 
         // Assert — no exception
     }

--- a/tests/UnitTests/Rok.PresentationTests/ViewModels/Start/FolderValidatorTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/ViewModels/Start/FolderValidatorTests.cs
@@ -2,7 +2,7 @@ using Rok.ViewModels.Start;
 
 namespace Rok.PresentationTests.ViewModels.Start;
 
-public class FolderValidatorTests : IDisposable
+public sealed class FolderValidatorTests : IDisposable
 {
     private readonly DirectoryInfo _tempDir = Directory.CreateTempSubdirectory("FolderValidatorTests_");
 


### PR DESCRIPTION
## Résumé

Reprise prudente du « Lot 4 » écarté de la PR #332 : bump des 3 analyseurs déclarés dans `Directory.Build.props`, **un commit par analyseur** pour isoler les diffs et permettre un revert ciblé. Chaque étape finit build vert (0 warning sous `TreatWarningsAsErrors`) + 1446 tests.

## Étapes

### 1. IDisposableAnalyzers 2.0.6 → 4.0.8 (`91a2a74`)
13 findings résolus :
- **IDISP025** (sceller les types `IDisposable` feuilles) : `PlayerService`, `DiscordRichPresenceService`, `MainViewModel`, `StartViewModel`, `ListeningViewModel`, `SearchSuggestionsViewModel`, `PlaylistMenuService` + types de test. L'analyseur ne flagge que les types non dérivés → sealing sûr par construction.
- **IDISP023** : `DiscordRichPresenceService` — pattern finaliseur inutile (aucun finaliseur, aucune ressource non managée) replié en un simple `Dispose()`.
- **IDISP024** : retrait de `GC.SuppressFinalize` devenu inutile (`ListViewExtended` + ViewModels scellés).
- **IDISP017** : `TagsProviderTests` — suppression locale justifiée (le test vérifie volontairement la double-dispose).

### 2. Roslynator.Analyzers 3.2.2 → 4.15.0 (`29899d5`)
Aucun finding (4.x active moins de règles par défaut).

### 3. Microsoft.VisualStudio.Threading.Analyzers 15.5.32 → 17.14.15 (`a412992`)
12 findings résolus :
- **VSTHRD110** (x8) : discard explicite `_ =` sur des fire-and-forget délibérés qui ne peuvent pas `await` (setters de propriété, gardes `bool`, boucle du Web API, callbacks dispatcher). Garde la règle active globalement. Remplace 2 vieux `#pragma CS4014`.
- **VSTHRD200** (x3) : renommage des 3 handlers `async void` de `MenuFlyoutExtensions` (drop suffixe `Async`, références file-local).
- **VSTHRD003** (x1) : `ReviewPromptControl` — pragma local, le pattern `TaskCompletionSource` complété sur thread UI est l'usage prévu, pas de deadlock.

## Validation

- Build `/p:Platform=x64` : 0 erreur, **0 warning** sous `TreatWarningsAsErrors`.
- Tests : **1446 passent**, 0 échec.
- Smoke test runtime : app lancée, démarrage propre (0 erreur log), responsive. Corrections neutres au runtime (sealing, discards de Task déjà non observées, collapse de Dispose sémantiquement identique, renommages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
