### PR TITLE
fix(deps): patch SQLite CVE-2025-6965 and bump outdated NuGet packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Presentation/Rok.csproj
+++ b/src/Presentation/Rok.csproj
@@ -129,7 +129,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
+		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Presentation/Rok.csproj
+++ b/src/Presentation/Rok.csproj
@@ -134,7 +134,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
 		<PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
 		<PackageReference Include="MiF.RelayCommand" Version="1.0.0" />
 	</ItemGroup>

--- a/src/Rok.Domain/Rok.Domain.csproj
+++ b/src/Rok.Domain/Rok.Domain.csproj
@@ -8,6 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Transitive override: pulls the patched native SQLite (>= 3.50.2) to fix CVE-2025-6965 / GHSA-2m69-gcr7-jv3q.
+         In 3.0.x the vulnerable SQLitePCLRaw.lib.e_sqlite3 is replaced by SourceGear.sqlite3. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
   </ItemGroup>
 

--- a/src/Rok.Infrastructure/Rok.Infrastructure.csproj
+++ b/src/Rok.Infrastructure/Rok.Infrastructure.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="CleanArch.DevKit.Guards" Version="1.1.1" />
 		<PackageReference Include="NAudio" Version="2.3.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
+++ b/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
@@ -15,6 +15,8 @@
 		</PackageReference>
 		<PackageReference Include="Dapper" Version="2.1.79" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+		<!-- Transitive override: patched native SQLite (>= 3.50.2) for CVE-2025-6965. See Rok.Domain.csproj. -->
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />

--- a/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
+++ b/tests/UnitTests/Rok.ApplicationTests/Rok.ApplicationTests.csproj
@@ -18,7 +18,7 @@
 		<!-- Transitive override: patched native SQLite (>= 3.50.2) for CVE-2025-6965. See Rok.Domain.csproj. -->
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/UnitTests/Rok.ImportTests/Rok.ImportTests.csproj
+++ b/tests/UnitTests/Rok.ImportTests/Rok.ImportTests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Rok.Infrastructure.UnitTests.csproj
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Rok.Infrastructure.UnitTests.csproj
@@ -12,7 +12,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
+++ b/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
@@ -21,7 +21,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
+++ b/tests/UnitTests/Rok.PresentationTests/Rok.PresentationTests.csproj
@@ -20,7 +20,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Correctif CVE-2025-6965 (SQLite)

`Microsoft.Data.Sqlite` 10.0.9 tirait transitivement `SQLitePCLRaw.lib.e_sqlite3` 2.1.11
(avis **High** GHSA-2m69-gcr7-jv3q, SQLite < 3.50.2). Override transitif vers
`SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 : la bibliothèque native vulnérable disparaît de
l'arbre, remplacée par `SourceGear.sqlite3` 3.50.4.

## Mise à jour des NuGet obsolètes

Regroupée dans la même branche, en commits isolés par niveau de risque :

- **Lot sûr** : Serilog.Settings.Configuration 10.0.1, Microsoft.NET.Test.Sdk 18.7.0,
  Microsoft.Windows.CsWin32 0.3.298.
- **Microsoft.VisualStudio.Threading.Analyzers** 17.14.15 → 18.7.23 (bump majeur, 0 nouveau
  warning sous `TreatWarningsAsErrors`).
- **Microsoft.WindowsAppSDK** 2.1.3 → 2.2.0.

## Validation

- Build solution `-p:Platform=x64` : 12 projets, 0 erreur, 0 warning (à chaque commit).
- Tests verts : Infrastructure 396, Application 615, Import 113, Presentation 339 (x64).
- `dotnet list package --outdated` : plus aucun paquet obsolète ; `--vulnerable` : aucun.
- Smoke runtime WinUI (MSIX) validé manuellement.
