### PR TITLE
fix(presentation): restore list scroll position on back navigation

### DIFF
--- a/src/Presentation/Commons/ScrollStateHelper.cs
+++ b/src/Presentation/Commons/ScrollStateHelper.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Rok.Commons;
 
 public static class ScrollStateHelper
 {
+    // Bounds the number of layout passes we wait for the scrollable extent to materialize
+    // before giving up, so a one-shot LayoutUpdated handler never stays attached indefinitely.
+    private const int KMaxRestoreAttempts = 60;
+
     private static double _verticalScrollOffset = 0;
 
     private static ScrollViewer? GetScrollViewer(DependencyObject dependencyObject)
@@ -26,10 +30,53 @@ public static class ScrollStateHelper
 
     public static void RestoreScrollOffset(DependencyObject dependencyObject)
     {
+        double target = _verticalScrollOffset;
+
+        if (target <= 0)
+            return;
+
         ScrollViewer? scrollViewer = GetScrollViewer(dependencyObject);
 
-        if (scrollViewer != null && _verticalScrollOffset > 0)
-            scrollViewer.ChangeView(null, _verticalScrollOffset, null, true);
+        if (scrollViewer == null)
+            return;
+
+        // When the page reloads, the list has just been given its ItemsSource and has not yet
+        // realized/measured its containers, so ScrollableHeight is still 0 and an immediate
+        // ChangeView clamps back to the top. Wait for the extent to reach the saved offset, then
+        // restore once (or clamp to whatever extent exists if the content genuinely shrank).
+        if (TryApplyOffset(scrollViewer, target, force: false))
+            return;
+
+        int attempts = 0;
+
+        void OnLayoutUpdated(object? sender, object e)
+        {
+            attempts++;
+
+            bool lastAttempt = attempts >= KMaxRestoreAttempts;
+
+            if (TryApplyOffset(scrollViewer, target, force: lastAttempt) || lastAttempt)
+                scrollViewer.LayoutUpdated -= OnLayoutUpdated;
+        }
+
+        scrollViewer.LayoutUpdated += OnLayoutUpdated;
+    }
+
+
+    private static bool TryApplyOffset(ScrollViewer scrollViewer, double target, bool force)
+    {
+        if (scrollViewer.ScrollableHeight <= 0)
+            return false;
+
+        // Keep waiting while the extent is still growing toward the saved offset, unless this is
+        // the final attempt — then restore as close as the current extent allows.
+        if (!force && scrollViewer.ScrollableHeight < target)
+            return false;
+
+        double clamped = System.Math.Min(target, scrollViewer.ScrollableHeight);
+        scrollViewer.ChangeView(null, clamped, null, true);
+
+        return true;
     }
 
 


### PR DESCRIPTION
## Problème

Le retour (back) sur **Albums**, **Artists** et **Titres** remettait la liste **en haut** au lieu de restaurer la position de scroll précédente. Régression antérieure aux bumps NuGet (non causée par WinAppSDK 2.1.3).

## Cause

`ScrollStateHelper.RestoreScrollOffset` appelait `ScrollViewer.ChangeView` **synchrone** depuis `Page_Loaded`, juste après que la liste ait reçu son `ItemsSource` — donc **avant** que le `GridView`/`ListView` ait réalisé et mesuré ses conteneurs. À cet instant `ScrollableHeight` vaut encore 0, donc le `ChangeView` était **clampé en haut**. Le code « marchait par chance » quand l'extent était disponible plus tôt ; un changement de layout/virtualisation a décalé ce timing.

VM `AlbumsViewModel` singleton + données stables au retour → ce n'est pas un reset de données, bien un problème de timing du `ChangeView`.

## Correctif

Dans `ScrollStateHelper` : attendre que l'extent scrollable se matérialise (handler `LayoutUpdated` one-shot, borné par un garde de nombre max de tentatives) puis appliquer l'offset sauvegardé, en clampant à l'extent disponible si le contenu a réellement rétréci. Le handler se détache dès l'offset appliqué.

Comme le correctif est dans le helper partagé, il couvre les **3 pages** qui l'utilisent : Albums, Artists, Titres.

## Validation

- Build `/p:Platform=x64` : 0 erreur, 0 warning.
- Smoke test runtime : scroll → drill-in → back restaure la position sur **Albums**, **Artists** et **Titres** (confirmé).

## Hors périmètre

Les autres pages de liste (Playlists, Genres, Écoute, Radios, Recherche) n'utilisent pas `ScrollStateHelper` et n'ont jamais restauré le scroll — amélioration possible séparée (nécessiterait de keyer l'offset par page, le champ statique actuel étant partagé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
