### PR TITLE
fix(album): reflect saved edits on the album detail page

### DIFF
--- a/src/Presentation/Pages/AlbumPage.xaml
+++ b/src/Presentation/Pages/AlbumPage.xaml
@@ -42,9 +42,9 @@
                 <HyperlinkButton x:Name="artistName" Style="{StaticResource HeaderHyperlinkStyle}" Content="{x:Bind ViewModel.Album.ArtistName}" RelativePanel.Below="albumName" Command="{x:Bind ViewModel.ArtistOpenCommand}" />
 
                 <StackPanel x:Name="albumType" RelativePanel.RightOf="albumName" RelativePanel.AlignVerticalCenterWith="albumName" Orientation="Horizontal" Margin="4,0,0,0">
-                    <common:BadgeControl x:Uid="badgeLive" Visibility="{x:Bind ViewModel.Album.IsLive, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeLiveBrush}"/>
-                    <common:BadgeControl x:Uid="badgeBestof" Visibility="{x:Bind ViewModel.Album.IsBestOf, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeBestOfBrush}" />
-                    <common:BadgeControl x:Uid="badgeCompilation" Visibility="{x:Bind ViewModel.Album.IsCompilation, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeCompilationBrush}" />
+                    <common:BadgeControl x:Uid="badgeLive" Visibility="{x:Bind ViewModel.Album.IsLive, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeLiveBrush}"/>
+                    <common:BadgeControl x:Uid="badgeBestof" Visibility="{x:Bind ViewModel.Album.IsBestOf, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeBestOfBrush}" />
+                    <common:BadgeControl x:Uid="badgeCompilation" Visibility="{x:Bind ViewModel.Album.IsCompilation, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeCompilationBrush}" />
                     <common:BadgeControl x:Uid="badgeNew" Visibility="{x:Bind ViewModel.ShowNewBadge, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeNewBrush}" />
                     <common:BadgeControl x:Uid="badgeAnniversary" Visibility="{x:Bind ViewModel.ShowAnniversaryBadge, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" BadgeBackground="{StaticResource BadgeAnniversaryBrush}" ToolTipService.ToolTip="{x:Bind ViewModel.AnniversaryTooltip, Mode=OneWay}" />
                 </StackPanel>
@@ -69,7 +69,7 @@
                 <CommandBar RelativePanel.AlignBottomWithPanel="True" RelativePanel.AlignLeftWith="albumName" Style="{StaticResource HeaderCommandBarStyle}">
                     <AppBarButton x:Uid="albumViewListen" Style="{StaticResource ListenAppBarButtonStyle}" Command="{x:Bind ViewModel.ListenCommand}" />
                     <AppBarToggleButton x:Uid="albumViewLike" x:Name="albumAppBarLike" Style="{StaticResource HeaderLikeButtonStyle}" IsChecked="{x:Bind ViewModel.IsFavorite, Mode=OneWay}" Command="{x:Bind ViewModel.AlbumFavoriteCommand}" />
-                    <AppBarButton x:Uid="albumViewBiography" Style="{StaticResource HeaderGenericButtonStyle}" Icon="Library" Command="{x:Bind ViewModel.OpenBiographyCommand}" Visibility="{x:Bind ViewModel.Album.Biography, Converter={StaticResource StringToVisibilityConverter}}" />
+                    <AppBarButton x:Uid="albumViewBiography" Style="{StaticResource HeaderGenericButtonStyle}" Icon="Library" Command="{x:Bind ViewModel.OpenBiographyCommand}" Visibility="{x:Bind ViewModel.Album.Biography, Mode=OneWay, Converter={StaticResource StringToVisibilityConverter}}" />
                     <AppBarButton x:Uid="albumViewPlaylist" Style="{StaticResource HeaderGenericButtonStyle}" Icon="Add">
                         <AppBarButton.Flyout>
                             <MenuFlyout x:Name="albumPlaylistFlyout" common:MenuFlyoutExtensions.PlaylistMenuService="{x:Bind ViewModel.PlaylistMenuService}" common:MenuFlyoutExtensions.AlbumId="{x:Bind ViewModel.Album.Id}" common:MenuFlyoutExtensions.FlattenPlaylistMenu="True" />

--- a/src/Presentation/Services/AlbumEditValues.cs
+++ b/src/Presentation/Services/AlbumEditValues.cs
@@ -1,0 +1,21 @@
+namespace Rok.Services;
+
+/// <summary>Immutable carrier for the album fields edited through the album edit dialog.</summary>
+public sealed record AlbumEditValues
+{
+    public bool IsLive { get; init; }
+
+    public bool IsBestOf { get; init; }
+
+    public bool IsCompilation { get; init; }
+
+    public bool IsLock { get; init; }
+
+    public string? MusicBrainzID { get; init; }
+
+    public string? ReleaseGroupMusicBrainzID { get; init; }
+
+    public string? Biography { get; init; }
+
+    public string? LastFmUrl { get; init; }
+}

--- a/src/Presentation/Services/DialogService.cs
+++ b/src/Presentation/Services/DialogService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.UI;
 using Microsoft.UI.Xaml.Controls;
+using Rok.Dialogs;
 using Windows.Foundation;
 using Windows.UI;
 using Windows.UI.Text;
@@ -8,6 +9,40 @@ namespace Rok.Services;
 
 public sealed class DialogService(ResourceLoader resourceLoader, ITranslateService translateService) : IDialogService
 {
+    public async Task<AlbumEditValues?> ShowEditAlbumAsync(AlbumEditValues current)
+    {
+        EditAlbumDialog dialog = new()
+        {
+            IsBestOf = current.IsBestOf,
+            IsLive = current.IsLive,
+            IsCompilation = current.IsCompilation,
+            MusicBrainzID = current.MusicBrainzID,
+            ReleaseGroupMusicBrainzId = current.ReleaseGroupMusicBrainzID,
+            IsLock = current.IsLock,
+            Biography = current.Biography,
+            LastFmUrl = current.LastFmUrl,
+
+            XamlRoot = App.MainWindow.Content.XamlRoot
+        };
+
+        ContentDialogResult result = await dialog.ShowAsync();
+
+        if (result != ContentDialogResult.Primary)
+            return null;
+
+        return new AlbumEditValues
+        {
+            IsBestOf = dialog.IsBestOf,
+            IsLive = dialog.IsLive,
+            IsCompilation = dialog.IsCompilation,
+            MusicBrainzID = dialog.MusicBrainzID,
+            ReleaseGroupMusicBrainzID = dialog.ReleaseGroupMusicBrainzId,
+            IsLock = dialog.IsLock,
+            Biography = dialog.Biography,
+            LastFmUrl = dialog.LastFmUrl
+        };
+    }
+
     public Task ShowTextAsync(string title, string content, bool showTranslateButton = false, string targetLanguage = "fr")
     {
         string closeButtonText = resourceLoader.GetString("Close");

--- a/src/Presentation/Services/IDialogService.cs
+++ b/src/Presentation/Services/IDialogService.cs
@@ -3,4 +3,8 @@
 public interface IDialogService
 {
     Task ShowTextAsync(string title, string content, bool showTranslateButton = false, string targetLanguage = "fr");
+
+    /// <summary>Shows the album edit dialog seeded with <paramref name="current"/>.</summary>
+    /// <returns>The edited values when the user confirms; <see langword="null"/> when the dialog is dismissed.</returns>
+    Task<AlbumEditValues?> ShowEditAlbumAsync(AlbumEditValues current);
 }

--- a/src/Presentation/ViewModels/Album/Services/AlbumEditService.cs
+++ b/src/Presentation/ViewModels/Album/Services/AlbumEditService.cs
@@ -1,30 +1,26 @@
-﻿using Microsoft.UI.Xaml.Controls;
-using Rok.Application.Features.Albums.Requests;
-using Rok.Dialogs;
+﻿using Rok.Application.Features.Albums.Requests;
 
 namespace Rok.ViewModels.Album.Services;
 
-public class AlbumEditService(IMediator mediator)
+public class AlbumEditService(IMediator mediator, IDialogService dialogService)
 {
     public async Task<bool> EditAlbumAsync(AlbumDto album)
     {
-        EditAlbumDialog dialog = new()
+        AlbumEditValues current = new()
         {
             IsBestOf = album.IsBestOf,
             IsLive = album.IsLive,
             IsCompilation = album.IsCompilation,
             MusicBrainzID = album.MusicBrainzID,
-            ReleaseGroupMusicBrainzId = album.ReleaseGroupMusicBrainzID,
+            ReleaseGroupMusicBrainzID = album.ReleaseGroupMusicBrainzID,
             IsLock = album.IsLock,
             Biography = album.Biography,
-            LastFmUrl = album.LastFmUrl,
-
-            XamlRoot = App.MainWindow.Content.XamlRoot
+            LastFmUrl = album.LastFmUrl
         };
 
-        ContentDialogResult result = await dialog.ShowAsync();
+        AlbumEditValues? edited = await dialogService.ShowEditAlbumAsync(current);
 
-        if (result != ContentDialogResult.Primary)
+        if (edited is null)
             return false;
 
         UpdateAlbumRequest command = new()
@@ -32,25 +28,25 @@ public class AlbumEditService(IMediator mediator)
             Id = album.Id,
         };
 
-        command.IsBestOf.Set(dialog.IsBestOf);
-        command.IsLive.Set(dialog.IsLive);
-        command.IsCompilation.Set(dialog.IsCompilation);
-        command.MusicBrainzID.Set(dialog.MusicBrainzID);
-        command.ReleaseGroupMusicBrainzID.Set(dialog.ReleaseGroupMusicBrainzId);
-        command.Biography.Set(dialog.Biography);
-        command.IsLock.Set(dialog.IsLock);
-        command.LastFmUrl.Set(dialog.LastFmUrl);
+        command.IsBestOf.Set(edited.IsBestOf);
+        command.IsLive.Set(edited.IsLive);
+        command.IsCompilation.Set(edited.IsCompilation);
+        command.MusicBrainzID.Set(edited.MusicBrainzID);
+        command.ReleaseGroupMusicBrainzID.Set(edited.ReleaseGroupMusicBrainzID);
+        command.Biography.Set(edited.Biography);
+        command.IsLock.Set(edited.IsLock);
+        command.LastFmUrl.Set(edited.LastFmUrl);
 
         await mediator.Send(command);
 
-        album.IsBestOf = dialog.IsBestOf;
-        album.IsLive = dialog.IsLive;
-        album.IsCompilation = dialog.IsCompilation;
-        album.MusicBrainzID = dialog.MusicBrainzID;
-        album.ReleaseGroupMusicBrainzID = dialog.ReleaseGroupMusicBrainzId;
-        album.Biography = dialog.Biography;
-        album.IsLock = dialog.IsLock;
-        album.LastFmUrl = dialog.LastFmUrl;
+        album.IsBestOf = edited.IsBestOf;
+        album.IsLive = edited.IsLive;
+        album.IsCompilation = edited.IsCompilation;
+        album.MusicBrainzID = edited.MusicBrainzID;
+        album.ReleaseGroupMusicBrainzID = edited.ReleaseGroupMusicBrainzID;
+        album.Biography = edited.Biography;
+        album.IsLock = edited.IsLock;
+        album.LastFmUrl = edited.LastFmUrl;
 
         return true;
     }

--- a/tests/UnitTests/Rok.PresentationTests/ViewModels/Album/Services/AlbumEditServiceTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/ViewModels/Album/Services/AlbumEditServiceTests.cs
@@ -1,5 +1,7 @@
+using Moq;
 using Rok.Application.Dto;
 using Rok.Application.Features.Albums.Requests;
+using Rok.Services;
 using Rok.ViewModels.Album.Services;
 
 namespace Rok.PresentationTests.ViewModels.Album.Services;
@@ -8,7 +10,9 @@ public class AlbumEditServiceTests
 {
     private readonly FakeMediator _mediator = new();
 
-    private AlbumEditService BuildService() => new(_mediator);
+    private readonly Mock<IDialogService> _dialogService = new();
+
+    private AlbumEditService BuildService() => new(_mediator, _dialogService.Object);
 
     [Fact(DisplayName = "UpdateFavoriteAsync should send the favorite command and update the album state")]
     public async Task UpdateFavoriteAsync_ShouldSendCommandAndUpdateState()
@@ -58,5 +62,126 @@ public class AlbumEditServiceTests
         UpdateAlbumPictureDominantColorRequest sent = Assert.Single(_mediator.Sent<UpdateAlbumPictureDominantColorRequest>());
         Assert.Equal(5, sent.Id);
         Assert.Equal(colorValue, sent.ColorValue);
+    }
+
+    [Fact(DisplayName = "EditAlbumAsync confirmed should mutate the album with the edited values")]
+    public async Task EditAlbumAsync_Confirmed_ShouldMutateAlbum()
+    {
+        // Arrange
+        AlbumDto album = new()
+        {
+            Id = 7,
+            IsLive = false,
+            IsBestOf = false,
+            IsCompilation = false,
+            IsLock = false,
+            Biography = "old bio",
+            LastFmUrl = "old-url",
+            MusicBrainzID = "old-mb",
+            ReleaseGroupMusicBrainzID = "old-rg"
+        };
+
+        AlbumEditValues edited = new()
+        {
+            IsLive = true,
+            IsBestOf = true,
+            IsCompilation = true,
+            IsLock = true,
+            Biography = "new bio",
+            LastFmUrl = "new-url",
+            MusicBrainzID = "new-mb",
+            ReleaseGroupMusicBrainzID = "new-rg"
+        };
+
+        _dialogService
+            .Setup(x => x.ShowEditAlbumAsync(It.IsAny<AlbumEditValues>()))
+            .ReturnsAsync(edited);
+
+        AlbumEditService sut = BuildService();
+
+        // Act
+        bool result = await sut.EditAlbumAsync(album);
+
+        // Assert
+        Assert.True(result);
+        Assert.True(album.IsLive);
+        Assert.True(album.IsBestOf);
+        Assert.True(album.IsCompilation);
+        Assert.True(album.IsLock);
+        Assert.Equal("new bio", album.Biography);
+        Assert.Equal("new-url", album.LastFmUrl);
+        Assert.Equal("new-mb", album.MusicBrainzID);
+        Assert.Equal("new-rg", album.ReleaseGroupMusicBrainzID);
+    }
+
+    [Fact(DisplayName = "EditAlbumAsync confirmed should send an update command with the edited fields")]
+    public async Task EditAlbumAsync_Confirmed_ShouldSendUpdateCommand()
+    {
+        // Arrange
+        AlbumDto album = new() { Id = 7 };
+
+        AlbumEditValues edited = new()
+        {
+            IsLive = true,
+            IsBestOf = false,
+            IsCompilation = true,
+            IsLock = true,
+            Biography = "bio",
+            LastFmUrl = "url",
+            MusicBrainzID = "mb",
+            ReleaseGroupMusicBrainzID = "rg"
+        };
+
+        _dialogService
+            .Setup(x => x.ShowEditAlbumAsync(It.IsAny<AlbumEditValues>()))
+            .ReturnsAsync(edited);
+
+        AlbumEditService sut = BuildService();
+
+        // Act
+        await sut.EditAlbumAsync(album);
+
+        // Assert
+        UpdateAlbumRequest sent = Assert.Single(_mediator.Sent<UpdateAlbumRequest>());
+        Assert.Equal(7, sent.Id);
+        Assert.True(sent.IsLive.IsSet);
+        Assert.True(sent.IsLive.Value);
+        Assert.True(sent.IsBestOf.IsSet);
+        Assert.False(sent.IsBestOf.Value);
+        Assert.True(sent.IsCompilation.IsSet);
+        Assert.True(sent.IsCompilation.Value);
+        Assert.True(sent.IsLock.IsSet);
+        Assert.True(sent.IsLock.Value);
+        Assert.Equal("bio", sent.Biography.Value);
+        Assert.Equal("url", sent.LastFmUrl.Value);
+        Assert.Equal("mb", sent.MusicBrainzID.Value);
+        Assert.Equal("rg", sent.ReleaseGroupMusicBrainzID.Value);
+    }
+
+    [Fact(DisplayName = "EditAlbumAsync cancelled should not send any command nor mutate the album")]
+    public async Task EditAlbumAsync_Cancelled_ShouldDoNothing()
+    {
+        // Arrange
+        AlbumDto album = new()
+        {
+            Id = 7,
+            IsLive = false,
+            Biography = "old bio"
+        };
+
+        _dialogService
+            .Setup(x => x.ShowEditAlbumAsync(It.IsAny<AlbumEditValues>()))
+            .ReturnsAsync((AlbumEditValues?)null);
+
+        AlbumEditService sut = BuildService();
+
+        // Act
+        bool result = await sut.EditAlbumAsync(album);
+
+        // Assert
+        Assert.False(result);
+        Assert.Empty(_mediator.Sent<UpdateAlbumRequest>());
+        Assert.False(album.IsLive);
+        Assert.Equal("old bio", album.Biography);
     }
 }


### PR DESCRIPTION
## Contexte

Quand l'utilisateur édite un album depuis sa fiche détail (ex. cocher « live »)
et enregistre, la fiche ne se rafraîchit pas : les badges restent figés sur
l'état affiché à l'ouverture. La donnée est pourtant bien persistée.

## Cause

Les badges Live / Best-of / Compilation (`AlbumPage.xaml:45-47`) et le bouton
biographie (`:72`) étaient liés en `x:Bind` **sans `Mode`**, donc en **OneTime**
(mode par défaut de `x:Bind`) : évalués une seule fois au premier rendu. Le
`OnPropertyChanged(nameof(Album))` déjà émis après l'édition
(`AlbumViewModel.cs:542`) ne pouvait pas les rafraîchir.

## Correctif

- Passer ces 4 liaisons en `Mode=OneWay`. Sur changement du nœud `Album`, `x:Bind`
  relit le `AlbumDto` muté en place — aucun `INotifyPropertyChanged` sur le DTO,
  aucune couche hors Presentation touchée. Le bouton Last.FM (`:58`) reposait déjà
  sur ce contrat ; le correctif aligne badges et biographie dessus.
- L'en-tête « Artiste » de la grille de pistes (`:103`) reste en OneTime
  volontairement : son plein effet sur la grille ne s'applique qu'à la
  re-navigation, pour éviter une grille à moitié rafraîchie.
- Extraction de l'appel au dialogue derrière `IDialogService`
  (`ShowEditAlbumAsync`) pour rendre `AlbumEditService.EditAlbumAsync` testable.
  Le `EditAlbumDialog` XAML est inchangé.

## Tests

- 3 tests unitaires ajoutés sur `AlbumEditService` : la confirmation mute le DTO,
  la confirmation envoie un `UpdateAlbumRequest` avec chaque champ positionné,
  l'annulation est un no-op.
- Suite complète verte : 0 échec sur 1468 tests. Build x64 propre (0 warning).
- Le rafraîchissement in-situ (liaison XAML) relève d'un smoke test WinUI manuel,
  non testable unitairement.

Closes #347
