### PR TITLE
feat(telemetry): capture current page on unhandled exceptions

### DIFF
--- a/src/Presentation/App.xaml.cs
+++ b/src/Presentation/App.xaml.cs
@@ -261,6 +261,8 @@ public partial class App : Microsoft.UI.Xaml.Application
             CrashStore crashStore = new();
             crashStore.IncrementCrashCount();
 
+            CaptureCrashContext(e.Exception);
+
             ITelemetryClient telemetry = ServiceProvider.GetRequiredService<ITelemetryClient>();
             _ = telemetry.CaptureExceptionAsync(e.Exception);
 #endif
@@ -270,6 +272,36 @@ public partial class App : Microsoft.UI.Xaml.Application
             // Ignore any logging errors to avoid masking the original exception.
         }
     }
+
+#if !DEBUG
+    // The flaky MeasureOverride COMException has a bare framework-only stack (no app frame),
+    // so the current/previous page is the only signal for which screen triggered it. Emit it as
+    // a "crash" event (CaptureEventAsync persists the payload) and block briefly so it ships
+    // before the process is torn down.
+    private void CaptureCrashContext(Exception exception)
+    {
+        try
+        {
+            Rok.Services.NavigationService? navigation = ServiceProvider.GetService<Rok.Services.NavigationService>();
+            ITelemetryClient telemetry = ServiceProvider.GetRequiredService<ITelemetryClient>();
+
+            Dictionary<string, object> properties = new()
+            {
+                ["currentPage"] = navigation?.CurrentPageName ?? "unknown",
+                ["previousPage"] = navigation?.PreviousPageName ?? "unknown",
+                ["exceptionType"] = exception.GetType().FullName ?? exception.GetType().Name,
+                ["hresult"] = exception.HResult
+            };
+
+            Task.Run(async () => await telemetry.CaptureEventAsync("crash", exception.GetType().Name, properties))
+                .Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            // Never let crash diagnostics throw inside an exception handler.
+        }
+    }
+#endif
 
     private void HookGlobalDiagnostics()
     {
@@ -291,6 +323,8 @@ public partial class App : Microsoft.UI.Xaml.Application
             {
                 CrashStore crashStore = new();
                 crashStore.IncrementCrashCount();
+
+                CaptureCrashContext(ex);
 
                 ITelemetryClient telemetry = ServiceProvider.GetRequiredService<ITelemetryClient>();
                 Task.Run(async () => await telemetry.CaptureExceptionAsync(ex))

--- a/src/Presentation/Services/NavigationService.cs
+++ b/src/Presentation/Services/NavigationService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
 using Rok.Pages;
 using Rok.ViewModels.Album;
 using Rok.ViewModels.Artist;
@@ -11,7 +12,34 @@ namespace Rok.Services;
 
 public class NavigationService(ITelemetryClient telemetryClient)
 {
-    public Frame MainFrame { set; get; } = default!;
+    private Frame _mainFrame = default!;
+
+    public Frame MainFrame
+    {
+        get => _mainFrame;
+        set
+        {
+            if (_mainFrame is not null)
+                _mainFrame.Navigated -= OnFrameNavigated;
+
+            _mainFrame = value;
+
+            if (_mainFrame is not null)
+                _mainFrame.Navigated += OnFrameNavigated;
+        }
+    }
+
+    // Tracked for crash telemetry: a bare MeasureOverride COMException carries no app frame,
+    // so the current/previous page is the only clue to which screen triggered it.
+    public string? CurrentPageName { get; private set; }
+
+    public string? PreviousPageName { get; private set; }
+
+    private void OnFrameNavigated(object sender, NavigationEventArgs e)
+    {
+        PreviousPageName = CurrentPageName;
+        CurrentPageName = e.SourcePageType?.Name ?? e.Content?.GetType().Name;
+    }
 
     public void NavigateTo(Type pageType)
     {


### PR DESCRIPTION
## Contexte

La `COMException` dans `FrameworkElement.MeasureOverride` est un crash **flaky du framework WinAppSDK** (stack 100 % framework, aucune frame applicative), déclenché par la navigation rapide chevauchée. Il persiste après le passage à WinAppSDK 2.1.3 (PR #333) → le correctif n'est dans aucune version, il faut le diagnostiquer puis le contourner.

Après plusieurs sessions, **on ignore toujours quelle page le déclenche** car la télémétrie ne captait que l'exception nue. Approche retenue : **télémétrie d'abord** — capter le contexte en prod, puis cibler le fix.

## Changements (diagnostics uniquement, zéro changement de comportement)

- **`NavigationService`** suit `CurrentPageName` / `PreviousPageName` via l'événement `Frame.Navigated` (couvre nav avant **et** retour).
- **Handlers d'exception** (`App.UnhandledException` XAML + `AppDomain.UnhandledException`) émettent un événement télémétrie `crash` dont le payload porte `currentPage`, `previousPage`, `exceptionType`, `hresult`, avec une attente courte (2 s) pour fiabiliser l'envoi avant terminaison du process.
- Réutilise le chemin `CaptureEventAsync` (payload JSON déjà persisté) → **aucune modification backend nécessaire**.

## Validation

- Build Debug `/p:Platform=x64` : 0 erreur, 0 warning.
- Build Release (RID win-x64) : compile OK (la branche `#if !DEBUG` est validée ; seul warning environnement `mspdbcmf.exe`).
- Tests : 1446 passent.
- Smoke test runtime : démarrage propre, navigation OK, app responsive.

## Suite

Une fois en prod, les crashes porteront la page → on saura enfin **où** cibler (garde de navigation sur la page incriminée, ou simplification de transition). Pistes de fix gardées en réserve : sérialisation de navigation (anti-chevauchement) et désactivation des transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
