### PR TITLE
fix(player): preserve track order for single-album playback

### DIFF
--- a/src/Presentation/ViewModels/Albums/Services/AlbumsPlaybackService.cs
+++ b/src/Presentation/ViewModels/Albums/Services/AlbumsPlaybackService.cs
@@ -8,13 +8,17 @@ public class AlbumsPlaybackService(IMediator mediator, IPlayerService playerServ
 {
     public async Task PlayAlbumsAsync(IEnumerable<long> albumIds)
     {
-        if (!albumIds.Any())
+        var ids = albumIds.ToList();
+
+        if (ids.Count == 0)
         {
             logger.LogDebug("No track to listen.");
             return;
         }
 
-        var tracks = (await mediator.Send(new GetTracksByAlbumListRequest { AlbumsId = albumIds.ToList() })).ToList();
+        var tracks = ids.Count == 1
+            ? (await mediator.Send(new GetTracksByAlbumIdRequest(ids[0]))).ToList()
+            : (await mediator.Send(new GetTracksByAlbumListRequest { AlbumsId = ids })).ToList();
 
         if (tracks.Count == 0)
         {
@@ -22,7 +26,7 @@ public class AlbumsPlaybackService(IMediator mediator, IPlayerService playerServ
             return;
         }
 
-        if (albumIds.Count() > 1)
+        if (ids.Count > 1)
             TracksRandomizer.ArtistBalancedTrackRandomize(tracks, 0);
 
         playerService.LoadPlaylist(tracks.ToList());

--- a/src/Rok.Infrastructure/Repositories/TrackRepository.cs
+++ b/src/Rok.Infrastructure/Repositories/TrackRepository.cs
@@ -88,8 +88,11 @@ public class TrackRepository(IDbConnection db, [FromKeyedServices("BackgroundCon
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(albumId);
 
+        // A single album plays in its track order; the multi-album overload below randomizes for cross-album diversity.
         string sql = GetSelectQuery() +
-                     "WHERE tracks.albumId = @albumId " + DefaultGroupBy;
+                     "WHERE tracks.albumId = @albumId " +
+                     DefaultGroupBy +
+                     " ORDER BY tracks.trackNumber ASC";
 
         return await ExecuteQueryAsync(sql, kind, new { albumId });
     }

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Repositories/TrackRepositoryTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Repositories/TrackRepositoryTests.cs
@@ -289,6 +289,36 @@ public class TrackRepositoryTests
     }
 
     [Fact]
+    public async Task GetByAlbumIdAsync_WithSingleAlbum_ReturnsTracksOrderedByTrackNumber()
+    {
+        // Arrange
+        using SqliteDatabaseFixture fixture = CreateFixture();
+        TrackRepository repo = CreateRepository(fixture);
+        DateTime now = DateTime.UtcNow;
+        long testAlbumId = 8210;
+
+        await fixture.Connection.ExecuteAsync(@"
+            INSERT INTO Albums(id, name, isLive, isCompilation, isBestof, trackCount, duration, isFavorite, listenCount, creatDate, artistId, genreId)
+            VALUES (@albumId, 'Ordered Album', 0, 0, 0, 3, 600, 0, 0, @now, 1, 1)",
+            new { albumId = testAlbumId, now });
+
+        // Insert tracks with ascending ids but track numbers out of order (3, 1, 2).
+        await fixture.Connection.ExecuteAsync(@"
+            INSERT INTO Tracks(id, title, duration, size, bitrate, musicFile, fileDate, isLive, score, listenCount, skipCount, creatDate, albumId, artistId, trackNumber)
+            VALUES
+            (8211, 'Third', 180, 1000, 128, '/test8211', @now, 0, 0, 0, 0, @now, @albumId, 1, 3),
+            (8212, 'First', 200, 1200, 128, '/test8212', @now, 0, 0, 0, 0, @now, @albumId, 1, 1),
+            (8213, 'Second', 200, 1200, 128, '/test8213', @now, 0, 0, 0, 0, @now, @albumId, 1, 2)",
+            new { albumId = testAlbumId, now });
+
+        // Act
+        List<TrackEntity> result = (await repo.GetByAlbumIdAsync(testAlbumId)).ToList();
+
+        // Assert
+        Assert.Equal(new int?[] { 1, 2, 3 }, result.Select(t => t.TrackNumber));
+    }
+
+    [Fact]
     public async Task GetByAlbumIdAsync_WithInvalidAlbumId_ThrowsArgumentOutOfRangeException()
     {
         // Arrange

--- a/tests/UnitTests/Rok.PresentationTests/ViewModels/Albums/Services/AlbumsPlaybackServiceTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/ViewModels/Albums/Services/AlbumsPlaybackServiceTests.cs
@@ -45,4 +45,23 @@ public class AlbumsPlaybackServiceTests
         Assert.True(sent.AlbumsId.SequenceEqual(new long[] { 1, 2 }));
         _player.Verify(p => p.LoadPlaylist(It.Is<List<TrackDto>>(l => l.Count == 2), It.IsAny<TrackDto>()), Times.Once);
     }
+
+    [Fact(DisplayName = "PlayAlbumsAsync should route a single album to the ordered request without reordering")]
+    public async Task PlayAlbumsAsync_ShouldRouteSingleAlbumToOrderedRequest_WhenOneId()
+    {
+        // Arrange
+        List<TrackDto> ordered = new() { new TrackDto { Id = 1 }, new TrackDto { Id = 2 }, new TrackDto { Id = 3 } };
+        _mediator.Setup<GetTracksByAlbumIdRequest, IEnumerable<TrackDto>>()
+                 .Returns(ordered);
+        AlbumsPlaybackService sut = BuildService();
+
+        // Act
+        await sut.PlayAlbumsAsync(new long[] { 42 });
+
+        // Assert
+        GetTracksByAlbumIdRequest sent = Assert.Single(_mediator.Sent<GetTracksByAlbumIdRequest>());
+        Assert.Equal(42L, sent.GenreId);
+        Assert.Empty(_mediator.Sent<GetTracksByAlbumListRequest>());
+        _player.Verify(p => p.LoadPlaylist(It.Is<List<TrackDto>>(l => l.SequenceEqual(ordered)), It.IsAny<TrackDto>()), Times.Once);
+    }
 }


### PR DESCRIPTION
## Problème

Le bouton « surprise me » et l'écoute d'un album depuis la page albums lisaient les pistes en ordre
aléatoire. Les trois commandes de la page albums passent par l'overload multi-album
`GetByAlbumIdAsync(IEnumerable<long>, int)`, qui porte `ORDER BY RANDOM() LIMIT 100` (introduit par
la PR #342). Pour un album unique, aucun mélange mémoire ne s'applique : le tri SQL aléatoire était donc
le seul ordre, et l'album se lisait dans le désordre, tronqué à 100 pistes. La page détail n'ordonnait
pas non plus (aucun `ORDER BY`, ordre rowid).

## Solution

Deux correctifs coordonnés :

- **Infrastructure** — `TrackRepository.GetByAlbumIdAsync(long)` trie désormais par
  `ORDER BY tracks.trackNumber ASC`. Cette requête devient l'ordre naturel canonique d'un album unique ;
  elle sert l'affichage et la lecture de la page détail, ainsi que l'ajout d'un album à une playlist.
- **Presentation** — `AlbumsPlaybackService.PlayAlbumsAsync` route un album unique (`Count == 1`) vers
  `GetTracksByAlbumIdRequest` (la requête ordonnée, sans `RANDOM()`/`LIMIT`/échantillonnage), sans mélange.
  Deux albums ou plus conservent le mélange diversifiant (`ORDER BY RANDOM()` + `ArtistBalancedTrackRandomize`,
  PR #342 intacte).

La colonne `disc`, peu renseignée, est volontairement exclue du tri.

## Hors périmètre

- Le « surprise me » et l'écoute par artiste restent mélangés (mélange en mémoire, indépendant du SQL).
- La commande vocale `PlayerCommandService.ListenAlbumAsync` reste mélangée (suivi produit noté).

## Tests

- Repository : `GetByAlbumIdAsync_WithSingleAlbum_ReturnsTracksOrderedByTrackNumber` (ordre déterministe).
- Presentation : `PlayAlbumsAsync_ShouldRouteSingleAlbumToOrderedRequest_WhenOneId` (routage vers la requête
  ordonnée + ordre préservé).
- Non-régression : les deux tests 50-albums de la PR #342 et le cas 2-albums restent verts. 737 tests verts
  (Infrastructure + Presentation).

## Gates

Plan (architect) accepté · Lint accepté (format vérifié sur le diff) · Review acceptée (blast radius Roslyn
confirmé, aucune régression sur les appelants) · Test accepté (737 verts, 0 échec).

Closes #346
