### PR TITLE
feat(player): remove queued tracks by song, album, artist or genre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,3 +376,6 @@ appsettings.*.json
 /.claude/settings.local.json
 
 .superpowers/
+
+# legion battle artifacts (local only)
+.legion/

--- a/src/Presentation/Pages/ListeningPage.xaml
+++ b/src/Presentation/Pages/ListeningPage.xaml
@@ -162,6 +162,27 @@
                                             <FontIcon Glyph="&#xE90B;" />
                                         </MenuFlyoutItem.Icon>
                                     </MenuFlyoutItem>
+                                    <MenuFlyoutSeparator />
+                                    <MenuFlyoutItem x:Uid="listeningFlyoutRemoveTrack" Command="{Binding ElementName=PageRoot, Path=ViewModel.RemoveTrackFromQueueCommand}" CommandParameter="{x:Bind}" IsEnabled="{x:Bind IsUpcoming, Mode=OneWay}">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xECC9;" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutItem x:Uid="listeningFlyoutRemoveAlbum" Command="{Binding ElementName=PageRoot, Path=ViewModel.RemoveAlbumFromQueueCommand}" CommandParameter="{x:Bind}" IsEnabled="{x:Bind Track.AlbumId.HasValue}">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xECC9;" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutItem x:Uid="listeningFlyoutRemoveArtist" Command="{Binding ElementName=PageRoot, Path=ViewModel.RemoveArtistFromQueueCommand}" CommandParameter="{x:Bind}" IsEnabled="{x:Bind Track.ArtistId.HasValue}">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xECC9;" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutItem x:Uid="listeningFlyoutRemoveGenre" Command="{Binding ElementName=PageRoot, Path=ViewModel.RemoveGenreFromQueueCommand}" CommandParameter="{x:Bind}" IsEnabled="{x:Bind Track.GenreId.HasValue}">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xECC9;" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
                                 </MenuFlyout>
                             </Grid.ContextFlyout>
 

--- a/src/Presentation/Pages/ListeningPage.xaml.cs
+++ b/src/Presentation/Pages/ListeningPage.xaml.cs
@@ -10,12 +10,16 @@ public sealed partial class ListeningPage : Page, IDisposable
 {
     public ListeningViewModel ViewModel { get; set; }
 
+    private readonly ResourceLoader _resourceLoader;
+
 
     public ListeningPage()
     {
         this.InitializeComponent();
 
+        _resourceLoader = App.ServiceProvider.GetRequiredService<ResourceLoader>();
         ViewModel = App.ServiceProvider.GetRequiredService<ListeningViewModel>();
+        ViewModel.RemovalConfirmationRequested = ConfirmQueueRemovalAsync;
         DataContext = ViewModel;
     }
 
@@ -28,6 +32,23 @@ public sealed partial class ListeningPage : Page, IDisposable
     private void SleepFlyout_Opening(object sender, object e)
     {
         ViewModel.RefreshSleepTime();
+    }
+
+    private async Task<bool> ConfirmQueueRemovalAsync(int trackCount)
+    {
+        ContentDialog dialog = new()
+        {
+            XamlRoot = XamlRoot,
+            Title = _resourceLoader.GetString("RemoveFromQueueConfirmationTitle"),
+            Content = string.Format(_resourceLoader.GetString("RemoveFromQueueConfirmation"), trackCount),
+            PrimaryButtonText = _resourceLoader.GetString("YesButton"),
+            CloseButtonText = _resourceLoader.GetString("CancelButton"),
+            DefaultButton = ContentDialogButton.Close
+        };
+
+        ContentDialogResult result = await dialog.ShowAsync();
+
+        return result == ContentDialogResult.Primary;
     }
 
     private void ListeningPage_Loaded(object sender, RoutedEventArgs e)
@@ -54,6 +75,7 @@ public sealed partial class ListeningPage : Page, IDisposable
     public void Dispose()
     {
         // ListeningViewModel is a singleton; releasing the x:Bind tracking lets the page be collected.
+        ViewModel.RemovalConfirmationRequested = null;
         Bindings.StopTracking();
         DataContext = null;
     }

--- a/src/Presentation/Strings/en-US/Resources.resw
+++ b/src/Presentation/Strings/en-US/Resources.resw
@@ -816,6 +816,24 @@
   <data name="trackFlyoutAddMoreFromArtist.Text" xml:space="preserve">
     <value>Add more songs from this artist</value>
   </data>
+  <data name="listeningFlyoutRemoveTrack.Text" xml:space="preserve">
+    <value>Remove this song from the queue</value>
+  </data>
+  <data name="listeningFlyoutRemoveAlbum.Text" xml:space="preserve">
+    <value>Remove this album from the queue</value>
+  </data>
+  <data name="listeningFlyoutRemoveArtist.Text" xml:space="preserve">
+    <value>Remove this artist from the queue</value>
+  </data>
+  <data name="listeningFlyoutRemoveGenre.Text" xml:space="preserve">
+    <value>Remove this genre from the queue</value>
+  </data>
+  <data name="RemoveFromQueueConfirmationTitle" xml:space="preserve">
+    <value>Remove from queue</value>
+  </data>
+  <data name="RemoveFromQueueConfirmation" xml:space="preserve">
+    <value>{0} tracks will be removed from the queue. Continue?</value>
+  </data>
   <data name="welcomeWaiting.Text" xml:space="preserve">
     <value>Just a moment longer, we are preparing your data...</value>
   </data>

--- a/src/Presentation/Strings/es-ES/Resources.resw
+++ b/src/Presentation/Strings/es-ES/Resources.resw
@@ -699,6 +699,24 @@
   <data name="trackFlyoutAddMoreFromArtist.Text" xml:space="preserve">
     <value>Añade más canciones de este artista</value>
   </data>
+  <data name="listeningFlyoutRemoveTrack.Text" xml:space="preserve">
+    <value>Quitar esta canción de la cola</value>
+  </data>
+  <data name="listeningFlyoutRemoveAlbum.Text" xml:space="preserve">
+    <value>Quitar este álbum de la cola</value>
+  </data>
+  <data name="listeningFlyoutRemoveArtist.Text" xml:space="preserve">
+    <value>Quitar este artista de la cola</value>
+  </data>
+  <data name="listeningFlyoutRemoveGenre.Text" xml:space="preserve">
+    <value>Quitar este género de la cola</value>
+  </data>
+  <data name="RemoveFromQueueConfirmationTitle" xml:space="preserve">
+    <value>Quitar de la cola</value>
+  </data>
+  <data name="RemoveFromQueueConfirmation" xml:space="preserve">
+    <value>Se quitarán {0} pistas de la cola. ¿Continuar?</value>
+  </data>
   <data name="welcomeWaiting.Text" xml:space="preserve">
     <value>Un momento más, estamos preparando sus datos...</value>
   </data>

--- a/src/Presentation/Strings/fr-FR/Resources.resw
+++ b/src/Presentation/Strings/fr-FR/Resources.resw
@@ -816,6 +816,24 @@
   <data name="trackFlyoutAddMoreFromArtist.Text" xml:space="preserve">
     <value>Ajouter plus de chansons de cet artiste</value>
   </data>
+  <data name="listeningFlyoutRemoveTrack.Text" xml:space="preserve">
+    <value>Retirer cette chanson de la file</value>
+  </data>
+  <data name="listeningFlyoutRemoveAlbum.Text" xml:space="preserve">
+    <value>Retirer cet album de la file</value>
+  </data>
+  <data name="listeningFlyoutRemoveArtist.Text" xml:space="preserve">
+    <value>Retirer cet artiste de la file</value>
+  </data>
+  <data name="listeningFlyoutRemoveGenre.Text" xml:space="preserve">
+    <value>Retirer ce genre de la file</value>
+  </data>
+  <data name="RemoveFromQueueConfirmationTitle" xml:space="preserve">
+    <value>Retirer de la file</value>
+  </data>
+  <data name="RemoveFromQueueConfirmation" xml:space="preserve">
+    <value>{0} titres seront retirés de la file. Continuer ?</value>
+  </data>
   <data name="welcomeWaiting.Text" xml:space="preserve">
     <value>Encore un petit instant, nous préparons vos données...</value>
   </data>

--- a/src/Presentation/Strings/uk-UA/Resources.resw
+++ b/src/Presentation/Strings/uk-UA/Resources.resw
@@ -757,6 +757,24 @@
   <data name="trackFlyoutAddMoreFromArtist.Text" xml:space="preserve">
     <value>Додати ще пісні цього виконавця</value>
   </data>
+  <data name="listeningFlyoutRemoveTrack.Text" xml:space="preserve">
+    <value>Прибрати цю пісню з черги</value>
+  </data>
+  <data name="listeningFlyoutRemoveAlbum.Text" xml:space="preserve">
+    <value>Прибрати цей альбом з черги</value>
+  </data>
+  <data name="listeningFlyoutRemoveArtist.Text" xml:space="preserve">
+    <value>Прибрати цього виконавця з черги</value>
+  </data>
+  <data name="listeningFlyoutRemoveGenre.Text" xml:space="preserve">
+    <value>Прибрати цей жанр з черги</value>
+  </data>
+  <data name="RemoveFromQueueConfirmationTitle" xml:space="preserve">
+    <value>Прибрати з черги</value>
+  </data>
+  <data name="RemoveFromQueueConfirmation" xml:space="preserve">
+    <value>З черги буде прибрано {0} пісень. Продовжити?</value>
+  </data>
   <data name="welcomeWaiting.Text" xml:space="preserve">
     <value>Ще хвилинку, ми готуємо ваші дані...</value>
   </data>

--- a/src/Presentation/ViewModels/Listening/ListeningViewModel.cs
+++ b/src/Presentation/ViewModels/Listening/ListeningViewModel.cs
@@ -31,6 +31,12 @@ public sealed partial class ListeningViewModel : ObservableObject, IDisposable
     public bool IsSleepModeActive => _playerSleepModeService.IsSleepTimerActive;
     public int RemainingSleepTime => _playerSleepModeService.GetRemainingSleepTimeInSeconds();
 
+    /// <summary>
+    /// Asks the view to confirm a multi-track removal from the queue, passing the number of tracks that would be removed.
+    /// Set by the page so the confirmation dialog stays out of the view model. Returns true when the user confirms.
+    /// </summary>
+    public Func<int, Task<bool>>? RemovalConfirmationRequested { get; set; }
+
     public ListeningViewModel(
         IPlayerService playerService,
         ListeningPlaylistManager playlistManager,
@@ -118,6 +124,67 @@ public sealed partial class ListeningViewModel : ObservableObject, IDisposable
     {
         IEnumerable<long> currentTrackIds = Tracks.Select(t => t.Track.Id);
         return _playbackService.AddMoreFromArtistAsync(track, currentTrackIds);
+    }
+
+    [RelayCommand]
+    private Task RemoveTrackFromQueueAsync(TrackViewModel track)
+        => RemoveFromQueueAsync(
+            _playerService.CountUpcomingByTrack(track.Track.Id),
+            () => _playerService.RemoveUpcomingByTrack(track.Track.Id));
+
+    [RelayCommand]
+    private Task RemoveAlbumFromQueueAsync(TrackViewModel track)
+    {
+        if (!track.Track.AlbumId.HasValue)
+            return Task.CompletedTask;
+
+        long albumId = track.Track.AlbumId.Value;
+
+        return RemoveFromQueueAsync(
+            _playerService.CountUpcomingByAlbum(albumId),
+            () => _playerService.RemoveUpcomingByAlbum(albumId));
+    }
+
+    [RelayCommand]
+    private Task RemoveArtistFromQueueAsync(TrackViewModel track)
+    {
+        if (!track.Track.ArtistId.HasValue)
+            return Task.CompletedTask;
+
+        long artistId = track.Track.ArtistId.Value;
+
+        return RemoveFromQueueAsync(
+            _playerService.CountUpcomingByArtist(artistId),
+            () => _playerService.RemoveUpcomingByArtist(artistId));
+    }
+
+    [RelayCommand]
+    private Task RemoveGenreFromQueueAsync(TrackViewModel track)
+    {
+        if (!track.Track.GenreId.HasValue)
+            return Task.CompletedTask;
+
+        long genreId = track.Track.GenreId.Value;
+
+        return RemoveFromQueueAsync(
+            _playerService.CountUpcomingByGenre(genreId),
+            () => _playerService.RemoveUpcomingByGenre(genreId));
+    }
+
+    private async Task RemoveFromQueueAsync(int upcomingCount, Func<int> remove)
+    {
+        if (upcomingCount <= 0)
+            return;
+
+        if (upcomingCount >= 2 && RemovalConfirmationRequested != null)
+        {
+            bool confirmed = await RemovalConfirmationRequested(upcomingCount);
+
+            if (!confirmed)
+                return;
+        }
+
+        remove();
     }
 
     [RelayCommand]

--- a/src/Presentation/ViewModels/Listening/Services/ListeningPlaylistManager.cs
+++ b/src/Presentation/ViewModels/Listening/Services/ListeningPlaylistManager.cs
@@ -59,6 +59,8 @@ public partial class ListeningPlaylistManager : ObservableObject
                 CurrentTrack.Listening = true;
                 OnPropertyChanged(nameof(CurrentTrack));
             }
+
+            UpdateUpcomingFlags();
         });
 
         await LoadArtistIfNeededAsync(track);
@@ -98,5 +100,13 @@ public partial class ListeningPlaylistManager : ObservableObject
 
         OnPropertyChanged(nameof(CurrentTrack));
         OnPropertyChanged(nameof(Artist));
+    }
+
+    private void UpdateUpcomingFlags()
+    {
+        int currentIndex = CurrentTrack != null ? Tracks.IndexOf(CurrentTrack) : -1;
+
+        for (int index = 0; index < Tracks.Count; index++)
+            Tracks[index].IsUpcoming = currentIndex >= 0 && index > currentIndex;
     }
 }

--- a/src/Presentation/ViewModels/Track/TrackViewModel.cs
+++ b/src/Presentation/ViewModels/Track/TrackViewModel.cs
@@ -36,6 +36,9 @@ public partial class TrackViewModel : ObservableObject, IDisposable, IFilterable
     [ObservableProperty]
     public partial bool Listening { get; set; }
 
+    [ObservableProperty]
+    public partial bool IsUpcoming { get; set; }
+
     public int Score
     {
         get

--- a/src/Rok.Application/Player/IPlayerService.cs
+++ b/src/Rok.Application/Player/IPlayerService.cs
@@ -59,6 +59,30 @@ public interface IPlayerService
 
     List<TrackDto> GetQueue();
 
+    /// <summary>Counts the upcoming tracks (queued after the current one) matching the given track id, without mutating the queue.</summary>
+    int CountUpcomingByTrack(long trackId);
+
+    /// <summary>Counts the upcoming tracks (queued after the current one) belonging to the given album, without mutating the queue.</summary>
+    int CountUpcomingByAlbum(long albumId);
+
+    /// <summary>Counts the upcoming tracks (queued after the current one) belonging to the given artist, without mutating the queue.</summary>
+    int CountUpcomingByArtist(long artistId);
+
+    /// <summary>Counts the upcoming tracks (queued after the current one) belonging to the given genre, without mutating the queue.</summary>
+    int CountUpcomingByGenre(long genreId);
+
+    /// <summary>Removes the upcoming tracks matching the given track id. The current and already-played tracks are never removed. Returns the number removed.</summary>
+    int RemoveUpcomingByTrack(long trackId);
+
+    /// <summary>Removes the upcoming tracks belonging to the given album. The current and already-played tracks are never removed. Returns the number removed.</summary>
+    int RemoveUpcomingByAlbum(long albumId);
+
+    /// <summary>Removes the upcoming tracks belonging to the given artist. The current and already-played tracks are never removed. Returns the number removed.</summary>
+    int RemoveUpcomingByArtist(long artistId);
+
+    /// <summary>Removes the upcoming tracks belonging to the given genre. The current and already-played tracks are never removed. Returns the number removed.</summary>
+    int RemoveUpcomingByGenre(long genreId);
+
     void HandleMediaControlCommand(MediaControlCommandMessage message);
 
     void PlayRadioStation(RadioStationDto station);

--- a/src/Rok.Application/Player/PlayerService.cs
+++ b/src/Rok.Application/Player/PlayerService.cs
@@ -341,6 +341,75 @@ public sealed class PlayerService : IPlayerService, IDisposable
         return Playlist.Skip(_currentIndex + 1).ToList();
     }
 
+    public int CountUpcomingByTrack(long trackId) => CountUpcoming(track => track.Id == trackId);
+
+    public int CountUpcomingByAlbum(long albumId) => CountUpcoming(track => track.AlbumId == albumId);
+
+    public int CountUpcomingByArtist(long artistId) => CountUpcoming(track => track.ArtistId == artistId);
+
+    public int CountUpcomingByGenre(long genreId) => CountUpcoming(track => track.GenreId == genreId);
+
+    public int RemoveUpcomingByTrack(long trackId) => RemoveUpcoming(track => track.Id == trackId);
+
+    public int RemoveUpcomingByAlbum(long albumId) => RemoveUpcoming(track => track.AlbumId == albumId);
+
+    public int RemoveUpcomingByArtist(long artistId) => RemoveUpcoming(track => track.ArtistId == artistId);
+
+    public int RemoveUpcomingByGenre(long genreId) => RemoveUpcoming(track => track.GenreId == genreId);
+
+    private int CountUpcoming(Func<TrackDto, bool> predicate)
+    {
+        if (_mode == EPlaybackMode.Radio)
+            return 0;
+
+        int count = 0;
+
+        for (int index = _currentIndex + 1; index < Playlist.Count; index++)
+        {
+            if (predicate(Playlist[index]))
+                count++;
+        }
+
+        return count;
+    }
+
+    private int RemoveUpcoming(Func<TrackDto, bool> predicate)
+    {
+        if (_mode == EPlaybackMode.Radio)
+            return 0;
+
+        int removed = 0;
+        bool imminentRemoved = false;
+
+        for (int index = Playlist.Count - 1; index > _currentIndex; index--)
+        {
+            if (!predicate(Playlist[index]))
+                continue;
+
+            if (index == _currentIndex + 1)
+                imminentRemoved = true;
+
+            Playlist.RemoveAt(index);
+            removed++;
+        }
+
+        if (removed == 0)
+            return 0;
+
+        if (imminentRemoved)
+            CancelCrossfade();
+
+        _messenger.Send(new PlaylistChanged(Playlist));
+
+        return removed;
+    }
+
+    private void CancelCrossfade()
+    {
+        _crossfadeCts?.Cancel();
+        _isCrossfadeRunning = false;
+    }
+
     public void AddTracksToPlaylist(List<TrackDto> tracks)
     {
         Guard.NotNull(tracks);
@@ -461,8 +530,7 @@ public sealed class PlayerService : IPlayerService, IDisposable
             return;
 
         // Cancel any ongoing crossfade
-        _crossfadeCts?.Cancel();
-        _isCrossfadeRunning = false;
+        CancelCrossfade();
 
         if (_currentIndex + 1 >= Playlist.Count)
         {

--- a/tests/UnitTests/Rok.ApplicationTests/Player/PlayerServiceRemovalTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Player/PlayerServiceRemovalTests.cs
@@ -1,0 +1,330 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Rok.Application.Dto;
+using Rok.Application.Interfaces;
+using Rok.Application.Interfaces.Pictures;
+using Rok.Application.Messages;
+using Rok.Application.Player;
+
+namespace Rok.ApplicationTests.Player;
+
+public class PlayerServiceRemovalTests
+{
+    private readonly Mock<IPlayerEngine> _engine = new();
+    private readonly Mock<IAppOptions> _appOptions = new();
+    private readonly Mock<ICallDetectionService> _callDetection = new();
+    private readonly Mock<IAlbumPicture> _albumPicture = new();
+    private readonly Messenger _messenger = new();
+
+    public PlayerServiceRemovalTests()
+    {
+        _engine.Setup(o => o.SetTrack(It.IsAny<TrackDto>())).Returns(true);
+        _appOptions.SetupGet(o => o.CrossFade).Returns(false);
+    }
+
+    private PlayerService BuildService() => new(
+        _callDetection.Object,
+        _engine.Object,
+        _appOptions.Object,
+        discordService: null,
+        smtcService: null,
+        albumPicture: _albumPicture.Object,
+        timeProvider: TimeProvider.System,
+        messenger: _messenger,
+        logger: NullLogger<PlayerService>.Instance);
+
+    private static TrackDto BuildTrack(long id, long? albumId = null, long? artistId = null, long? genreId = null)
+        => new() { Id = id, Title = $"t{id}", AlbumId = albumId, ArtistId = artistId, GenreId = genreId };
+
+    [Fact(DisplayName = "when_remove_upcoming_by_track_then_only_that_upcoming_track_is_removed")]
+    public void Remove_upcoming_by_track_removes_only_that_track()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1);
+        TrackDto t2 = BuildTrack(2);
+        TrackDto t3 = BuildTrack(3);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3 });
+
+        // Act
+        int removed = sut.RemoveUpcomingByTrack(2);
+
+        // Assert
+        Assert.Equal(1, removed);
+        Assert.Equal(new List<TrackDto> { t1, t3 }, sut.Playlist);
+        Assert.Equal(t1, sut.CurrentTrack);
+    }
+
+    [Fact(DisplayName = "when_remove_upcoming_by_album_then_all_upcoming_album_tracks_are_removed_and_others_kept")]
+    public void Remove_upcoming_by_album_removes_only_upcoming_album_tracks()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, albumId: 10);
+        TrackDto t2 = BuildTrack(2, albumId: 10);
+        TrackDto t3 = BuildTrack(3, albumId: 10);
+        TrackDto t4 = BuildTrack(4, albumId: 10);
+        TrackDto t5 = BuildTrack(5, albumId: 20);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3, t4, t5 });
+        sut.Next(); // current = t2 (index 1); played = [t1]; upcoming = [t3, t4, t5]
+
+        // Act
+        int removed = sut.RemoveUpcomingByAlbum(10);
+
+        // Assert
+        Assert.Equal(2, removed);
+        Assert.Equal(new List<TrackDto> { t1, t2, t5 }, sut.Playlist);
+        Assert.Equal(t2, sut.CurrentTrack);
+        Assert.Equal(new List<TrackDto> { t5 }, sut.GetQueue());
+    }
+
+    [Fact(DisplayName = "when_remove_upcoming_by_artist_then_all_upcoming_artist_tracks_are_removed")]
+    public void Remove_upcoming_by_artist_removes_all_upcoming_artist_tracks()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, artistId: 7);
+        TrackDto t2 = BuildTrack(2, artistId: 7);
+        TrackDto t3 = BuildTrack(3, artistId: 8);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3 });
+
+        // Act
+        int removed = sut.RemoveUpcomingByArtist(7);
+
+        // Assert
+        Assert.Equal(1, removed);
+        Assert.Equal(new List<TrackDto> { t1, t3 }, sut.Playlist);
+    }
+
+    [Fact(DisplayName = "when_remove_upcoming_by_genre_then_all_upcoming_genre_tracks_are_removed")]
+    public void Remove_upcoming_by_genre_removes_all_upcoming_genre_tracks()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, genreId: 3);
+        TrackDto t2 = BuildTrack(2, genreId: 3);
+        TrackDto t3 = BuildTrack(3, genreId: 3);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3 });
+
+        // Act
+        int removed = sut.RemoveUpcomingByGenre(3);
+
+        // Assert
+        Assert.Equal(2, removed);
+        Assert.Equal(new List<TrackDto> { t1 }, sut.Playlist);
+    }
+
+    [Fact(DisplayName = "when_remove_by_group_then_current_track_is_never_removed")]
+    public void Remove_by_group_never_removes_current_track()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, albumId: 10);
+        TrackDto t2 = BuildTrack(2, albumId: 10);
+        TrackDto t3 = BuildTrack(3, albumId: 10);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3 });
+        sut.Next(); // current = t2 (album 10)
+
+        // Act
+        int removed = sut.RemoveUpcomingByAlbum(10);
+
+        // Assert
+        Assert.Equal(1, removed); // only t3 (upcoming)
+        Assert.Contains(t2, sut.Playlist);
+        Assert.Equal(t2, sut.CurrentTrack);
+    }
+
+    [Fact(DisplayName = "when_remove_by_group_then_already_played_tracks_are_never_removed")]
+    public void Remove_by_group_never_removes_already_played_tracks()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, albumId: 10);
+        TrackDto t2 = BuildTrack(2, albumId: 10);
+        TrackDto t3 = BuildTrack(3, albumId: 10);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3 });
+        sut.Next(); // current = t2; t1 already played
+
+        // Act
+        sut.RemoveUpcomingByAlbum(10);
+
+        // Assert
+        Assert.Contains(t1, sut.Playlist);
+    }
+
+    [Fact(DisplayName = "when_counting_upcoming_then_the_count_is_returned_without_mutating_the_queue")]
+    public void Count_upcoming_does_not_mutate_the_queue()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, albumId: 10);
+        TrackDto t2 = BuildTrack(2, albumId: 10);
+        TrackDto t3 = BuildTrack(3, albumId: 10);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3 });
+        sut.Next(); // current = t2; upcoming = [t3]
+
+        // Act
+        int count = sut.CountUpcomingByAlbum(10);
+
+        // Assert
+        Assert.Equal(1, count);
+        Assert.Equal(3, sut.Playlist.Count);
+    }
+
+    [Fact(DisplayName = "when_removal_removes_at_least_one_track_then_playlist_changed_is_emitted")]
+    public void Effective_removal_emits_playlist_changed()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, albumId: 10);
+        TrackDto t2 = BuildTrack(2, albumId: 10);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2 });
+
+        int emissions = 0;
+        using IDisposable subscription = _messenger.Subscribe<PlaylistChanged>(_ => emissions++);
+
+        // Act
+        sut.RemoveUpcomingByAlbum(10);
+
+        // Assert
+        Assert.Equal(1, emissions);
+    }
+
+    [Fact(DisplayName = "when_removal_removes_nothing_then_playlist_changed_is_not_emitted")]
+    public void Empty_removal_does_not_emit_playlist_changed()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, albumId: 10);
+        TrackDto t2 = BuildTrack(2, albumId: 10);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2 });
+
+        int emissions = 0;
+        using IDisposable subscription = _messenger.Subscribe<PlaylistChanged>(_ => emissions++);
+
+        // Act
+        int removed = sut.RemoveUpcomingByAlbum(999);
+
+        // Assert
+        Assert.Equal(0, removed);
+        Assert.Equal(0, emissions);
+    }
+
+    [Fact(DisplayName = "when_removing_by_group_then_tracks_with_a_null_group_id_are_never_matched")]
+    public void Remove_by_group_ignores_tracks_with_null_group_id()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1);
+        TrackDto t2 = BuildTrack(2, genreId: null);
+        TrackDto t3 = BuildTrack(3, genreId: 5);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3 });
+
+        // Act
+        int removed = sut.RemoveUpcomingByGenre(5);
+
+        // Assert
+        Assert.Equal(1, removed);
+        Assert.Equal(new List<TrackDto> { t1, t2 }, sut.Playlist);
+    }
+
+    [Fact(DisplayName = "when_group_is_entirely_already_played_then_nothing_is_removed")]
+    public void Remove_by_group_does_nothing_when_group_is_entirely_played()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1, albumId: 10);
+        TrackDto t2 = BuildTrack(2, albumId: 10);
+        TrackDto t3 = BuildTrack(3, albumId: 20);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2, t3 });
+        sut.Next();
+        sut.Next(); // current = t3; album 10 entirely behind the cursor
+
+        // Act
+        int removed = sut.RemoveUpcomingByAlbum(10);
+
+        // Assert
+        Assert.Equal(0, removed);
+        Assert.Equal(3, sut.Playlist.Count);
+    }
+
+    [Fact(DisplayName = "when_track_id_is_absent_then_nothing_is_removed")]
+    public void Remove_upcoming_by_track_does_nothing_when_id_absent()
+    {
+        // Arrange
+        TrackDto t1 = BuildTrack(1);
+        TrackDto t2 = BuildTrack(2);
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { t1, t2 });
+
+        // Act
+        int removed = sut.RemoveUpcomingByTrack(9999);
+
+        // Assert
+        Assert.Equal(0, removed);
+        Assert.Equal(2, sut.Playlist.Count);
+    }
+
+    [Fact(DisplayName = "when_queue_is_empty_then_removal_returns_zero_without_throwing")]
+    public void Remove_on_empty_queue_returns_zero()
+    {
+        // Arrange
+        PlayerService sut = BuildService();
+
+        // Act
+        int removed = sut.RemoveUpcomingByTrack(1);
+
+        // Assert
+        Assert.Equal(0, removed);
+    }
+
+    [Fact(DisplayName = "when_player_is_in_radio_mode_then_removal_is_a_no_op")]
+    public void Remove_in_radio_mode_is_no_op()
+    {
+        // Arrange
+        _engine.Setup(o => o.SetStream(It.IsAny<RadioStationDto>())).Returns(true);
+        PlayerService sut = BuildService();
+        sut.PlayRadioStation(new RadioStationDto(1, "Radio", "http://stream", null, null, null, null, null, null, DateTime.UtcNow, null));
+
+        // Act
+        int removed = sut.RemoveUpcomingByAlbum(10);
+
+        // Assert
+        Assert.Equal(0, removed);
+    }
+
+    [Fact(DisplayName = "when_removing_the_imminent_track_during_a_crossfade_then_the_crossfade_is_cancelled")]
+    public async Task Removing_imminent_track_during_crossfade_cancels_it()
+    {
+        // Arrange
+        _appOptions.SetupGet(o => o.CrossFade).Returns(true);
+        _engine.SetupGet(o => o.Position).Returns(95);
+        _engine.SetupGet(o => o.Length).Returns(100);
+        _engine.SetupGet(o => o.CrossfadeDelay).Returns(5);
+
+        TaskCompletionSource crossfadeEntered = new();
+        CancellationToken capturedToken = default;
+
+        _engine
+            .Setup(o => o.CrossfadeToAsync(It.IsAny<TrackDto>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .Returns<TrackDto, double, double, CancellationToken>((_, _, _, token) =>
+            {
+                capturedToken = token;
+                crossfadeEntered.SetResult();
+                return Task.Delay(Timeout.Infinite, token); // keep the crossfade in flight until its token is cancelled
+            });
+
+        PlayerService sut = BuildService();
+        sut.LoadPlaylist(new List<TrackDto> { BuildTrack(1), BuildTrack(2), BuildTrack(3) });
+
+        _engine.Raise(m => m.OnMediaAboutToEnd += null, this, EventArgs.Empty);
+        await crossfadeEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        // Act
+        int removed = sut.RemoveUpcomingByTrack(2); // the imminent upcoming track (index currentIndex + 1)
+
+        // Assert
+        Assert.Equal(1, removed);
+        Assert.True(capturedToken.IsCancellationRequested);
+    }
+}


### PR DESCRIPTION
Retrait depuis la file de lecture en cours : chanson / album / artiste / genre, titres à venir uniquement (le titre courant et les déjà-joués sont protégés), confirmation si retrait de 2+ titres. Closes #339