### PR TITLE
feat(playlist): add per-playlist shuffle-on-play option

### DIFF
--- a/src/Presentation/Pages/PlaylistPage.xaml
+++ b/src/Presentation/Pages/PlaylistPage.xaml
@@ -40,6 +40,7 @@
                 <CommandBar RelativePanel.AlignBottomWithPanel="True" Style="{StaticResource HeaderCommandBarStyle}">
                     <AppBarButton x:Uid="playlistListen" Style="{StaticResource ListenAppBarButtonStyle}" Command="{x:Bind ViewModel.ListenCommand}" />
                     <AppBarButton x:Uid="shuffleButton" Style="{StaticResource AppBarButtonCompactStyle}" Icon="Shuffle" Command="{x:Bind ViewModel.ShufflePlaylistCommand}" />
+                    <AppBarToggleButton x:Uid="shuffleOnPlayButton" Style="{StaticResource AppBarToggleButtonCompactStyle}" Icon="Shuffle" IsChecked="{x:Bind ViewModel.ShuffleOnPlay, Mode=TwoWay}" />
                     <AppBarButton x:Uid="playlistDelete" Style="{StaticResource AppBarButtonCompactStyle}" Icon="Delete" Click="DeleteButton_Click" />
                     <AppBarButton x:Uid="playlistExport" Style="{StaticResource AppBarButtonCompactStyle}" Icon="Save" Command="{x:Bind ViewModel.ExportPlaylistCommand}" />
                 </CommandBar>

--- a/src/Presentation/Strings/en-US/Resources.resw
+++ b/src/Presentation/Strings/en-US/Resources.resw
@@ -1018,6 +1018,9 @@
   <data name="shuffleButton.Label" xml:space="preserve">
     <value>Shuffle</value>
   </data>
+  <data name="shuffleOnPlayButton.Label" xml:space="preserve">
+    <value>Shuffle on play</value>
+  </data>
   <data name="NoLibraryFoldersTitleMessage" xml:space="preserve">
     <value>No library</value>
   </data>

--- a/src/Presentation/Strings/es-ES/Resources.resw
+++ b/src/Presentation/Strings/es-ES/Resources.resw
@@ -901,6 +901,9 @@
   <data name="shuffleButton.Label" xml:space="preserve">
     <value>Barajar</value>
   </data>
+  <data name="shuffleOnPlayButton.Label" xml:space="preserve">
+    <value>Reproducción aleatoria</value>
+  </data>
   <data name="NoLibraryFoldersTitleMessage" xml:space="preserve">
     <value>No se encuentra la biblioteca</value>
   </data>

--- a/src/Presentation/Strings/fr-FR/Resources.resw
+++ b/src/Presentation/Strings/fr-FR/Resources.resw
@@ -1017,6 +1017,9 @@
   <data name="shuffleButton.Label" xml:space="preserve">
     <value>Mélanger</value>
   </data>
+  <data name="shuffleOnPlayButton.Label" xml:space="preserve">
+    <value>Lecture aléatoire</value>
+  </data>
   <data name="NoLibraryFoldersTitleMessage" xml:space="preserve">
     <value>Aucune librarie</value>
   </data>

--- a/src/Presentation/Strings/uk-UA/Resources.resw
+++ b/src/Presentation/Strings/uk-UA/Resources.resw
@@ -959,6 +959,9 @@
   <data name="shuffleButton.Label" xml:space="preserve">
     <value>Перемішати</value>
   </data>
+  <data name="shuffleOnPlayButton.Label" xml:space="preserve">
+    <value>Випадкове відтворення</value>
+  </data>
   <data name="NoLibraryFoldersTitleMessage" xml:space="preserve">
     <value>Немає бібліотеки</value>
   </data>

--- a/src/Presentation/Styles/Components/ControlsStyles.xaml
+++ b/src/Presentation/Styles/Components/ControlsStyles.xaml
@@ -288,6 +288,147 @@
         </Setter>
     </Style>
 
+    <Style x:Key="AppBarToggleButtonCompactStyle" TargetType="AppBarToggleButton">
+        <Setter Property="Foreground" Value="{ThemeResource OnNeutralSurfacePrimaryBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="Margin" Value="6,0,0,0" />
+        <Setter Property="CornerRadius" Value="{StaticResource CornerRadiusSmallValue}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeSmall}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Width" Value="auto" />
+        <Setter Property="Height" Value="36" />
+        <Setter Property="MinHeight" Value="36" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="UseSystemFocusVisuals" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="AppBarToggleButton">
+                    <Grid x:Name="Root" Height="{TemplateBinding Height}" VerticalAlignment="Center" Background="Transparent">
+                        <Border x:Name="Bg"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                VerticalAlignment="Center"
+                                Height="{TemplateBinding Height}">
+                            <StackPanel x:Name="ContentPanel" Orientation="Horizontal" Spacing="{StaticResource SpacingSmall}" VerticalAlignment="Center" HorizontalAlignment="Center">
+
+                                <ContentPresenter x:Name="IconGlyph"
+                                                  Content="{TemplateBinding Icon}"
+                                                  FontSize="{StaticResource FontSizeMedium}"
+                                                  Foreground="{TemplateBinding Foreground}" />
+
+                                <TextBlock x:Name="LabelText"
+                                           Text="{TemplateBinding Label}"
+                                           Foreground="{TemplateBinding Foreground}"
+                                           VerticalAlignment="Center"
+                                           FontSize="{TemplateBinding FontSize}"
+                                           FontWeight="{TemplateBinding FontWeight}" />
+                            </StackPanel>
+                        </Border>
+
+                        <VisualStateManager.VisualStateGroups>
+
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="PointerOver">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Bg" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BrandPrimaryHoverBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LabelText" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="IconGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Bg"
+                                       Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Root" Storyboard.TargetProperty="Opacity" To="0.45" Duration="0:0:0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Checked">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Bg" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BrandPrimaryHoverBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LabelText" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="IconGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPointerOver">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Bg" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BrandPrimaryHoverBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LabelText" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="IconGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPressed">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Bg" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+
+                            <VisualStateGroup x:Name="FocusStates">
+                                <VisualState x:Name="Focused">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Bg" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource OnNeutralSurfacePrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Bg" Storyboard.TargetProperty="BorderThickness">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="1" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="PointerFocused" />
+                                <VisualState x:Name="Unfocused" />
+                            </VisualStateGroup>
+
+                            <VisualStateGroup x:Name="DisplayModeStates">
+                                <VisualState x:Name="FullSize" />
+                                <VisualState x:Name="Compact">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LabelText" Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="HyperlinkGroupButtonStyle" TargetType="HyperlinkButton">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{ThemeResource BrandAccentBrush}"/>

--- a/src/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
+++ b/src/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Rok.Application.Dto;
 using Rok.Application.Player;
+using Rok.Application.Randomizer;
 using Rok.ViewModels.Playlist.Services;
 using Rok.ViewModels.Track;
 
@@ -48,6 +50,16 @@ public partial class PlaylistViewModel : ObservableObject
         set
         {
             Playlist.Name = value;
+            _ = SavePlaylistAsync();
+        }
+    }
+
+    public bool ShuffleOnPlay
+    {
+        get => Playlist.ShuffleOnPlay;
+        set
+        {
+            Playlist.ShuffleOnPlay = value;
             _ = SavePlaylistAsync();
         }
     }
@@ -245,8 +257,17 @@ public partial class PlaylistViewModel : ObservableObject
                 await LoadTracksAsync(Playlist.Id);
         }
 
-        if (_tracks?.Any() == true)
+        if (_tracks?.Any() != true)
+            return;
+
+        if (!Playlist.ShuffleOnPlay)
+        {
             _playerService.LoadPlaylist(_tracks.ToList(), track?.Track);
+            return;
+        }
+
+        List<TrackDto> ordered = PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder(_tracks, track?.Track);
+        _playerService.LoadPlaylist(ordered, track?.Track);
     }
 
     [RelayCommand]

--- a/src/Presentation/ViewModels/Playlist/Services/PlaylistUpdateService.cs
+++ b/src/Presentation/ViewModels/Playlist/Services/PlaylistUpdateService.cs
@@ -28,7 +28,8 @@ public class PlaylistUpdateService(
             TrackMaximum = playlist.TrackMaximum,
             DurationMaximum = playlist.DurationMaximum,
             Picture = track?.ArtistName!,
-            Groups = groups ?? playlist.Groups
+            Groups = groups ?? playlist.Groups,
+            ShuffleOnPlay = playlist.ShuffleOnPlay
         };
 
         bool hasChanges = forceUpdate ||
@@ -38,7 +39,8 @@ public class PlaylistUpdateService(
             command.TrackMaximum != playlist.TrackMaximum ||
             command.DurationMaximum != playlist.DurationMaximum ||
             command.Picture != playlist.Picture ||
-            command.Groups != playlist.Groups;
+            command.Groups != playlist.Groups ||
+            command.ShuffleOnPlay != playlist.ShuffleOnPlay;
 
         if (!hasChanges)
             return false;
@@ -61,6 +63,7 @@ public class PlaylistUpdateService(
         playlist.TrackMaximum = command.TrackMaximum;
         playlist.DurationMaximum = command.DurationMaximum;
         playlist.Groups = command.Groups;
+        playlist.ShuffleOnPlay = command.ShuffleOnPlay;
 
         messenger.Send(new PlaylistUpdatedMessage(playlist.Id, ActionType.Update));
 

--- a/src/Rok.Application/Dto/PlaylistHeaderDto.cs
+++ b/src/Rok.Application/Dto/PlaylistHeaderDto.cs
@@ -24,6 +24,8 @@ public class PlaylistHeaderDto
 
     public int Type { get; set; }
 
+    public bool ShuffleOnPlay { get; set; }
+
     public bool IsSmart => Type == 0;
 
     public List<PlaylistGroupDto> Groups { get; set; } = [];

--- a/src/Rok.Application/Features/Playlists/Requests/UpdatePlaylistRequestHandler.cs
+++ b/src/Rok.Application/Features/Playlists/Requests/UpdatePlaylistRequestHandler.cs
@@ -25,6 +25,8 @@ public class UpdatePlaylistRequest : IRequest<Result>
     public SmartPlaylistSelectBy Sorts { get; set; }
 
     public int Type { get; set; } = 0;
+
+    public bool ShuffleOnPlay { get; set; }
 }
 
 public sealed class UpdatePlaylistRequestValidator : Validator<UpdatePlaylistRequest>

--- a/src/Rok.Application/Mapping/PlaylistHeadeDtoMapping.cs
+++ b/src/Rok.Application/Mapping/PlaylistHeadeDtoMapping.cs
@@ -24,6 +24,7 @@ public static class PlaylistHeadeDtoMapping
             DurationMaximum = entity.DurationMaximum,
             GroupsJson = entity.GroupsJson,
             Type = entity.Type,
+            ShuffleOnPlay = entity.ShuffleOnPlay,
             Groups = groups
         };
     }
@@ -53,7 +54,8 @@ public static class PlaylistHeadeDtoMapping
             TrackMaximum = command.TrackMaximum,
             DurationMaximum = command.DurationMaximum,
             GroupsJson = command.Groups is { Count: > 0 } ? JsonSerializer.Serialize(command.Groups) : string.Empty,
-            Type = command.Type
+            Type = command.Type,
+            ShuffleOnPlay = command.ShuffleOnPlay
         };
     }
 
@@ -82,6 +84,7 @@ public static class PlaylistHeadeDtoMapping
             TrackMaximum = dto.TrackMaximum,
             DurationMaximum = dto.DurationMaximum,
             Type = dto.Type,
+            ShuffleOnPlay = dto.ShuffleOnPlay,
             Groups = dto.Groups ?? new List<PlaylistGroupDto>()
         };
     }

--- a/src/Rok.Application/Randomizer/PlaylistPlaybackOrderBuilder.cs
+++ b/src/Rok.Application/Randomizer/PlaylistPlaybackOrderBuilder.cs
@@ -1,0 +1,34 @@
+﻿namespace Rok.Application.Randomizer;
+
+public static class PlaylistPlaybackOrderBuilder
+{
+    public static List<TrackDto> BuildShuffledPlayOrder(IEnumerable<TrackDto> tracks, TrackDto? clickedTrack, Random? random = null)
+    {
+        List<TrackDto> ordered = tracks.ToList();
+
+        if (ordered.Count <= 1)
+            return ordered;
+
+        random ??= Random.Shared;
+
+        if (clickedTrack == null)
+        {
+            int randomIndex = random.Next(ordered.Count);
+            (ordered[0], ordered[randomIndex]) = (ordered[randomIndex], ordered[0]);
+
+            TracksRandomizer.ArtistBalancedTrackRandomize(ordered, 0, random);
+            return ordered;
+        }
+
+        int clickedIndex = ordered.FindIndex(t => t.Id == clickedTrack.Id);
+        if (clickedIndex > 0)
+        {
+            TrackDto clicked = ordered[clickedIndex];
+            ordered.RemoveAt(clickedIndex);
+            ordered.Insert(0, clicked);
+        }
+
+        TracksRandomizer.ArtistBalancedTrackRandomize(ordered, 0, random);
+        return ordered;
+    }
+}

--- a/src/Rok.Domain/Entities/PlaylistHeaderEntity.cs
+++ b/src/Rok.Domain/Entities/PlaylistHeaderEntity.cs
@@ -18,4 +18,6 @@ public class PlaylistHeaderEntity : BaseEntity
     public string GroupsJson { get; set; } = string.Empty;
 
     public int Type { get; set; }
+
+    public bool ShuffleOnPlay { get; set; }
 }

--- a/src/Rok.Infrastructure/DependencyInjection.cs
+++ b/src/Rok.Infrastructure/DependencyInjection.cs
@@ -79,6 +79,7 @@ public static class DependencyInjection
         services.AddSingleton<IMigration, Migration12>();
         services.AddSingleton<IMigration, Migration13>();
         services.AddSingleton<IMigration, Migration14>();
+        services.AddSingleton<IMigration, Migration15>();
 
         services.AddScoped<IArtistRepository, ArtistRepository>();
         services.AddScoped<IAlbumRepository, AlbumRepository>();

--- a/src/Rok.Infrastructure/Migration/Migration15.cs
+++ b/src/Rok.Infrastructure/Migration/Migration15.cs
@@ -1,0 +1,15 @@
+namespace Rok.Infrastructure.Migration;
+
+/// <summary>
+/// Adds the ShuffleOnPlay flag to Playlists, letting a playlist opt into shuffled
+/// playback whenever it starts listening.
+/// </summary>
+public class Migration15 : IMigration
+{
+    public int TargetVersion => 15;
+
+    public void Apply(IDbConnection connection)
+    {
+        connection.Execute("ALTER TABLE Playlists ADD COLUMN shuffleOnPlay INTEGER NOT NULL DEFAULT 0;");
+    }
+}

--- a/src/Rok.Infrastructure/Repositories/PlaylistHeaderRepository.cs
+++ b/src/Rok.Infrastructure/Repositories/PlaylistHeaderRepository.cs
@@ -46,8 +46,8 @@ public class PlaylistHeaderRepository(IDbConnection connection, [FromKeyedServic
     public override string GetSelectQuery(string? whereParam = null)
     {
         string query = """
-                    SELECT id, name, picture, duration, trackCount, trackMaximum, durationMaximum, groupsJson, type, creatDate, editDate 
-                    FROM playlists                                  
+                    SELECT id, name, picture, duration, trackCount, trackMaximum, durationMaximum, groupsJson, type, shuffleOnPlay, creatDate, editDate
+                    FROM playlists
                 """;
 
         if (!string.IsNullOrEmpty(whereParam))

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/ImportPlaylistCommandHandlerTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/ImportPlaylistCommandHandlerTests.cs
@@ -23,7 +23,7 @@ public sealed class ImportPlaylistRequestHandlerTests : IDisposable
     {
         _connection = new SqliteConnection($"Data Source=ImportHandler_{Guid.NewGuid():N};Mode=Memory;Cache=Shared");
         _connection.Open();
-        _connection.Execute("CREATE TABLE playlists (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, picture TEXT, duration INTEGER, trackCount INTEGER, trackMaximum INTEGER, durationMaximum INTEGER, groupsJson TEXT, type INTEGER, creatDate TEXT, editDate TEXT)");
+        _connection.Execute("CREATE TABLE playlists (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, picture TEXT, duration INTEGER, trackCount INTEGER, trackMaximum INTEGER, durationMaximum INTEGER, groupsJson TEXT, type INTEGER, creatDate TEXT, editDate TEXT, shuffleOnPlay INTEGER NOT NULL DEFAULT 0)");
         _connection.Execute("CREATE TABLE playlisttracks (id INTEGER PRIMARY KEY AUTOINCREMENT, playlistId INTEGER, trackId INTEGER, position INTEGER, listened INTEGER, creatDate TEXT)");
     }
 
@@ -349,6 +349,33 @@ public sealed class ImportPlaylistRequestHandlerTests : IDisposable
             // Assert
             result.Should().BeFailure().And.HaveError<OperationError>().And.HaveErrorWithCode("playlist.database_error");
             Assert.Equal(0, _connection.ExecuteScalar<int>("SELECT COUNT(*) FROM playlists"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact(DisplayName = "imported_playlist_defaults_shuffle_on_play_to_false")]
+    public async Task Imported_playlist_defaults_shuffle_on_play_to_false()
+    {
+        // Arrange
+        string path = WritePlaylistFile("dummy");
+        try
+        {
+            _reader.Setup(r => r.ReadAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(Model("Mix", ("D:\\a.mp3", null, null, null)));
+            _trackRepository.Setup(r => r.GetByFilePathAsync("D:\\a.mp3", It.IsAny<CancellationToken>())).ReturnsAsync(new TrackEntity { Id = 1 });
+
+            ImportPlaylistRequestHandler sut = BuildHandler();
+
+            // Act
+            Result<PlaylistImportResult> result = await sut.Handle(new ImportPlaylistRequest(path), CancellationToken.None);
+
+            // Assert
+            result.Should().BeSuccess();
+            int shuffleOnPlay = _connection.ExecuteScalar<int>("SELECT shuffleOnPlay FROM playlists WHERE id = @id", new { id = result.Value.PlaylistId });
+            Assert.Equal(0, shuffleOnPlay);
         }
         finally
         {

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/PlaylistCommandHandlerTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/PlaylistCommandHandlerTests.cs
@@ -70,6 +70,22 @@ public class UpdatePlaylistRequestHandlerTests
         // Assert
         result.Should().BeFailure().And.HaveError<OperationError>().And.HaveErrorWithCode("playlist.update_failed");
     }
+
+    [Fact(DisplayName = "Handle should pass shuffle on play flag to repository")]
+    public async Task Handle_ShouldPassShuffleOnPlayToRepository()
+    {
+        // Arrange
+        Mock<IPlaylistHeaderRepository> repository = new();
+        repository.Setup(r => r.UpdateAsync(It.IsAny<PlaylistHeaderEntity>(), It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(true);
+        UpdatePlaylistRequestHandler handler = new(repository.Object, Mock.Of<ILogger<UpdatePlaylistRequestHandler>>());
+
+        // Act
+        Result result = await handler.Handle(new UpdatePlaylistRequest { Id = 1, Name = "N", ShuffleOnPlay = true }, CancellationToken.None);
+
+        // Assert
+        result.Should().BeSuccess();
+        repository.Verify(r => r.UpdateAsync(It.Is<PlaylistHeaderEntity>(e => e.ShuffleOnPlay), It.IsAny<RepositoryConnectionKind>()), Times.Once);
+    }
 }
 
 public class DeletePlaylistRequestHandlerTests

--- a/tests/UnitTests/Rok.ApplicationTests/Mapping/PlaylistHeaderDtoMappingTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Mapping/PlaylistHeaderDtoMappingTests.cs
@@ -133,4 +133,67 @@ public class PlaylistHeaderDtoMappingTests
         Assert.Equal(3600, command.DurationMaximum);
         Assert.Single(command.Groups);
     }
+
+    [Theory(DisplayName = "Map entity to dto should propagate ShuffleOnPlay")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapEntityToDto_ShouldPropagateShuffleOnPlay(bool shuffleOnPlay)
+    {
+        // Arrange
+        PlaylistHeaderEntity entity = new()
+        {
+            Id = 1,
+            Name = "Plain",
+            Type = (int)PlaylistType.Classic,
+            ShuffleOnPlay = shuffleOnPlay
+        };
+
+        // Act
+        PlaylistHeaderDto dto = PlaylistHeadeDtoMapping.Map(entity);
+
+        // Assert
+        Assert.Equal(shuffleOnPlay, dto.ShuffleOnPlay);
+    }
+
+    [Theory(DisplayName = "Map update command to entity should propagate ShuffleOnPlay")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapUpdateCommandToEntity_ShouldPropagateShuffleOnPlay(bool shuffleOnPlay)
+    {
+        // Arrange
+        UpdatePlaylistRequest command = new()
+        {
+            Id = 1,
+            Name = "Plain",
+            Type = (int)PlaylistType.Classic,
+            ShuffleOnPlay = shuffleOnPlay
+        };
+
+        // Act
+        PlaylistHeaderEntity entity = PlaylistHeadeDtoMapping.Map(command);
+
+        // Assert
+        Assert.Equal(shuffleOnPlay, entity.ShuffleOnPlay);
+    }
+
+    [Theory(DisplayName = "MapToUpdatePlaylistRequest should propagate ShuffleOnPlay")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapToUpdatePlaylistRequest_ShouldPropagateShuffleOnPlay(bool shuffleOnPlay)
+    {
+        // Arrange
+        PlaylistHeaderDto dto = new()
+        {
+            Id = 1,
+            Name = "Plain",
+            Type = (int)PlaylistType.Classic,
+            ShuffleOnPlay = shuffleOnPlay
+        };
+
+        // Act
+        UpdatePlaylistRequest command = PlaylistHeadeDtoMapping.MapToUpdatePlaylistRequest(dto);
+
+        // Assert
+        Assert.Equal(shuffleOnPlay, command.ShuffleOnPlay);
+    }
 }

--- a/tests/UnitTests/Rok.ApplicationTests/PlaylistPlaybackOrderBuilderTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/PlaylistPlaybackOrderBuilderTests.cs
@@ -1,0 +1,134 @@
+﻿using Rok.Application.Dto;
+using Rok.Application.Randomizer;
+
+namespace Rok.ApplicationTests;
+
+public class PlaylistPlaybackOrderBuilderTests
+{
+    [Fact(DisplayName = "when_clicked_track_provided_it_starts_first")]
+    public void BuildShuffledPlayOrder_ShouldPlaceClickedTrackFirst_WhenTrackIsClicked()
+    {
+        // Arrange
+        List<TrackDto> tracks = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" },
+            new() { Id = 2, ArtistName = "Artist B" },
+            new() { Id = 3, ArtistName = "Artist C" },
+            new() { Id = 4, ArtistName = "Artist D" },
+            new() { Id = 5, ArtistName = "Artist E" }
+        };
+        TrackDto clicked = tracks[3];
+
+        // Act
+        List<TrackDto> ordered = PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder(tracks, clicked, new Random(42));
+
+        // Assert
+        Assert.Equal(4, ordered[0].Id);
+    }
+
+    [Fact(DisplayName = "when_clicked_track_already_first_it_stays_first")]
+    public void BuildShuffledPlayOrder_ShouldKeepClickedTrackFirst_WhenAlreadyFirst()
+    {
+        // Arrange
+        List<TrackDto> tracks = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" },
+            new() { Id = 2, ArtistName = "Artist B" },
+            new() { Id = 3, ArtistName = "Artist C" }
+        };
+        TrackDto clicked = tracks[0];
+
+        // Act
+        List<TrackDto> ordered = PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder(tracks, clicked, new Random(42));
+
+        // Assert
+        Assert.Equal(1, ordered[0].Id);
+    }
+
+    [Fact(DisplayName = "when_clicked_track_not_found_it_does_not_crash")]
+    public void BuildShuffledPlayOrder_ShouldNotCrash_WhenClickedTrackNotFound()
+    {
+        // Arrange
+        List<TrackDto> tracks = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" },
+            new() { Id = 2, ArtistName = "Artist B" },
+            new() { Id = 3, ArtistName = "Artist C" }
+        };
+        TrackDto notInList = new() { Id = 99, ArtistName = "Artist Z" };
+
+        // Act
+        List<TrackDto> ordered = PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder(tracks, notInList, new Random(42));
+
+        // Assert
+        Assert.Equal(3, ordered.Count);
+        Assert.Equal(new List<long> { 1, 2, 3 }, ordered.Select(t => t.Id).OrderBy(id => id).ToList());
+    }
+
+    [Fact(DisplayName = "when_no_track_clicked_first_track_varies_across_seeds")]
+    public void BuildShuffledPlayOrder_ShouldVaryFirstTrack_WhenNoTrackClickedAcrossSeeds()
+    {
+        // Arrange
+        List<TrackDto> tracks = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" },
+            new() { Id = 2, ArtistName = "Artist B" },
+            new() { Id = 3, ArtistName = "Artist C" },
+            new() { Id = 4, ArtistName = "Artist D" },
+            new() { Id = 5, ArtistName = "Artist E" }
+        };
+
+        // Act
+        HashSet<long> firstTrackIds = new();
+        for (int seed = 0; seed < 20; seed++)
+        {
+            List<TrackDto> ordered = PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder(tracks, null, new Random(seed));
+            firstTrackIds.Add(ordered[0].Id);
+        }
+
+        // Assert
+        Assert.True(firstTrackIds.Count > 1);
+    }
+
+    [Fact(DisplayName = "when_no_track_clicked_multiset_is_preserved")]
+    public void BuildShuffledPlayOrder_ShouldPreserveMultiset_WhenNoTrackClicked()
+    {
+        // Arrange
+        List<TrackDto> tracks = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" },
+            new() { Id = 2, ArtistName = "Artist B" },
+            new() { Id = 3, ArtistName = "Artist C" },
+            new() { Id = 4, ArtistName = "Artist D" },
+            new() { Id = 5, ArtistName = "Artist E" }
+        };
+
+        // Act
+        List<TrackDto> ordered = PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder(tracks, null, new Random(42));
+
+        // Assert
+        Assert.Equal(5, ordered.Count);
+        Assert.Equal(ordered.Select(t => t.Id).Distinct().Count(), ordered.Count);
+        Assert.Equal(new List<long> { 1, 2, 3, 4, 5 }, ordered.Select(t => t.Id).OrderBy(id => id).ToList());
+    }
+
+    [Fact(DisplayName = "when_tracks_have_one_or_zero_elements_it_is_a_no_op")]
+    public void BuildShuffledPlayOrder_ShouldNoOp_WhenTracksHaveOneOrZeroElements()
+    {
+        // Arrange
+        List<TrackDto> emptyTracks = new();
+        List<TrackDto> singleTrack = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" }
+        };
+
+        // Act
+        List<TrackDto> orderedEmpty = PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder(emptyTracks, null, new Random(42));
+        List<TrackDto> orderedSingle = PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder(singleTrack, null, new Random(42));
+
+        // Assert
+        Assert.Empty(orderedEmpty);
+        Assert.Single(orderedSingle);
+        Assert.Equal(1, orderedSingle[0].Id);
+    }
+}

--- a/tests/UnitTests/Rok.ApplicationTests/TracksRandomizerTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/TracksRandomizerTests.cs
@@ -132,6 +132,74 @@ public class TracksRandomizerTests
         Assert.Equal(1, playlist[0].Id);
     }
 
+    [Fact(DisplayName = "when_shuffle_start_index_is_zero_first_track_is_preserved")]
+    public void ArtistBalancedTrackRandomize_ShouldPreserveFirstTrack_WhenShuffleStartIndexIsZero()
+    {
+        // Arrange
+        List<TrackDto> playlist = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" },
+            new() { Id = 2, ArtistName = "Artist B" },
+            new() { Id = 3, ArtistName = "Artist C" },
+            new() { Id = 4, ArtistName = "Artist D" },
+            new() { Id = 5, ArtistName = "Artist E" }
+        };
+        int shuffleStartIndex = 0;
+
+        // Act
+        TracksRandomizer.ArtistBalancedTrackRandomize(playlist, shuffleStartIndex, new Random(42));
+
+        // Assert
+        Assert.Equal(1, playlist[0].Id);
+        List<long> shuffledIds = playlist.Skip(1).Select(track => track.Id).ToList();
+        Assert.NotEqual(new List<long> { 2, 3, 4, 5 }, shuffledIds);
+    }
+
+    [Fact(DisplayName = "when_shuffle_start_index_is_zero_multiset_is_preserved")]
+    public void ArtistBalancedTrackRandomize_ShouldPreserveMultiset_WhenShuffleStartIndexIsZero()
+    {
+        // Arrange
+        List<TrackDto> playlist = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" },
+            new() { Id = 2, ArtistName = "Artist B" },
+            new() { Id = 3, ArtistName = "Artist C" },
+            new() { Id = 4, ArtistName = "Artist D" },
+            new() { Id = 5, ArtistName = "Artist E" }
+        };
+        int shuffleStartIndex = 0;
+        List<long> originalIds = playlist.Select(track => track.Id).ToList();
+
+        // Act
+        TracksRandomizer.ArtistBalancedTrackRandomize(playlist, shuffleStartIndex, new Random(42));
+
+        // Assert
+        List<long> resultingIds = playlist.Select(track => track.Id).ToList();
+        Assert.Equal(originalIds.Count, resultingIds.Count);
+        Assert.Equal(originalIds.OrderBy(id => id), resultingIds.OrderBy(id => id));
+        Assert.Equal(resultingIds.Distinct().Count(), resultingIds.Count);
+    }
+
+    [Fact(DisplayName = "when_playlist_has_one_or_zero_tracks_it_is_a_no_op")]
+    public void ArtistBalancedTrackRandomize_ShouldNoOp_WhenPlaylistHasOneOrZeroTracks()
+    {
+        // Arrange
+        List<TrackDto> emptyPlaylist = new();
+        List<TrackDto> singleTrackPlaylist = new()
+        {
+            new() { Id = 1, ArtistName = "Artist A" }
+        };
+
+        // Act
+        TracksRandomizer.ArtistBalancedTrackRandomize(emptyPlaylist, -1, new Random(42));
+        TracksRandomizer.ArtistBalancedTrackRandomize(singleTrackPlaylist, -1, new Random(42));
+
+        // Assert
+        Assert.Empty(emptyPlaylist);
+        Assert.Single(singleTrackPlaylist);
+        Assert.Equal(1, singleTrackPlaylist[0].Id);
+    }
+
     [Fact]
     public void Randomize_ShouldShuffleTracks()
     {

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Migrations/Migration15Tests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Migrations/Migration15Tests.cs
@@ -1,0 +1,36 @@
+using Dapper;
+
+namespace Rok.Infrastructure.UnitTests.Migrations;
+
+public class Migration15Tests
+{
+    [Fact(DisplayName = "Migration 15 should add shuffleOnPlay column to Playlists")]
+    public void Migration15_ShouldAddShuffleOnPlayColumn_ToPlaylists()
+    {
+        // Arrange
+        using SqliteDatabaseFixture fixture = new();
+
+        // Act — fixture applies all migrations including Migration15
+
+        // Assert — column exists on Playlists
+        string[] columns = fixture.Connection
+            .Query<string>("SELECT name FROM pragma_table_info('Playlists')")
+            .ToArray();
+
+        Assert.Contains("shuffleOnPlay", columns);
+    }
+
+    [Fact(DisplayName = "Migration 15 should default shuffleOnPlay to zero")]
+    public void Migration15_ShouldDefaultShuffleOnPlay_ToZero()
+    {
+        // Arrange
+        using SqliteDatabaseFixture fixture = new();
+
+        // Act
+        string? defaultValue = fixture.Connection.QueryFirstOrDefault<string>(
+            "SELECT dflt_value FROM pragma_table_info('Playlists') WHERE name = 'shuffleOnPlay'");
+
+        // Assert
+        Assert.Equal("0", defaultValue);
+    }
+}

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Repositories/PlaylistHeaderRepositoryTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Repositories/PlaylistHeaderRepositoryTests.cs
@@ -115,4 +115,27 @@ public class PlaylistHeaderRepositoryTests
         // Assert
         Assert.Equal(0, affected);
     }
+
+    [Fact(DisplayName = "Update should persist and reread ShuffleOnPlay through GetSelectQuery")]
+    public async Task Update_ShouldPersistAndRereadShuffleOnPlay_ThroughGetSelectQuery()
+    {
+        // Arrange
+        using SqliteDatabaseFixture fixture = new();
+        PlaylistHeaderRepository repo = CreateRepository(fixture);
+        PlaylistHeaderEntity entity = new() { Name = "Shuffled", Type = 1, CreatDate = DateTime.UtcNow, ShuffleOnPlay = false };
+        long id = await repo.AddAsync(entity);
+        PlaylistHeaderEntity? added = await repo.GetByIdAsync(id);
+        Assert.False(added!.ShuffleOnPlay);
+
+        added.ShuffleOnPlay = true;
+
+        // Act
+        bool updated = await repo.UpdateAsync(added);
+
+        // Assert
+        Assert.True(updated);
+        PlaylistHeaderEntity? fetched = await repo.GetByIdAsync(id);
+        Assert.NotNull(fetched);
+        Assert.True(fetched!.ShuffleOnPlay);
+    }
 }

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/SqliteDatabaseFixture.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/SqliteDatabaseFixture.cs
@@ -24,7 +24,7 @@ public sealed class SqliteDatabaseFixture : IDisposable
         _sqliteConnection.Open();
         Connection = _sqliteConnection;
 
-        var migrations = new IMigration[] { new Migration2(), new Migration3(), new Migration4(), new Migration5(), new Migration6(), new Migration7(), new Migration8(), new Migration9(), new Migration10(), new Migration11(), new Migration12(), new Migration13(), new Migration14() };
+        var migrations = new IMigration[] { new Migration2(), new Migration3(), new Migration4(), new Migration5(), new Migration6(), new Migration7(), new Migration8(), new Migration9(), new Migration10(), new Migration11(), new Migration12(), new Migration13(), new Migration14(), new Migration15() };
         MigrationService migrationService = new(Connection, migrations, NullLogger<MigrationService>.Instance);
         migrationService.Initial();
         migrationService.MigrateToLatest();

--- a/tests/UnitTests/Rok.PresentationTests/ViewModels/Playlist/Services/PlaylistUpdateServiceTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/ViewModels/Playlist/Services/PlaylistUpdateServiceTests.cs
@@ -53,6 +53,23 @@ public class PlaylistUpdateServiceTests
         Assert.Equal(1, sent.Id);
     }
 
+    [Fact(DisplayName = "SavePlaylistAsync should carry ShuffleOnPlay into the update request and persist it on the playlist")]
+    public async Task SavePlaylistAsync_ShouldCarryShuffleOnPlay_IntoRequestAndPlaylist()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Id = 1, Name = "Mix", ShuffleOnPlay = true };
+        _mediator.Setup<UpdatePlaylistRequest, Result>().Returns(Result.Ok());
+        PlaylistUpdateService sut = BuildService();
+
+        // Act
+        await sut.SavePlaylistAsync(playlist, Array.Empty<TrackViewModel>(), forceUpdate: true);
+
+        // Assert
+        UpdatePlaylistRequest sent = Assert.Single(_mediator.Sent<UpdatePlaylistRequest>());
+        Assert.True(sent.ShuffleOnPlay);
+        Assert.True(playlist.ShuffleOnPlay);
+    }
+
     [Fact(DisplayName = "SavePlaylistAsync should return false when the mediator returns an error")]
     public async Task SavePlaylistAsync_ShouldReturnFalse_WhenMediatorFails()
     {


### PR DESCRIPTION
## Intention

Démarrer une playlist joue aujourd'hui les titres dans leur ordre stocké. Cette PR
ajoute une option, mémorisée par playlist, qui mélange les titres avant la lecture.

## Approche

Le flag `ShuffleOnPlay` est persisté sur la table `Playlists` via `Migration15`
(colonne `shuffleOnPlay`, défaut `0`). Il traverse l'entité, le DTO, le mapping,
`UpdatePlaylistRequest` et le `SELECT` du dépôt.

À la lecture, `PlaylistPlaybackOrderBuilder.BuildShuffledPlayOrder` construit l'ordre
de départ sur une **copie** des titres — l'ordre affiché n'est jamais muté. Le mélange
réutilise `TracksRandomizer.ArtistBalancedTrackRandomize`, qui évite deux titres
consécutifs du même artiste. Aucune logique de mélange n'est dupliquée.

Comportement retenu :
- Titre cliqué → il démarre en tête, le reste est mélangé.
- Lecture globale → toute la liste est mélangée.
- Option inactive → l'ordre stocké est conservé, comportement actuel inchangé.

L'option s'applique aux playlists classiques et smart. Le toggle est un
`AppBarToggleButton` du `CommandBar`, traduit dans les 4 langues.

## Points à connaître pour la relecture

- `ArtistBalancedTrackRandomize` ne mélange **jamais** l'index 0 de la liste qu'on lui
  passe (`prefixCount >= 1` quel que soit l'argument). En lecture globale, un élément
  aléatoire est donc permuté en position 0 avant l'appel, sinon le premier titre serait
  toujours le même. Le randomizer partagé n'est pas modifié : 4 autres appelants en
  dépendent.
- Conséquence assumée : la distribution globale n'est pas parfaitement uniforme, car
  l'élément amené en position 0 ne repasse pas dans le Fisher-Yates. Sans impact
  fonctionnel — le multiset est préservé et la variance du premier titre est prouvée par
  test sur 20 graines.
- Un style `AppBarToggleButtonCompactStyle` a été ajouté : le style existant
  `AppBarButtonCompactStyle` cible strictement `AppBarButton`.
- L'import de playlist insère l'en-tête sans la colonne : le défaut `0` s'applique, et un
  test verrouille cette non-régression.

## Validation

- `dotnet build Rok.slnx -p:Platform=x64` : vert, 0 warning (`TreatWarningsAsErrors`).
- `dotnet test Rok.slnx -p:Platform=x64` : **1500 tests passés**, 0 échec, 0 ignoré.
- Gates : lint `accept`, review `accept_with_opportunity` (0 FAIL), test `accept`.

**Smoke test WinUI manuel restant** : le toggle n'a jamais été rendu à l'écran. À vérifier
avant merge — affichage du bouton, persistance de l'état après redémarrage, et lecture
effectivement mélangée.

## Suite

L'alignement du bouton *Shuffle* manuel sur le même algorithme artist-balanced est suivi
séparément dans #356.

Closes #355
