### PR TITLE
feat(artist): add manual artist edit dialog and flow

### DIFF
--- a/src/Presentation/Dialogs/EditArtistDialog.xaml
+++ b/src/Presentation/Dialogs/EditArtistDialog.xaml
@@ -1,0 +1,78 @@
+<ContentDialog x:Class="Rok.Dialogs.EditArtistDialog"
+               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+               xmlns:local="using:Rok.Dialogs"
+               x:Uid="EditArtistDialog"
+               Title=""
+               MinWidth="900"
+               MaxWidth="900"
+               Width="900"
+               PrimaryButtonText=""
+               CloseButtonText="">
+
+    <StackPanel>
+        <StackPanel Orientation="Horizontal">
+            <ToggleSwitch x:Uid="disbandedSwitch"
+                          IsOn="{x:Bind Disbanded, Mode=TwoWay}"></ToggleSwitch>
+        </StackPanel>
+        <MenuFlyoutSeparator></MenuFlyoutSeparator>
+
+        <TextBlock x:Uid="artistMusicBrainzId"
+                   Margin="0,8,0,0"
+                   Text="MusicBrainz ID"></TextBlock>
+        <TextBox x:Uid="artistMusicBrainzIdInput"
+                 Text="{x:Bind MusicBrainzID, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 Margin="0,4,0,0"></TextBox>
+
+        <StackPanel Orientation="Horizontal" Spacing="16">
+            <StackPanel Width="180">
+                <TextBlock x:Uid="artistFormedYear"
+                           Margin="0,8,0,0"
+                           Text="Formed year" />
+                <TextBox x:Uid="artistFormedYearInput"
+                         Text="{x:Bind FormedYear, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         Margin="0,4,0,0" />
+            </StackPanel>
+            <StackPanel Width="180">
+                <TextBlock x:Uid="artistBornYear"
+                           Margin="0,8,0,0"
+                           Text="Born year" />
+                <TextBox x:Uid="artistBornYearInput"
+                         Text="{x:Bind BornYear, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         Margin="0,4,0,0" />
+            </StackPanel>
+            <StackPanel Width="180">
+                <TextBlock x:Uid="artistDiedYear"
+                           Margin="0,8,0,0"
+                           Text="Died year" />
+                <TextBox x:Uid="artistDiedYearInput"
+                         Text="{x:Bind DiedYear, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         Margin="0,4,0,0" />
+            </StackPanel>
+        </StackPanel>
+
+        <TextBlock x:Uid="artistMembers"
+                   Margin="0,8,0,0"
+                   Text="Members" />
+        <TextBox x:Uid="artistMembersInput"
+                 Text="{x:Bind Members, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 TextWrapping="Wrap"
+                 AcceptsReturn="True"
+                 Height="80"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 Margin="0,4,0,0" />
+
+        <TextBlock x:Uid="artistBiography"
+                   Margin="0,8,0,0"
+                   Text="Informations" />
+        <TextBox x:Uid="artistBiographyInput"
+                 Text="{x:Bind Biography, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 TextWrapping="Wrap"
+                 AcceptsReturn="True"
+                 Height="200"
+                 Width="600"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 Margin="0,4,0,0"></TextBox>
+
+    </StackPanel>
+</ContentDialog>

--- a/src/Presentation/Dialogs/EditArtistDialog.xaml.cs
+++ b/src/Presentation/Dialogs/EditArtistDialog.xaml.cs
@@ -1,0 +1,26 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Rok.Dialogs;
+
+public sealed partial class EditArtistDialog : ContentDialog
+{
+    public string? MusicBrainzID { get; set; }
+
+    public string? FormedYear { get; set; }
+
+    public string? BornYear { get; set; }
+
+    public string? DiedYear { get; set; }
+
+    public bool Disbanded { get; set; }
+
+    public string? Members { get; set; }
+
+    public string? Biography { get; set; }
+
+
+    public EditArtistDialog()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/src/Presentation/Pages/ArtistPage.xaml
+++ b/src/Presentation/Pages/ArtistPage.xaml
@@ -75,6 +75,7 @@
                     <AppBarButton x:Uid="artistViewListen" Style="{StaticResource ListenAppBarButtonStyle}" Command="{x:Bind ViewModel.ListenCommand}" />
                     <AppBarToggleButton x:Uid="artistViewLike" x:Name="artistAppBarLike" Style="{StaticResource HeaderLikeButtonStyle}" IsChecked="{x:Bind ViewModel.IsFavorite, Mode=OneWay}" Command="{x:Bind ViewModel.ArtistFavoriteCommand}" />
                     <AppBarButton x:Uid="artistViewBiography" Style="{StaticResource HeaderGenericButtonStyle}" Icon="Library" Command="{x:Bind ViewModel.OpenBiographyCommand}" Visibility="{x:Bind ViewModel.Artist.Biography, Converter={StaticResource StringToVisibilityConverter}}" />
+                    <AppBarButton x:Uid="artistViewEdit" Style="{StaticResource HeaderGenericButtonStyle}" Icon="Edit" Command="{x:Bind ViewModel.EditArtistCommand}" />
                     <AppBarButton x:Uid="albumViewPlaylist" Style="{StaticResource HeaderGenericButtonStyle}" Icon="Add">
                         <AppBarButton.Flyout>
                             <MenuFlyout x:Name="albumPlaylistFlyout" common:MenuFlyoutExtensions.PlaylistMenuService="{x:Bind ViewModel.PlaylistMenuService}" common:MenuFlyoutExtensions.ArtistId="{x:Bind ViewModel.Artist.Id}" common:MenuFlyoutExtensions.FlattenPlaylistMenu="True" />

--- a/src/Presentation/Services/ArtistEditValues.cs
+++ b/src/Presentation/Services/ArtistEditValues.cs
@@ -1,0 +1,25 @@
+namespace Rok.Services;
+
+/// <summary>Immutable carrier for the artist fields edited through the artist edit dialog.</summary>
+/// <remarks>
+/// Year fields are carried as <see langword="string"/> so the dialog binds them to plain
+/// <c>TextBox</c> controls (mirroring the album dialog); <see cref="ArtistEditService"/> parses
+/// them back to <see cref="int"/> when building the update command. An empty or non-numeric
+/// year maps to <see langword="null"/>.
+/// </remarks>
+public sealed record ArtistEditValues
+{
+    public string? MusicBrainzID { get; init; }
+
+    public string? FormedYear { get; init; }
+
+    public string? BornYear { get; init; }
+
+    public string? DiedYear { get; init; }
+
+    public bool Disbanded { get; init; }
+
+    public string? Members { get; init; }
+
+    public string? Biography { get; init; }
+}

--- a/src/Presentation/Services/DialogService.cs
+++ b/src/Presentation/Services/DialogService.cs
@@ -43,6 +43,38 @@ public sealed class DialogService(ResourceLoader resourceLoader, ITranslateServi
         };
     }
 
+    public async Task<ArtistEditValues?> ShowEditArtistAsync(ArtistEditValues current)
+    {
+        EditArtistDialog dialog = new()
+        {
+            MusicBrainzID = current.MusicBrainzID,
+            FormedYear = current.FormedYear,
+            BornYear = current.BornYear,
+            DiedYear = current.DiedYear,
+            Disbanded = current.Disbanded,
+            Members = current.Members,
+            Biography = current.Biography,
+
+            XamlRoot = App.MainWindow.Content.XamlRoot
+        };
+
+        ContentDialogResult result = await dialog.ShowAsync();
+
+        if (result != ContentDialogResult.Primary)
+            return null;
+
+        return new ArtistEditValues
+        {
+            MusicBrainzID = dialog.MusicBrainzID,
+            FormedYear = dialog.FormedYear,
+            BornYear = dialog.BornYear,
+            DiedYear = dialog.DiedYear,
+            Disbanded = dialog.Disbanded,
+            Members = dialog.Members,
+            Biography = dialog.Biography
+        };
+    }
+
     public Task ShowTextAsync(string title, string content, bool showTranslateButton = false, string targetLanguage = "fr")
     {
         string closeButtonText = resourceLoader.GetString("Close");

--- a/src/Presentation/Services/IDialogService.cs
+++ b/src/Presentation/Services/IDialogService.cs
@@ -7,4 +7,8 @@ public interface IDialogService
     /// <summary>Shows the album edit dialog seeded with <paramref name="current"/>.</summary>
     /// <returns>The edited values when the user confirms; <see langword="null"/> when the dialog is dismissed.</returns>
     Task<AlbumEditValues?> ShowEditAlbumAsync(AlbumEditValues current);
+
+    /// <summary>Shows the artist edit dialog seeded with <paramref name="current"/>.</summary>
+    /// <returns>The edited values when the user confirms; <see langword="null"/> when the dialog is dismissed.</returns>
+    Task<ArtistEditValues?> ShowEditArtistAsync(ArtistEditValues current);
 }

--- a/src/Presentation/Strings/en-US/Resources.resw
+++ b/src/Presentation/Strings/en-US/Resources.resw
@@ -1036,6 +1036,21 @@
   <data name="EditAlbumDialog.CloseButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="EditArtistDialog.Title" xml:space="preserve">
+    <value>Artist edit</value>
+  </data>
+  <data name="EditArtistDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="EditArtistDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="disbandedSwitch.OnContent" xml:space="preserve">
+    <value>Disbanded</value>
+  </data>
+  <data name="disbandedSwitch.OffContent" xml:space="preserve">
+    <value>Disbanded</value>
+  </data>
   <data name="liveSwitch.OnContent" xml:space="preserve">
     <value>Live</value>
   </data>

--- a/src/Presentation/Strings/es-ES/Resources.resw
+++ b/src/Presentation/Strings/es-ES/Resources.resw
@@ -919,6 +919,21 @@
   <data name="EditAlbumDialog.CloseButtonText" xml:space="preserve">
     <value>Cancelar</value>
   </data>
+  <data name="EditArtistDialog.Title" xml:space="preserve">
+    <value>Editar artista</value>
+  </data>
+  <data name="EditArtistDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Guardar</value>
+  </data>
+  <data name="EditArtistDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="disbandedSwitch.OnContent" xml:space="preserve">
+    <value>Disuelto</value>
+  </data>
+  <data name="disbandedSwitch.OffContent" xml:space="preserve">
+    <value>Disuelto</value>
+  </data>
   <data name="liveSwitch.OnContent" xml:space="preserve">
     <value>En directo</value>
   </data>

--- a/src/Presentation/Strings/fr-FR/Resources.resw
+++ b/src/Presentation/Strings/fr-FR/Resources.resw
@@ -1035,6 +1035,21 @@
   <data name="EditAlbumDialog.CloseButtonText" xml:space="preserve">
     <value>Annuler</value>
   </data>
+  <data name="EditArtistDialog.Title" xml:space="preserve">
+    <value>Modification artiste</value>
+  </data>
+  <data name="EditArtistDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="EditArtistDialog.CloseButtonText" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="disbandedSwitch.OnContent" xml:space="preserve">
+    <value>Séparé</value>
+  </data>
+  <data name="disbandedSwitch.OffContent" xml:space="preserve">
+    <value>Séparé</value>
+  </data>
   <data name="liveSwitch.OnContent" xml:space="preserve">
     <value>Live</value>
   </data>

--- a/src/Presentation/Strings/uk-UA/Resources.resw
+++ b/src/Presentation/Strings/uk-UA/Resources.resw
@@ -977,6 +977,21 @@
   <data name="EditAlbumDialog.CloseButtonText" xml:space="preserve">
     <value>Скасувати</value>
   </data>
+  <data name="EditArtistDialog.Title" xml:space="preserve">
+    <value>Редагування виконавця</value>
+  </data>
+  <data name="EditArtistDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Зберегти</value>
+  </data>
+  <data name="EditArtistDialog.CloseButtonText" xml:space="preserve">
+    <value>Скасувати</value>
+  </data>
+  <data name="disbandedSwitch.OnContent" xml:space="preserve">
+    <value>Розпущений</value>
+  </data>
+  <data name="disbandedSwitch.OffContent" xml:space="preserve">
+    <value>Розпущений</value>
+  </data>
   <data name="liveSwitch.OnContent" xml:space="preserve">
     <value>Live</value>
   </data>

--- a/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
+++ b/src/Presentation/ViewModels/Artist/ArtistViewModel.cs
@@ -3,12 +3,12 @@ using System.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Rok.Application.Features.Artists.Services;
+using Rok.Application.Features.ListeningEvents;
 using Rok.Application.Features.Playlists.PlaylistMenu;
 using Rok.Application.Player;
 using Rok.Application.Randomizer;
 using Rok.Application.Services.Filters;
 using Rok.Application.Services.Grouping;
-using Rok.Application.Features.ListeningEvents;
 using Rok.Commons;
 using Rok.Infrastructure.Files;
 using Rok.ViewModels.Album;
@@ -581,6 +581,18 @@ public partial class ArtistViewModel : ObservableObject, IFilterableArtist, IGro
     private Task OpenOfficialSiteAsync()
     {
         return _editService.OpenOfficialSiteAsync(Artist);
+    }
+
+    [RelayCommand]
+    private async Task EditArtistAsync()
+    {
+        bool updated = await _editService.EditArtistAsync(Artist);
+
+        if (!updated)
+            return;
+
+        _messenger.Send(new ArtistUpdateMessage(Artist.Id, ActionType.Update));
+        OnPropertyChanged(nameof(Artist));
     }
 
     [RelayCommand]

--- a/src/Presentation/ViewModels/Artist/Services/ArtistEditService.cs
+++ b/src/Presentation/ViewModels/Artist/Services/ArtistEditService.cs
@@ -1,9 +1,65 @@
-﻿using Rok.Application.Features.Artists.Requests;
+﻿using System.Globalization;
+using Rok.Application.Features.Artists.Requests;
+using Rok.Application.Mapping;
 
 namespace Rok.ViewModels.Artist.Services;
 
-public class ArtistEditService(IMediator mediator, ILogger<ArtistEditService> logger)
+public class ArtistEditService(IMediator mediator, IDialogService dialogService, ILogger<ArtistEditService> logger)
 {
+    public async Task<bool> EditArtistAsync(ArtistDto artist)
+    {
+        ArtistEditValues current = new()
+        {
+            MusicBrainzID = artist.MusicBrainzID,
+            FormedYear = artist.FormedYear?.ToString(CultureInfo.InvariantCulture),
+            BornYear = artist.BornYear?.ToString(CultureInfo.InvariantCulture),
+            DiedYear = artist.DiedYear?.ToString(CultureInfo.InvariantCulture),
+            Disbanded = artist.Disbanded,
+            Members = artist.Members,
+            Biography = artist.Biography
+        };
+
+        ArtistEditValues? edited = await dialogService.ShowEditArtistAsync(current);
+
+        if (edited is null)
+            return false;
+
+        int? formedYear = ParseYear(edited.FormedYear);
+        int? bornYear = ParseYear(edited.BornYear);
+        int? diedYear = ParseYear(edited.DiedYear);
+
+        // Start from the full command so URLs and other fields not shown in the dialog are
+        // preserved, then overwrite only the edited subset.
+        UpdateArtistRequest command = artist.ToCommand();
+        command.MusicBrainzID = edited.MusicBrainzID;
+        command.FormedYear = formedYear;
+        command.BornYear = bornYear;
+        command.DiedYear = diedYear;
+        command.Disbanded = edited.Disbanded;
+        command.Members = edited.Members;
+        command.Biography = edited.Biography;
+
+        await mediator.Send(command);
+
+        artist.MusicBrainzID = edited.MusicBrainzID;
+        artist.FormedYear = formedYear;
+        artist.BornYear = bornYear;
+        artist.DiedYear = diedYear;
+        artist.Disbanded = edited.Disbanded;
+        artist.Members = edited.Members;
+        artist.Biography = edited.Biography;
+
+        return true;
+    }
+
+    /// <summary>Parses a year typed in the dialog; empty or non-numeric input maps to <see langword="null"/>.</summary>
+    private static int? ParseYear(string? value)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int year)
+            ? year
+            : null;
+    }
+
     public async Task UpdateFavoriteAsync(ArtistDto artist, bool isFavorite)
     {
         await mediator.Send(new UpdateArtistFavoriteRequest(artist.Id, isFavorite));

--- a/src/Rok.Application/Features/Artists/Requests/UpdateArtistRequestHandler.cs
+++ b/src/Rok.Application/Features/Artists/Requests/UpdateArtistRequestHandler.cs
@@ -98,8 +98,7 @@ public class UpdateArtistRequestHandler(IArtistRepository _artistRepository) : I
         entity.Members = command.Members;
         entity.SimilarArtists = command.SimilarArtists;
 
-        if (!string.IsNullOrWhiteSpace(command.Biography))
-            entity.Biography = command.Biography;
+        entity.Biography = command.Biography;
 
         bool result = await _artistRepository.UpdateAsync(entity);
 

--- a/src/Rok.Application/Features/Artists/Services/ArtistApiService.cs
+++ b/src/Rok.Application/Features/Artists/Services/ArtistApiService.cs
@@ -96,8 +96,7 @@ public class ArtistApiService(
             DiedYear = artistApi.EndYear ?? artist.DiedYear,
         };
 
-        if (string.IsNullOrEmpty(artist.Biography))
-            command.Biography = artistApi.Biography;
+        command.Biography = string.IsNullOrEmpty(artist.Biography) ? artistApi.Biography : artist.Biography;
 
         await mediator.Send(command);
 

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Artists/Requests/ArtistCommandHandlerTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Artists/Requests/ArtistCommandHandlerTests.cs
@@ -63,8 +63,8 @@ public class UpdateArtistRequestHandlerTests
         Assert.True(entity.Disbanded);
     }
 
-    [Fact(DisplayName = "Handle should keep existing biography when new biography is blank")]
-    public async Task Handle_ShouldKeepExistingBiography_WhenNewBiographyIsBlank()
+    [Fact(DisplayName = "Handle should clear biography when command biography is blank")]
+    public async Task Handle_ShouldClearBiography_WhenCommandBiographyIsBlank()
     {
         // Arrange
         ArtistEntity entity = new() { Id = 1, Biography = "original bio" };
@@ -78,7 +78,7 @@ public class UpdateArtistRequestHandlerTests
 
         // Assert
         result.Should().BeSuccess();
-        Assert.Equal("original bio", entity.Biography);
+        Assert.Equal("  ", entity.Biography);
     }
 
     [Fact(DisplayName = "Handle should return failure when artist is not found")]

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Artists/Services/ArtistApiServiceTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Artists/Services/ArtistApiServiceTests.cs
@@ -202,6 +202,46 @@ public class ArtistApiServiceTests
         _musicData.Verify(m => m.DownloadArtistBackdropsAsync(It.IsAny<MusicDataArtistDto>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should preserve the existing biography when the API returns a different one")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldPreserveExistingBiography_WhenApiBiographyDiffers()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 1, Name = "Beatles", Biography = "manual bio", FlickrUrl = "old-flickr" };
+        MusicDataArtistDto artistApi = new() { MusicBrainzID = "mbid", Biography = "api bio", Flickr = "new-flickr" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>())).ReturnsAsync(artistApi);
+        _pictureService.Setup(p => p.PictureExists(artist.Name)).Returns(true);
+        _backdropPicture.Setup(b => b.HasBackdrops(artist.Name)).Returns(true);
+        ArtistApiService sut = BuildService();
+
+        // Act
+        await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+
+        // Assert
+        UpdateArtistRequest sent = Assert.Single(_mediator.Sent<UpdateArtistRequest>());
+        Assert.Equal("manual bio", sent.Biography);
+    }
+
+    [Fact(DisplayName = "GetAndUpdateArtistDataAsync should adopt the API biography when the current one is empty")]
+    public async Task GetAndUpdateArtistDataAsync_ShouldAdoptApiBiography_WhenCurrentIsEmpty()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 1, Name = "Beatles", Biography = string.Empty, FlickrUrl = "old-flickr" };
+        MusicDataArtistDto artistApi = new() { MusicBrainzID = "mbid", Biography = "api bio", Flickr = "new-flickr" };
+        _musicData.Setup(m => m.IsApiRetryAllowed(It.IsAny<DateTime?>())).Returns(true);
+        _musicData.Setup(m => m.GetArtistAsync(It.IsAny<string>(), It.IsAny<string?>())).ReturnsAsync(artistApi);
+        _pictureService.Setup(p => p.PictureExists(artist.Name)).Returns(true);
+        _backdropPicture.Setup(b => b.HasBackdrops(artist.Name)).Returns(true);
+        ArtistApiService sut = BuildService();
+
+        // Act
+        await sut.GetAndUpdateArtistDataAsync(artist, _pictureService.Object, _backdropPicture.Object);
+
+        // Assert
+        UpdateArtistRequest sent = Assert.Single(_mediator.Sent<UpdateArtistRequest>());
+        Assert.Equal("api bio", sent.Biography);
+    }
+
     [Fact(DisplayName = "GetAndUpdateArtistDataAsync should report PictureDownloaded independently of DataUpdated")]
     public async Task GetAndUpdateArtistDataAsync_ShouldReportPictureDownloaded_EvenWhenNoDataChanged()
     {

--- a/tests/UnitTests/Rok.PresentationTests/ViewModels/Artist/Services/ArtistEditServiceTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/ViewModels/Artist/Services/ArtistEditServiceTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Rok.Application.Dto;
 using Rok.Application.Features.Artists.Requests;
+using Rok.Services;
 using Rok.ViewModels.Artist.Services;
 
 namespace Rok.PresentationTests.ViewModels.Artist.Services;
@@ -9,7 +11,9 @@ public class ArtistEditServiceTests
 {
     private readonly FakeMediator _mediator = new();
 
-    private ArtistEditService BuildService() => new(_mediator, NullLogger<ArtistEditService>.Instance);
+    private readonly Mock<IDialogService> _dialogService = new();
+
+    private ArtistEditService BuildService() => new(_mediator, _dialogService.Object, NullLogger<ArtistEditService>.Instance);
 
     [Fact(DisplayName = "UpdateFavoriteAsync should send the favorite command and update the artist state")]
     public async Task UpdateFavoriteAsync_ShouldSendCommandAndUpdateState()
@@ -74,5 +78,178 @@ public class ArtistEditServiceTests
 
         // Assert
         Assert.False(result);
+    }
+
+    [Fact(DisplayName = "EditArtistAsync confirmed should mutate the artist with the edited values")]
+    public async Task EditArtistAsync_Confirmed_ShouldMutateArtist()
+    {
+        // Arrange
+        ArtistDto artist = new()
+        {
+            Id = 7,
+            MusicBrainzID = "old-mb",
+            FormedYear = 1980,
+            BornYear = 1955,
+            DiedYear = null,
+            Disbanded = false,
+            Members = "old members",
+            Biography = "old bio"
+        };
+
+        ArtistEditValues edited = new()
+        {
+            MusicBrainzID = "new-mb",
+            FormedYear = "1990",
+            BornYear = "1960",
+            DiedYear = "2020",
+            Disbanded = true,
+            Members = "new members",
+            Biography = "new bio"
+        };
+
+        SetupDialog(edited);
+        ArtistEditService sut = BuildService();
+
+        // Act
+        bool result = await sut.EditArtistAsync(artist);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal("new-mb", artist.MusicBrainzID);
+        Assert.Equal(1990, artist.FormedYear);
+        Assert.Equal(1960, artist.BornYear);
+        Assert.Equal(2020, artist.DiedYear);
+        Assert.True(artist.Disbanded);
+        Assert.Equal("new members", artist.Members);
+        Assert.Equal("new bio", artist.Biography);
+    }
+
+    [Fact(DisplayName = "EditArtistAsync confirmed should send an update command with the edited fields")]
+    public async Task EditArtistAsync_Confirmed_ShouldSendUpdateCommand()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 7 };
+
+        ArtistEditValues edited = new()
+        {
+            MusicBrainzID = "mb",
+            FormedYear = "1990",
+            BornYear = "1960",
+            DiedYear = "2020",
+            Disbanded = true,
+            Members = "members",
+            Biography = "bio"
+        };
+
+        SetupDialog(edited);
+        ArtistEditService sut = BuildService();
+
+        // Act
+        await sut.EditArtistAsync(artist);
+
+        // Assert
+        UpdateArtistRequest sent = Assert.Single(_mediator.Sent<UpdateArtistRequest>());
+        Assert.Equal(7, sent.Id);
+        Assert.Equal("mb", sent.MusicBrainzID);
+        Assert.Equal(1990, sent.FormedYear);
+        Assert.Equal(1960, sent.BornYear);
+        Assert.Equal(2020, sent.DiedYear);
+        Assert.True(sent.Disbanded);
+        Assert.Equal("members", sent.Members);
+        Assert.Equal("bio", sent.Biography);
+    }
+
+    [Fact(DisplayName = "EditArtistAsync confirmed should preserve fields not shown in the dialog (social URLs)")]
+    public async Task EditArtistAsync_Confirmed_ShouldPreserveHiddenFields()
+    {
+        // Arrange - a URL that the dialog never edits must survive the round-trip via ToCommand().
+        ArtistDto artist = new()
+        {
+            Id = 7,
+            FacebookUrl = "https://facebook.com/band",
+            WikipediaUrl = "https://wikipedia.org/band",
+            SimilarArtists = "Some Other Band"
+        };
+
+        SetupDialog(new ArtistEditValues { Biography = "bio" });
+        ArtistEditService sut = BuildService();
+
+        // Act
+        await sut.EditArtistAsync(artist);
+
+        // Assert
+        UpdateArtistRequest sent = Assert.Single(_mediator.Sent<UpdateArtistRequest>());
+        Assert.Equal("https://facebook.com/band", sent.FacebookUrl);
+        Assert.Equal("https://wikipedia.org/band", sent.WikipediaUrl);
+        Assert.Equal("Some Other Band", sent.SimilarArtists);
+    }
+
+    [Fact(DisplayName = "EditArtistAsync confirmed with a cleared biography should send an empty biography")]
+    public async Task EditArtistAsync_Confirmed_ClearedBiography_ShouldSendEmpty()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 7, Biography = "old bio" };
+
+        SetupDialog(new ArtistEditValues { Biography = "" });
+        ArtistEditService sut = BuildService();
+
+        // Act
+        await sut.EditArtistAsync(artist);
+
+        // Assert
+        UpdateArtistRequest sent = Assert.Single(_mediator.Sent<UpdateArtistRequest>());
+        Assert.True(string.IsNullOrEmpty(sent.Biography));
+        Assert.True(string.IsNullOrEmpty(artist.Biography));
+    }
+
+    [Theory(DisplayName = "EditArtistAsync should map an empty or non-numeric year to null")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData(null)]
+    public async Task EditArtistAsync_NonNumericYear_ShouldMapToNull(string? yearInput)
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 7, FormedYear = 1980 };
+
+        SetupDialog(new ArtistEditValues { FormedYear = yearInput });
+        ArtistEditService sut = BuildService();
+
+        // Act
+        await sut.EditArtistAsync(artist);
+
+        // Assert
+        UpdateArtistRequest sent = Assert.Single(_mediator.Sent<UpdateArtistRequest>());
+        Assert.Null(sent.FormedYear);
+        Assert.Null(artist.FormedYear);
+    }
+
+    [Fact(DisplayName = "EditArtistAsync cancelled should not send any command nor mutate the artist")]
+    public async Task EditArtistAsync_Cancelled_ShouldDoNothing()
+    {
+        // Arrange
+        ArtistDto artist = new() { Id = 7, Biography = "old bio", FormedYear = 1980 };
+
+        _dialogService
+            .Setup(x => x.ShowEditArtistAsync(It.IsAny<ArtistEditValues>()))
+            .ReturnsAsync((ArtistEditValues?)null);
+
+        ArtistEditService sut = BuildService();
+
+        // Act
+        bool result = await sut.EditArtistAsync(artist);
+
+        // Assert
+        Assert.False(result);
+        Assert.Empty(_mediator.Sent<UpdateArtistRequest>());
+        Assert.Equal("old bio", artist.Biography);
+        Assert.Equal(1980, artist.FormedYear);
+    }
+
+    private void SetupDialog(ArtistEditValues edited)
+    {
+        _dialogService
+            .Setup(x => x.ShowEditArtistAsync(It.IsAny<ArtistEditValues>()))
+            .ReturnsAsync(edited);
     }
 }


### PR DESCRIPTION
## Intention

Permettre l'édition manuelle d'une fiche artiste depuis `ArtistPage`, en miroir de
l'édition d'album existante. Le back-end (`UpdateArtistRequest` + handler +
`ArtistMapping.ToCommand`) existait déjà ; cette PR ajoute la couche UI et corrige le
chemin biographie.

## Périmètre

Champs éditables : `MusicBrainzID`, `FormedYear`, `BornYear`, `DiedYear`, `Disbanded`,
`Members`, `Biography`. Les 17 URLs réseaux et les autres champs non affichés restent
inchangés (auto-API).

## Approche (6 slices)

1. **Correctif biographie** (Application, risque isolé) : garde non-vide retirée de
   `UpdateArtistRequestHandler` + `ArtistApiService` renvoie désormais la bio courante
   au lieu de `null`, pour qu'un fetch auto-API n'écrase pas une bio saisie.
2. `ArtistEditValues` (record) + `EditArtistDialog` (miroir de `EditAlbumDialog`).
3. `IDialogService.ShowEditArtistAsync` + implémentation `DialogService`.
4. `ArtistEditService.EditArtistAsync` : part de `artist.ToCommand()` (préserve les URLs
   et champs non affichés), n'écrase que le sous-ensemble édité, `Send`, mute le DTO.
5. `ArtistViewModel.EditArtistCommand` : émet `ArtistUpdateMessage(Update)` + rafraîchit.
6. `AppBarButton Icon="Edit"` sur `ArtistPage` + ressources i18n dans les 4 locales.

## Choix d'implémentation

- **Années en TextBox** (`string?` dans le dialog, `int.TryParse` invariant dans le
  service ; vide/non-numérique → `null`) — cohérence avec le miroir album, pas de
  `NumberBox` ni de converter.
- **Full-replace via `ToCommand`** conservé (pas le pattern partiel `.Set()` de l'album) :
  la commande est pré-remplie depuis le DTO courant, donc aucun champ non affiché n'est
  perdu.
- **4 locales** alimentées (`en-US`, `fr-FR`, `es-ES`, `uk-UA`), comme la convention du
  dialog album.

## Vérification

- `dotnet build` (Presentation + tests, `-p:Platform=x64`) : 0 warning, 0 erreur
  (`TreatWarningsAsErrors=true`).
- `dotnet test` : **617** (Application) + **352** (Presentation) verts, 0 échec.
- Gates legion : `lint` accept (après correctif format déterministe), `review`
  accept_with_opportunity, `test` accept.
- Rendu bout-en-bout du dialog et bouton : acceptation humaine (dépend du `XamlRoot`).

Closes #350
