### PR TITLE
build: release v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ﻿# ChangeLog
 
+## [1.16.0] Store – 9 juillet 2026
+
+### Ajouté
+
+- Édition manuelle des artistes via une boîte de dialogue dédiée.
+
+### Corrigé
+
+- Prise en compte des modifications enregistrées sur la page de détail d'un album.
+- Ordre des titres préservé lors de la lecture d'un album unique.
+
+--
+
 ## [1.15.0] Store – 24 juin 2026
 
 ### Ajouté

--- a/src/Presentation/Package.appxmanifest
+++ b/src/Presentation/Package.appxmanifest
@@ -10,7 +10,7 @@
 	<Identity
 	  Name="Rokapp.Rokmusicplayer"
 	  Publisher="CN=C9A55691-54ED-46EA-9D4F-F3CD41C04242"
-	  Version="1.15.0.0" />
+	  Version="1.16.0.0" />
 
 	<Properties>
 		<DisplayName>Rok musicplayer</DisplayName>


### PR DESCRIPTION
## Résumé

Release **1.16.0** : entrée `CHANGELOG.md` + bump version manifest (`1.15.0.0` → `1.16.0.0`).

## Contenu (commits depuis `v1.15.0`)

### Ajouté
- Édition manuelle des artistes via une boîte de dialogue dédiée (#352).

### Corrigé
- Prise en compte des modifications enregistrées sur la page de détail d'un album (#349, #351).
- Ordre des titres préservé lors de la lecture d'un album unique (#348).

Tag `v1.16.0` poussé sur le commit de cette branche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
