### PR TITLE
build: bump version to v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ﻿# ChangeLog
 
+## [1.15.0] Store – 24 juin 2026
+
+### Ajouté
+
+- Retrait de pistes de la file d'attente par titre, album, artiste ou genre.
+
+### Corrigé
+
+- File d'attente lue depuis plusieurs albums : meilleure diversité des artistes (la lecture ne ramène plus systématiquement les mêmes).
+- Correctif de sécurité du moteur de base de données SQLite et mise à jour des composants tiers.
+
+--
+
 ## [1.14.0] Store – 10 juin 2026
 
 ### Ajouté

--- a/src/Presentation/Package.appxmanifest
+++ b/src/Presentation/Package.appxmanifest
@@ -10,7 +10,7 @@
 	<Identity
 	  Name="Rokapp.Rokmusicplayer"
 	  Publisher="CN=C9A55691-54ED-46EA-9D4F-F3CD41C04242"
-	  Version="1.14.0.0" />
+	  Version="1.15.0.0" />
 
 	<Properties>
 		<DisplayName>Rok musicplayer</DisplayName>


### PR DESCRIPTION
## [1.15.0] Store – 24 juin 2026

### Ajouté

- Retrait de pistes de la file d'attente par titre, album, artiste ou genre.

### Corrigé

- File d'attente lue depuis plusieurs albums : meilleure diversité des artistes (la lecture ne ramène plus systématiquement les mêmes).
- Correctif de sécurité du moteur de base de données SQLite et mise à jour des composants tiers.
