### PR TITLE
feat(playlist): add per-playlist refresh-on-play option

### DIFF
--- a/src/Presentation/Pages/SmartPlaylistPage.xaml
+++ b/src/Presentation/Pages/SmartPlaylistPage.xaml
@@ -40,6 +40,7 @@
                 <CommandBar RelativePanel.AlignBottomWithPanel="True" Style="{StaticResource HeaderCommandBarStyle}">
                     <AppBarButton x:Uid="playlistListen" Style="{StaticResource ListenAppBarButtonStyle}" Command="{x:Bind ViewModel.ListenCommand}" />
                     <AppBarButton x:Uid="playlistRefresh" Style="{StaticResource AppBarButtonCompactStyle}" Icon="Refresh" Command="{x:Bind ViewModel.GenerateCommand}" />
+                    <AppBarToggleButton x:Uid="refreshOnPlayButton" Style="{StaticResource AppBarToggleButtonCompactStyle}" Icon="Refresh" IsChecked="{x:Bind ViewModel.RefreshOnPlay, Mode=TwoWay}" />
                     <AppBarButton x:Uid="playlistDelete" Style="{StaticResource AppBarButtonCompactStyle}" Icon="Delete" Click="DeleteButton_Click" />
                     <AppBarButton x:Uid="playlistExport" Style="{StaticResource AppBarButtonCompactStyle}" Icon="Save" Command="{x:Bind ViewModel.ExportPlaylistCommand}" />
                 </CommandBar>

--- a/src/Presentation/Strings/en-US/Resources.resw
+++ b/src/Presentation/Strings/en-US/Resources.resw
@@ -1021,6 +1021,9 @@
   <data name="shuffleOnPlayButton.Label" xml:space="preserve">
     <value>Shuffle on play</value>
   </data>
+  <data name="refreshOnPlayButton.Label" xml:space="preserve">
+    <value>Refresh on play</value>
+  </data>
   <data name="NoLibraryFoldersTitleMessage" xml:space="preserve">
     <value>No library</value>
   </data>

--- a/src/Presentation/Strings/es-ES/Resources.resw
+++ b/src/Presentation/Strings/es-ES/Resources.resw
@@ -904,6 +904,9 @@
   <data name="shuffleOnPlayButton.Label" xml:space="preserve">
     <value>Reproducción aleatoria</value>
   </data>
+  <data name="refreshOnPlayButton.Label" xml:space="preserve">
+    <value>Actualizar al reproducir</value>
+  </data>
   <data name="NoLibraryFoldersTitleMessage" xml:space="preserve">
     <value>No se encuentra la biblioteca</value>
   </data>

--- a/src/Presentation/Strings/fr-FR/Resources.resw
+++ b/src/Presentation/Strings/fr-FR/Resources.resw
@@ -1020,6 +1020,9 @@
   <data name="shuffleOnPlayButton.Label" xml:space="preserve">
     <value>Lecture aléatoire</value>
   </data>
+  <data name="refreshOnPlayButton.Label" xml:space="preserve">
+    <value>Actualiser au lancement</value>
+  </data>
   <data name="NoLibraryFoldersTitleMessage" xml:space="preserve">
     <value>Aucune librarie</value>
   </data>

--- a/src/Presentation/Strings/uk-UA/Resources.resw
+++ b/src/Presentation/Strings/uk-UA/Resources.resw
@@ -962,6 +962,9 @@
   <data name="shuffleOnPlayButton.Label" xml:space="preserve">
     <value>Випадкове відтворення</value>
   </data>
+  <data name="refreshOnPlayButton.Label" xml:space="preserve">
+    <value>Оновити перед відтворенням</value>
+  </data>
   <data name="NoLibraryFoldersTitleMessage" xml:space="preserve">
     <value>Немає бібліотеки</value>
   </data>

--- a/src/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
+++ b/src/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Rok.Application.Dto;
+using Rok.Application.Features.Playlists;
 using Rok.Application.Player;
 using Rok.Application.Randomizer;
 using Rok.ViewModels.Playlist.Services;
@@ -60,6 +61,16 @@ public partial class PlaylistViewModel : ObservableObject
         set
         {
             Playlist.ShuffleOnPlay = value;
+            _ = SavePlaylistAsync();
+        }
+    }
+
+    public bool RefreshOnPlay
+    {
+        get => Playlist.RefreshOnPlay;
+        set
+        {
+            Playlist.RefreshOnPlay = value;
             _ = SavePlaylistAsync();
         }
     }
@@ -255,6 +266,10 @@ public partial class PlaylistViewModel : ObservableObject
                 await GenerateAsync();
             else
                 await LoadTracksAsync(Playlist.Id);
+        }
+        else if (PlaylistPlaybackPolicy.ShouldRegenerateBeforePlay(Playlist, trackClicked: track != null))
+        {
+            await GenerateAsync();
         }
 
         if (_tracks?.Any() != true)

--- a/src/Presentation/ViewModels/Playlist/Services/PlaylistUpdateService.cs
+++ b/src/Presentation/ViewModels/Playlist/Services/PlaylistUpdateService.cs
@@ -1,3 +1,4 @@
+using Rok.Application.Features.Playlists;
 using Rok.Application.Features.Playlists.Requests;
 using Rok.ViewModels.Track;
 
@@ -29,18 +30,11 @@ public class PlaylistUpdateService(
             DurationMaximum = playlist.DurationMaximum,
             Picture = track?.ArtistName!,
             Groups = groups ?? playlist.Groups,
-            ShuffleOnPlay = playlist.ShuffleOnPlay
+            ShuffleOnPlay = playlist.ShuffleOnPlay,
+            RefreshOnPlay = playlist.RefreshOnPlay
         };
 
-        bool hasChanges = forceUpdate ||
-            command.Name != playlist.Name ||
-            command.Duration != playlist.Duration ||
-            command.TrackCount != playlist.TrackCount ||
-            command.TrackMaximum != playlist.TrackMaximum ||
-            command.DurationMaximum != playlist.DurationMaximum ||
-            command.Picture != playlist.Picture ||
-            command.Groups != playlist.Groups ||
-            command.ShuffleOnPlay != playlist.ShuffleOnPlay;
+        bool hasChanges = forceUpdate || await HasChangesAsync(command, playlist.Id);
 
         if (!hasChanges)
             return false;
@@ -64,10 +58,21 @@ public class PlaylistUpdateService(
         playlist.DurationMaximum = command.DurationMaximum;
         playlist.Groups = command.Groups;
         playlist.ShuffleOnPlay = command.ShuffleOnPlay;
+        playlist.RefreshOnPlay = command.RefreshOnPlay;
 
         messenger.Send(new PlaylistUpdatedMessage(playlist.Id, ActionType.Update));
 
         return true;
+    }
+
+    private async Task<bool> HasChangesAsync(UpdatePlaylistRequest command, long playlistId)
+    {
+        Result<PlaylistHeaderDto> persistedResult = await mediator.Send(new GetPlaylistByIdRequest(playlistId));
+
+        if (persistedResult.IsFailure)
+            return true;
+
+        return PlaylistHeaderChangeDetector.HasChanges(command, persistedResult.Value);
     }
 
     public async Task<bool> RemoveTrackAsync(long playlistId, long trackId)

--- a/src/Rok.Application/Dto/PlaylistHeaderDto.cs
+++ b/src/Rok.Application/Dto/PlaylistHeaderDto.cs
@@ -26,6 +26,8 @@ public class PlaylistHeaderDto
 
     public bool ShuffleOnPlay { get; set; }
 
+    public bool RefreshOnPlay { get; set; }
+
     public bool IsSmart => Type == 0;
 
     public List<PlaylistGroupDto> Groups { get; set; } = [];

--- a/src/Rok.Application/Features/Playlists/PlaylistHeaderChangeDetector.cs
+++ b/src/Rok.Application/Features/Playlists/PlaylistHeaderChangeDetector.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Rok.Application.Features.Playlists.Requests;
+
+namespace Rok.Application.Features.Playlists;
+
+/// <summary>
+/// Decides whether a playlist update command actually differs from the persisted
+/// state, field by field, so that PlaylistUpdateService only writes on real changes.
+/// </summary>
+public static class PlaylistHeaderChangeDetector
+{
+    public static bool HasChanges(UpdatePlaylistRequest command, PlaylistHeaderDto persisted)
+    {
+        if (command.Name != persisted.Name)
+            return true;
+
+        if (command.Duration != persisted.Duration)
+            return true;
+
+        if (command.TrackCount != persisted.TrackCount)
+            return true;
+
+        if (command.TrackMaximum != persisted.TrackMaximum)
+            return true;
+
+        if (command.DurationMaximum != persisted.DurationMaximum)
+            return true;
+
+        if ((command.Picture ?? string.Empty) != (persisted.Picture ?? string.Empty))
+            return true;
+
+        if (command.ShuffleOnPlay != persisted.ShuffleOnPlay)
+            return true;
+
+        if (command.RefreshOnPlay != persisted.RefreshOnPlay)
+            return true;
+
+        string commandGroupsJson = command.Groups is { Count: > 0 } ? JsonSerializer.Serialize(command.Groups) : string.Empty;
+        if (commandGroupsJson != (persisted.GroupsJson ?? string.Empty))
+            return true;
+
+        return false;
+    }
+}

--- a/src/Rok.Application/Features/Playlists/PlaylistPlaybackPolicy.cs
+++ b/src/Rok.Application/Features/Playlists/PlaylistPlaybackPolicy.cs
@@ -1,0 +1,21 @@
+using Rok.Shared.Enums;
+
+namespace Rok.Application.Features.Playlists;
+
+/// <summary>
+/// Decides whether a smart playlist should regenerate its selection before playback
+/// starts, based on the RefreshOnPlay flag and whether a specific track was clicked.
+/// </summary>
+public static class PlaylistPlaybackPolicy
+{
+    public static bool ShouldRegenerateBeforePlay(PlaylistHeaderDto playlist, bool trackClicked)
+    {
+        if (playlist.Type != (int)PlaylistType.Smart)
+            return false;
+
+        if (!playlist.RefreshOnPlay)
+            return false;
+
+        return !trackClicked;
+    }
+}

--- a/src/Rok.Application/Features/Playlists/Requests/UpdatePlaylistRequestHandler.cs
+++ b/src/Rok.Application/Features/Playlists/Requests/UpdatePlaylistRequestHandler.cs
@@ -27,6 +27,8 @@ public class UpdatePlaylistRequest : IRequest<Result>
     public int Type { get; set; } = 0;
 
     public bool ShuffleOnPlay { get; set; }
+
+    public bool RefreshOnPlay { get; set; }
 }
 
 public sealed class UpdatePlaylistRequestValidator : Validator<UpdatePlaylistRequest>

--- a/src/Rok.Application/Mapping/PlaylistHeadeDtoMapping.cs
+++ b/src/Rok.Application/Mapping/PlaylistHeadeDtoMapping.cs
@@ -25,6 +25,7 @@ public static class PlaylistHeadeDtoMapping
             GroupsJson = entity.GroupsJson,
             Type = entity.Type,
             ShuffleOnPlay = entity.ShuffleOnPlay,
+            RefreshOnPlay = entity.RefreshOnPlay,
             Groups = groups
         };
     }
@@ -55,7 +56,8 @@ public static class PlaylistHeadeDtoMapping
             DurationMaximum = command.DurationMaximum,
             GroupsJson = command.Groups is { Count: > 0 } ? JsonSerializer.Serialize(command.Groups) : string.Empty,
             Type = command.Type,
-            ShuffleOnPlay = command.ShuffleOnPlay
+            ShuffleOnPlay = command.ShuffleOnPlay,
+            RefreshOnPlay = command.RefreshOnPlay
         };
     }
 
@@ -85,6 +87,7 @@ public static class PlaylistHeadeDtoMapping
             DurationMaximum = dto.DurationMaximum,
             Type = dto.Type,
             ShuffleOnPlay = dto.ShuffleOnPlay,
+            RefreshOnPlay = dto.RefreshOnPlay,
             Groups = dto.Groups ?? new List<PlaylistGroupDto>()
         };
     }

--- a/src/Rok.Domain/Entities/PlaylistHeaderEntity.cs
+++ b/src/Rok.Domain/Entities/PlaylistHeaderEntity.cs
@@ -20,4 +20,6 @@ public class PlaylistHeaderEntity : BaseEntity
     public int Type { get; set; }
 
     public bool ShuffleOnPlay { get; set; }
+
+    public bool RefreshOnPlay { get; set; }
 }

--- a/src/Rok.Infrastructure/DependencyInjection.cs
+++ b/src/Rok.Infrastructure/DependencyInjection.cs
@@ -80,6 +80,7 @@ public static class DependencyInjection
         services.AddSingleton<IMigration, Migration13>();
         services.AddSingleton<IMigration, Migration14>();
         services.AddSingleton<IMigration, Migration15>();
+        services.AddSingleton<IMigration, Migration16>();
 
         services.AddScoped<IArtistRepository, ArtistRepository>();
         services.AddScoped<IAlbumRepository, AlbumRepository>();

--- a/src/Rok.Infrastructure/Migration/Migration16.cs
+++ b/src/Rok.Infrastructure/Migration/Migration16.cs
@@ -1,0 +1,15 @@
+namespace Rok.Infrastructure.Migration;
+
+/// <summary>
+/// Adds the RefreshOnPlay flag to Playlists, letting a smart playlist regenerate
+/// its selection right before playback starts.
+/// </summary>
+public class Migration16 : IMigration
+{
+    public int TargetVersion => 16;
+
+    public void Apply(IDbConnection connection)
+    {
+        connection.Execute("ALTER TABLE Playlists ADD COLUMN refreshOnPlay INTEGER NOT NULL DEFAULT 0;");
+    }
+}

--- a/src/Rok.Infrastructure/Repositories/PlaylistHeaderRepository.cs
+++ b/src/Rok.Infrastructure/Repositories/PlaylistHeaderRepository.cs
@@ -46,7 +46,7 @@ public class PlaylistHeaderRepository(IDbConnection connection, [FromKeyedServic
     public override string GetSelectQuery(string? whereParam = null)
     {
         string query = """
-                    SELECT id, name, picture, duration, trackCount, trackMaximum, durationMaximum, groupsJson, type, shuffleOnPlay, creatDate, editDate
+                    SELECT id, name, picture, duration, trackCount, trackMaximum, durationMaximum, groupsJson, type, shuffleOnPlay, refreshOnPlay, creatDate, editDate
                     FROM playlists
                 """;
 

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/PlaylistHeaderChangeDetectorTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/PlaylistHeaderChangeDetectorTests.cs
@@ -1,0 +1,185 @@
+using Rok.Application.Features.Playlists;
+using Rok.Application.Features.Playlists.Requests;
+
+namespace Rok.ApplicationTests.Features.Playlists;
+
+public class PlaylistHeaderChangeDetectorTests
+{
+    private static UpdatePlaylistRequest BaseCommand() => new()
+    {
+        Id = 1,
+        Name = "Mix",
+        Duration = 100,
+        TrackCount = 5,
+        TrackMaximum = 20,
+        DurationMaximum = 3600,
+        Picture = "artist.png",
+        ShuffleOnPlay = true,
+        RefreshOnPlay = false,
+        Groups = new List<PlaylistGroupDto> { new() { Name = "g1" } }
+    };
+
+    private static PlaylistHeaderDto MatchingPersisted() => new()
+    {
+        Id = 1,
+        Name = "Mix",
+        Duration = 100,
+        TrackCount = 5,
+        TrackMaximum = 20,
+        DurationMaximum = 3600,
+        Picture = "artist.png",
+        ShuffleOnPlay = true,
+        RefreshOnPlay = false,
+        GroupsJson = System.Text.Json.JsonSerializer.Serialize(new List<PlaylistGroupDto> { new() { Name = "g1" } })
+    };
+
+    [Fact(DisplayName = "HasChanges should return false when persisted state matches the command in every field")]
+    public void HasChanges_ShouldReturnFalse_WhenStateIsIdenticalInEveryField()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        PlaylistHeaderDto persisted = MatchingPersisted();
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return true when only RefreshOnPlay differs")]
+    public void HasChanges_ShouldReturnTrue_WhenOnlyRefreshOnPlayDiffers()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        command.RefreshOnPlay = true;
+        PlaylistHeaderDto persisted = MatchingPersisted();
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return true when only ShuffleOnPlay differs")]
+    public void HasChanges_ShouldReturnTrue_WhenOnlyShuffleOnPlayDiffers()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        PlaylistHeaderDto persisted = MatchingPersisted();
+        persisted.ShuffleOnPlay = false;
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return true when only Name differs")]
+    public void HasChanges_ShouldReturnTrue_WhenOnlyNameDiffers()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        command.Name = "Other name";
+        PlaylistHeaderDto persisted = MatchingPersisted();
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return true when Duration differs")]
+    public void HasChanges_ShouldReturnTrue_WhenDurationDiffers()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        command.Duration = 999;
+        PlaylistHeaderDto persisted = MatchingPersisted();
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return true when TrackCount differs")]
+    public void HasChanges_ShouldReturnTrue_WhenTrackCountDiffers()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        command.TrackCount = 99;
+        PlaylistHeaderDto persisted = MatchingPersisted();
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return true when Picture differs")]
+    public void HasChanges_ShouldReturnTrue_WhenPictureDiffers()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        command.Picture = "other.png";
+        PlaylistHeaderDto persisted = MatchingPersisted();
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return false when command Picture is null and persisted Picture is an empty string")]
+    public void HasChanges_ShouldReturnFalse_WhenPictureIsNullAgainstPersistedEmptyString()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        command.Picture = null!;
+        PlaylistHeaderDto persisted = MatchingPersisted();
+        persisted.Picture = string.Empty;
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return false when Groups have identical content but different instances")]
+    public void HasChanges_ShouldReturnFalse_WhenGroupsAreEqualByValue_ButDifferentInstances()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        command.Groups = new List<PlaylistGroupDto> { new() { Name = "g1" } };
+        PlaylistHeaderDto persisted = MatchingPersisted();
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact(DisplayName = "HasChanges should return true when Groups content differs")]
+    public void HasChanges_ShouldReturnTrue_WhenGroupsContentDiffers()
+    {
+        // Arrange
+        UpdatePlaylistRequest command = BaseCommand();
+        command.Groups = new List<PlaylistGroupDto> { new() { Name = "different" } };
+        PlaylistHeaderDto persisted = MatchingPersisted();
+
+        // Act
+        bool result = PlaylistHeaderChangeDetector.HasChanges(command, persisted);
+
+        // Assert
+        Assert.True(result);
+    }
+}

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/PlaylistPlaybackPolicyTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/PlaylistPlaybackPolicyTests.cs
@@ -1,0 +1,59 @@
+using Rok.Application.Features.Playlists;
+using Rok.Shared.Enums;
+
+namespace Rok.ApplicationTests.Features.Playlists;
+
+public class PlaylistPlaybackPolicyTests
+{
+    [Fact(DisplayName = "ShouldRegenerateBeforePlay should return true for a smart playlist with the flag active and no track clicked")]
+    public void ShouldRegenerateBeforePlay_ShouldReturnTrue_WhenSmartFlagActiveAndNoTrackClicked()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Type = (int)PlaylistType.Smart, RefreshOnPlay = true };
+
+        // Act
+        bool result = PlaylistPlaybackPolicy.ShouldRegenerateBeforePlay(playlist, trackClicked: false);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "ShouldRegenerateBeforePlay should return false for a smart playlist with the flag active when a track was clicked")]
+    public void ShouldRegenerateBeforePlay_ShouldReturnFalse_WhenSmartFlagActiveButTrackClicked()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Type = (int)PlaylistType.Smart, RefreshOnPlay = true };
+
+        // Act
+        bool result = PlaylistPlaybackPolicy.ShouldRegenerateBeforePlay(playlist, trackClicked: true);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact(DisplayName = "ShouldRegenerateBeforePlay should return false for a smart playlist with the flag inactive")]
+    public void ShouldRegenerateBeforePlay_ShouldReturnFalse_WhenSmartFlagInactive()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Type = (int)PlaylistType.Smart, RefreshOnPlay = false };
+
+        // Act
+        bool result = PlaylistPlaybackPolicy.ShouldRegenerateBeforePlay(playlist, trackClicked: false);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact(DisplayName = "ShouldRegenerateBeforePlay should return false for a classic playlist even with the flag active")]
+    public void ShouldRegenerateBeforePlay_ShouldReturnFalse_WhenClassicPlaylist()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Type = (int)PlaylistType.Classic, RefreshOnPlay = true };
+
+        // Act
+        bool result = PlaylistPlaybackPolicy.ShouldRegenerateBeforePlay(playlist, trackClicked: false);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/ImportPlaylistCommandHandlerTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/ImportPlaylistCommandHandlerTests.cs
@@ -23,7 +23,7 @@ public sealed class ImportPlaylistRequestHandlerTests : IDisposable
     {
         _connection = new SqliteConnection($"Data Source=ImportHandler_{Guid.NewGuid():N};Mode=Memory;Cache=Shared");
         _connection.Open();
-        _connection.Execute("CREATE TABLE playlists (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, picture TEXT, duration INTEGER, trackCount INTEGER, trackMaximum INTEGER, durationMaximum INTEGER, groupsJson TEXT, type INTEGER, creatDate TEXT, editDate TEXT, shuffleOnPlay INTEGER NOT NULL DEFAULT 0)");
+        _connection.Execute("CREATE TABLE playlists (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, picture TEXT, duration INTEGER, trackCount INTEGER, trackMaximum INTEGER, durationMaximum INTEGER, groupsJson TEXT, type INTEGER, creatDate TEXT, editDate TEXT, shuffleOnPlay INTEGER NOT NULL DEFAULT 0, refreshOnPlay INTEGER NOT NULL DEFAULT 0)");
         _connection.Execute("CREATE TABLE playlisttracks (id INTEGER PRIMARY KEY AUTOINCREMENT, playlistId INTEGER, trackId INTEGER, position INTEGER, listened INTEGER, creatDate TEXT)");
     }
 
@@ -376,6 +376,33 @@ public sealed class ImportPlaylistRequestHandlerTests : IDisposable
             result.Should().BeSuccess();
             int shuffleOnPlay = _connection.ExecuteScalar<int>("SELECT shuffleOnPlay FROM playlists WHERE id = @id", new { id = result.Value.PlaylistId });
             Assert.Equal(0, shuffleOnPlay);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact(DisplayName = "imported_playlist_defaults_refresh_on_play_to_false")]
+    public async Task Imported_playlist_defaults_refresh_on_play_to_false()
+    {
+        // Arrange
+        string path = WritePlaylistFile("dummy");
+        try
+        {
+            _reader.Setup(r => r.ReadAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(Model("Mix", ("D:\\a.mp3", null, null, null)));
+            _trackRepository.Setup(r => r.GetByFilePathAsync("D:\\a.mp3", It.IsAny<CancellationToken>())).ReturnsAsync(new TrackEntity { Id = 1 });
+
+            ImportPlaylistRequestHandler sut = BuildHandler();
+
+            // Act
+            Result<PlaylistImportResult> result = await sut.Handle(new ImportPlaylistRequest(path), CancellationToken.None);
+
+            // Assert
+            result.Should().BeSuccess();
+            int refreshOnPlay = _connection.ExecuteScalar<int>("SELECT refreshOnPlay FROM playlists WHERE id = @id", new { id = result.Value.PlaylistId });
+            Assert.Equal(0, refreshOnPlay);
         }
         finally
         {

--- a/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/PlaylistCommandHandlerTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Features/Playlists/Requests/PlaylistCommandHandlerTests.cs
@@ -86,6 +86,22 @@ public class UpdatePlaylistRequestHandlerTests
         result.Should().BeSuccess();
         repository.Verify(r => r.UpdateAsync(It.Is<PlaylistHeaderEntity>(e => e.ShuffleOnPlay), It.IsAny<RepositoryConnectionKind>()), Times.Once);
     }
+
+    [Fact(DisplayName = "Handle should pass refresh on play flag to repository")]
+    public async Task Handle_ShouldPassRefreshOnPlayToRepository()
+    {
+        // Arrange
+        Mock<IPlaylistHeaderRepository> repository = new();
+        repository.Setup(r => r.UpdateAsync(It.IsAny<PlaylistHeaderEntity>(), It.IsAny<RepositoryConnectionKind>())).ReturnsAsync(true);
+        UpdatePlaylistRequestHandler handler = new(repository.Object, Mock.Of<ILogger<UpdatePlaylistRequestHandler>>());
+
+        // Act
+        Result result = await handler.Handle(new UpdatePlaylistRequest { Id = 1, Name = "N", RefreshOnPlay = true }, CancellationToken.None);
+
+        // Assert
+        result.Should().BeSuccess();
+        repository.Verify(r => r.UpdateAsync(It.Is<PlaylistHeaderEntity>(e => e.RefreshOnPlay), It.IsAny<RepositoryConnectionKind>()), Times.Once);
+    }
 }
 
 public class DeletePlaylistRequestHandlerTests

--- a/tests/UnitTests/Rok.ApplicationTests/Mapping/PlaylistHeaderDtoMappingTests.cs
+++ b/tests/UnitTests/Rok.ApplicationTests/Mapping/PlaylistHeaderDtoMappingTests.cs
@@ -196,4 +196,67 @@ public class PlaylistHeaderDtoMappingTests
         // Assert
         Assert.Equal(shuffleOnPlay, command.ShuffleOnPlay);
     }
+
+    [Theory(DisplayName = "Map entity to dto should propagate RefreshOnPlay")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapEntityToDto_ShouldPropagateRefreshOnPlay(bool refreshOnPlay)
+    {
+        // Arrange
+        PlaylistHeaderEntity entity = new()
+        {
+            Id = 1,
+            Name = "Plain",
+            Type = (int)PlaylistType.Classic,
+            RefreshOnPlay = refreshOnPlay
+        };
+
+        // Act
+        PlaylistHeaderDto dto = PlaylistHeadeDtoMapping.Map(entity);
+
+        // Assert
+        Assert.Equal(refreshOnPlay, dto.RefreshOnPlay);
+    }
+
+    [Theory(DisplayName = "Map update command to entity should propagate RefreshOnPlay")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapUpdateCommandToEntity_ShouldPropagateRefreshOnPlay(bool refreshOnPlay)
+    {
+        // Arrange
+        UpdatePlaylistRequest command = new()
+        {
+            Id = 1,
+            Name = "Plain",
+            Type = (int)PlaylistType.Classic,
+            RefreshOnPlay = refreshOnPlay
+        };
+
+        // Act
+        PlaylistHeaderEntity entity = PlaylistHeadeDtoMapping.Map(command);
+
+        // Assert
+        Assert.Equal(refreshOnPlay, entity.RefreshOnPlay);
+    }
+
+    [Theory(DisplayName = "MapToUpdatePlaylistRequest should propagate RefreshOnPlay")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapToUpdatePlaylistRequest_ShouldPropagateRefreshOnPlay(bool refreshOnPlay)
+    {
+        // Arrange
+        PlaylistHeaderDto dto = new()
+        {
+            Id = 1,
+            Name = "Plain",
+            Type = (int)PlaylistType.Classic,
+            RefreshOnPlay = refreshOnPlay
+        };
+
+        // Act
+        UpdatePlaylistRequest command = PlaylistHeadeDtoMapping.MapToUpdatePlaylistRequest(dto);
+
+        // Assert
+        Assert.Equal(refreshOnPlay, command.RefreshOnPlay);
+    }
 }

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Migrations/Migration16Tests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Migrations/Migration16Tests.cs
@@ -1,0 +1,36 @@
+using Dapper;
+
+namespace Rok.Infrastructure.UnitTests.Migrations;
+
+public class Migration16Tests
+{
+    [Fact(DisplayName = "Migration 16 should add refreshOnPlay column to Playlists")]
+    public void Migration16_ShouldAddRefreshOnPlayColumn_ToPlaylists()
+    {
+        // Arrange
+        using SqliteDatabaseFixture fixture = new();
+
+        // Act — fixture applies all migrations including Migration16
+
+        // Assert — column exists on Playlists
+        string[] columns = fixture.Connection
+            .Query<string>("SELECT name FROM pragma_table_info('Playlists')")
+            .ToArray();
+
+        Assert.Contains("refreshOnPlay", columns);
+    }
+
+    [Fact(DisplayName = "Migration 16 should default refreshOnPlay to zero")]
+    public void Migration16_ShouldDefaultRefreshOnPlay_ToZero()
+    {
+        // Arrange
+        using SqliteDatabaseFixture fixture = new();
+
+        // Act
+        string? defaultValue = fixture.Connection.QueryFirstOrDefault<string>(
+            "SELECT dflt_value FROM pragma_table_info('Playlists') WHERE name = 'refreshOnPlay'");
+
+        // Assert
+        Assert.Equal("0", defaultValue);
+    }
+}

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/Repositories/PlaylistHeaderRepositoryTests.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/Repositories/PlaylistHeaderRepositoryTests.cs
@@ -138,4 +138,27 @@ public class PlaylistHeaderRepositoryTests
         Assert.NotNull(fetched);
         Assert.True(fetched!.ShuffleOnPlay);
     }
+
+    [Fact(DisplayName = "Update should persist and reread RefreshOnPlay through GetSelectQuery")]
+    public async Task Update_ShouldPersistAndRereadRefreshOnPlay_ThroughGetSelectQuery()
+    {
+        // Arrange
+        using SqliteDatabaseFixture fixture = new();
+        PlaylistHeaderRepository repo = CreateRepository(fixture);
+        PlaylistHeaderEntity entity = new() { Name = "Refreshed", Type = 0, CreatDate = DateTime.UtcNow, RefreshOnPlay = false };
+        long id = await repo.AddAsync(entity);
+        PlaylistHeaderEntity? added = await repo.GetByIdAsync(id);
+        Assert.False(added!.RefreshOnPlay);
+
+        added.RefreshOnPlay = true;
+
+        // Act
+        bool updated = await repo.UpdateAsync(added);
+
+        // Assert
+        Assert.True(updated);
+        PlaylistHeaderEntity? fetched = await repo.GetByIdAsync(id);
+        Assert.NotNull(fetched);
+        Assert.True(fetched!.RefreshOnPlay);
+    }
 }

--- a/tests/UnitTests/Rok.Infrastructure.UnitTests/SqliteDatabaseFixture.cs
+++ b/tests/UnitTests/Rok.Infrastructure.UnitTests/SqliteDatabaseFixture.cs
@@ -24,7 +24,7 @@ public sealed class SqliteDatabaseFixture : IDisposable
         _sqliteConnection.Open();
         Connection = _sqliteConnection;
 
-        var migrations = new IMigration[] { new Migration2(), new Migration3(), new Migration4(), new Migration5(), new Migration6(), new Migration7(), new Migration8(), new Migration9(), new Migration10(), new Migration11(), new Migration12(), new Migration13(), new Migration14(), new Migration15() };
+        var migrations = new IMigration[] { new Migration2(), new Migration3(), new Migration4(), new Migration5(), new Migration6(), new Migration7(), new Migration8(), new Migration9(), new Migration10(), new Migration11(), new Migration12(), new Migration13(), new Migration14(), new Migration15(), new Migration16() };
         MigrationService migrationService = new(Connection, migrations, NullLogger<MigrationService>.Instance);
         migrationService.Initial();
         migrationService.MigrateToLatest();

--- a/tests/UnitTests/Rok.PresentationTests/ViewModels/Playlist/Services/PlaylistUpdateServiceTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/ViewModels/Playlist/Services/PlaylistUpdateServiceTests.cs
@@ -24,8 +24,10 @@ public class PlaylistUpdateServiceTests
     [Fact(DisplayName = "SavePlaylistAsync should not call mediator when nothing has changed and forceUpdate is false")]
     public async Task SavePlaylistAsync_ShouldSkip_WhenNoChange()
     {
-        // Arrange — no track means command.Picture is null, so playlist.Picture must be null too for "no change"
+        // Arrange — persisted state mirrors the current playlist in every compared field
         PlaylistHeaderDto playlist = new() { Id = 1, Name = "Mix", Picture = null!, Duration = 0, TrackCount = 0, TrackMaximum = 0, DurationMaximum = 0 };
+        PlaylistHeaderDto persisted = new() { Id = 1, Name = "Mix", Picture = string.Empty, Duration = 0, TrackCount = 0, TrackMaximum = 0, DurationMaximum = 0 };
+        _mediator.Setup<GetPlaylistByIdRequest, Result<PlaylistHeaderDto>>().Returns(Result<PlaylistHeaderDto>.Ok(persisted));
         PlaylistUpdateService sut = BuildService();
 
         // Act
@@ -68,6 +70,75 @@ public class PlaylistUpdateServiceTests
         UpdatePlaylistRequest sent = Assert.Single(_mediator.Sent<UpdatePlaylistRequest>());
         Assert.True(sent.ShuffleOnPlay);
         Assert.True(playlist.ShuffleOnPlay);
+    }
+
+    [Fact(DisplayName = "SavePlaylistAsync should carry RefreshOnPlay into the update request and persist it on the playlist")]
+    public async Task SavePlaylistAsync_ShouldCarryRefreshOnPlay_IntoRequestAndPlaylist()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Id = 1, Name = "Mix", RefreshOnPlay = true };
+        _mediator.Setup<UpdatePlaylistRequest, Result>().Returns(Result.Ok());
+        PlaylistUpdateService sut = BuildService();
+
+        // Act
+        await sut.SavePlaylistAsync(playlist, Array.Empty<TrackViewModel>(), forceUpdate: true);
+
+        // Assert
+        UpdatePlaylistRequest sent = Assert.Single(_mediator.Sent<UpdatePlaylistRequest>());
+        Assert.True(sent.RefreshOnPlay);
+        Assert.True(playlist.RefreshOnPlay);
+    }
+
+    [Fact(DisplayName = "SavePlaylistAsync should reread persisted state and write when only a toggle changed")]
+    public async Task SavePlaylistAsync_ShouldRereadAndWrite_WhenOnlyToggleChanged()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Id = 1, Name = "Mix", Picture = string.Empty, RefreshOnPlay = true };
+        PlaylistHeaderDto persisted = new() { Id = 1, Name = "Mix", Picture = string.Empty, RefreshOnPlay = false };
+        _mediator.Setup<GetPlaylistByIdRequest, Result<PlaylistHeaderDto>>().Returns(Result<PlaylistHeaderDto>.Ok(persisted));
+        _mediator.Setup<UpdatePlaylistRequest, Result>().Returns(Result.Ok());
+        PlaylistUpdateService sut = BuildService();
+
+        // Act
+        bool result = await sut.SavePlaylistAsync(playlist, Array.Empty<TrackViewModel>(), forceUpdate: false);
+
+        // Assert
+        Assert.True(result);
+        UpdatePlaylistRequest sent = Assert.Single(_mediator.Sent<UpdatePlaylistRequest>());
+        Assert.True(sent.RefreshOnPlay);
+    }
+
+    [Fact(DisplayName = "SavePlaylistAsync should write when the reread of the persisted state fails")]
+    public async Task SavePlaylistAsync_ShouldWrite_WhenRereadFails()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Id = 1, Name = "Mix" };
+        _mediator.Setup<GetPlaylistByIdRequest, Result<PlaylistHeaderDto>>().Returns(Result<PlaylistHeaderDto>.Fail(new OperationError("playlist.not_found", "not found")));
+        _mediator.Setup<UpdatePlaylistRequest, Result>().Returns(Result.Ok());
+        PlaylistUpdateService sut = BuildService();
+
+        // Act
+        bool result = await sut.SavePlaylistAsync(playlist, Array.Empty<TrackViewModel>(), forceUpdate: false);
+
+        // Assert
+        Assert.True(result);
+        Assert.Single(_mediator.Sent<UpdatePlaylistRequest>());
+    }
+
+    [Fact(DisplayName = "SavePlaylistAsync should not reread persisted state when forceUpdate is true")]
+    public async Task SavePlaylistAsync_ShouldNotReread_WhenForced()
+    {
+        // Arrange
+        PlaylistHeaderDto playlist = new() { Id = 1, Name = "Mix" };
+        _mediator.Setup<UpdatePlaylistRequest, Result>().Returns(Result.Ok());
+        PlaylistUpdateService sut = BuildService();
+
+        // Act
+        bool result = await sut.SavePlaylistAsync(playlist, Array.Empty<TrackViewModel>(), forceUpdate: true);
+
+        // Assert
+        Assert.True(result);
+        Assert.Empty(_mediator.Sent<GetPlaylistByIdRequest>());
     }
 
     [Fact(DisplayName = "SavePlaylistAsync should return false when the mediator returns an error")]


### PR DESCRIPTION
## Intention

Sur une smart playlist, la lecture repart désormais d'une sélection fraîche. Un nouveau flag `RefreshOnPlay`, persisté par playlist, régénère le contenu avant de lancer le son.

C'est le pendant du toggle « Lecture random » livré en #355 : celui-ci change l'**ordre** des titres, celui-là change leur **contenu**. Les deux options sont indépendantes et cumulables — la régénération vient d'abord, le mélange ensuite.

## Deux corrections de périmètre par rapport à l'issue

**Le toggle va sur `SmartPlaylistPage`, pas sur `PlaylistPage`.** L'issue pointait la page des playlists classiques. Les smart playlists ouvrent `SmartPlaylistPage` (`src/Presentation/Services/NavigationService.cs:92`). Poser le toggle sur cette seule page satisfait le critère « invisible sur playlist classique » sans une ligne de logique de visibilité conditionnelle.

**La détection de changement était tautologique.** `PlaylistUpdateService.SavePlaylistAsync` construisait la commande depuis le DTO, puis comparait la commande à ce même DTO. Les clauses sur `Name`, `TrackMaximum`, `DurationMaximum`, `Groups` et `ShuffleOnPlay` étaient donc **toujours fausses** : la bascule d'un flag seul n'était jamais écrite. Sans réparation, le critère d'acceptation 1 tombait.

La réparation relit l'état persisté via `GetPlaylistByIdRequest` et délègue la comparaison à un comparateur pur `PlaylistHeaderChangeDetector`. Aucun état introduit, aucune signature changée. Elle corrige au passage `ShuffleOnPlay`, dont la persistance souffrait du même défaut depuis #355.

## Approche

Cinq slices, dans l'ordre des couches :

1. **Schéma et lecture SQL** — `Migration16` ajoute `refreshOnPlay INTEGER NOT NULL DEFAULT 0`, la colonne rejoint la liste en dur de `PlaylistHeaderRepository.GetSelectQuery` et le tableau de `SqliteDatabaseFixture`.
2. **Transport applicatif** — DTO, entité, `UpdatePlaylistRequest` et les 3 sens de mapping.
3. **Détection de changement réparée** — `PlaylistHeaderChangeDetector` compare les 9 champs, `Groups` **par valeur** et `Picture` avec normalisation de `null` en chaîne vide. En échec de relecture, repli conservateur : on écrit, une modification utilisateur n'est jamais perdue. `forceUpdate` court-circuite la relecture, sémantique inchangée pour l'appelant existant.
4. **Décision de lecture** — `PlaylistPlaybackPolicy`, prédicat pur, décide de régénérer.
5. **Interface** — `AppBarToggleButton` sur `SmartPlaylistPage.xaml` et la clé `refreshOnPlayButton.Label` dans les 4 fichiers de langue.

## Choix tranché : pas de régénération sur clic d'un titre

`ListenAsync(TrackViewModel? track)` sert deux gestes. La régénération est limitée à la lecture globale (`track == null`).

La raison est concrète : `PlayerService.Start` fait un `FindIndex` sur le titre de départ et **sort sans rien jouer** si l'index vaut `-1` (`src/Rok.Application/Player/PlayerService.cs:447-453`). Régénérer sur un clic ferait donc disparaître le titre demandé, après un `Stop` déjà émis — une lecture silencieuse, sans erreur ni message.

## Effets de bord assumés

Réparer la détection rend `TrackMaximum` et `DurationMaximum` persistants dès la prochaine sauvegarde, sans attendre le bouton « Enregistrer ». Elle supprime aussi une écriture parasite qui se déclenchait à chaque chargement de page, quand `Picture` valait `null` face à une valeur persistée vide.

## Vérifications

| Gate | Verdict |
|---|---|
| `architect` | `accept` — 0 FAIL |
| `lint` | `accept` — `dotnet format --verify-no-changes` en exit 0 sur les 20 fichiers `.cs` du diff |
| `reviewer` | `accept` — 0 FAIL, conformité au plan vérifiée champ par champ |
| `test-engineer` | `accept` — **1529 tests verts**, matrice intégralement couverte |

Build à **0 warning** (`TreatWarningsAsErrors` est actif globalement).

Tests ajoutés : `Migration16Tests` (colonne et défaut), aller-retour repository protégeant la liste de colonnes en dur, 11 cas sur le comparateur dont la comparaison de `Groups` par valeur sur instances distinctes, 4 combinaisons sur la policy, repli conservateur et court-circuit `forceUpdate` sur le service.

## Reste à charge

Un smoke test WinUI manuel : `PlaylistViewModel` exige `NavigationService` et `ResourceLoader`, non instanciables en test. À vérifier à la main — la bascule survit au redémarrage, et la lecture d'une smart playlist option active régénère bien avant de jouer.

Closes #359
