### PR TITLE
refactor(playlist): align manual shuffle with artist-balanced randomizer

### DIFF
--- a/src/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
+++ b/src/Presentation/ViewModels/Playlist/PlaylistViewModel.cs
@@ -318,7 +318,8 @@ public partial class PlaylistViewModel : ObservableObject
         if (Tracks.Count == 0)
             return;
 
-        Tracks.Shuffle();
+        List<TrackViewModel> reordered = PlaylistShuffleReorderer.Reorder(Tracks.ToList(), track => track.Track);
+        Tracks.InitWithAddRange(reordered);
     }
 
     [RelayCommand]

--- a/src/Presentation/ViewModels/Playlist/Services/PlaylistShuffleReorderer.cs
+++ b/src/Presentation/ViewModels/Playlist/Services/PlaylistShuffleReorderer.cs
@@ -1,0 +1,58 @@
+using Rok.Application.Dto;
+using Rok.Application.Randomizer;
+
+namespace Rok.ViewModels.Playlist.Services;
+
+/// <summary>
+/// Reorders a playlist with the artist-balanced randomizer while keeping the current head track in place.
+/// Generic over the item type so it can be unit-tested against <see cref="TrackDto"/> directly, without
+/// constructing view models.
+/// </summary>
+public static class PlaylistShuffleReorderer
+{
+    /// <summary>
+    /// Produces a new list holding the same items, reordered by
+    /// <see cref="TracksRandomizer.ArtistBalancedTrackRandomize"/>. The first item is preserved; the rest are
+    /// shuffled with artist balancing.
+    /// </summary>
+    /// <typeparam name="T">The item type (e.g. a view model wrapping a <see cref="TrackDto"/>).</typeparam>
+    /// <param name="items">The items to reorder.</param>
+    /// <param name="dtoSelector">Projects an item onto its underlying <see cref="TrackDto"/>.</param>
+    /// <param name="random">Optional random source; defaults to <see cref="Random.Shared"/>.</param>
+    /// <returns>A new list with the same items in the reordered sequence.</returns>
+    public static List<T> Reorder<T>(IReadOnlyList<T> items, Func<T, TrackDto> dtoSelector, Random? random = null)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentNullException.ThrowIfNull(dtoSelector);
+
+        if (items.Count <= 1)
+            return items.ToList();
+
+        Dictionary<long, Queue<T>> itemsById = new();
+
+        foreach (T item in items)
+        {
+            long id = dtoSelector(item).Id;
+
+            if (!itemsById.TryGetValue(id, out Queue<T>? queue))
+            {
+                queue = new Queue<T>();
+                itemsById[id] = queue;
+            }
+
+            queue.Enqueue(item);
+        }
+
+        List<TrackDto> order = items.Select(dtoSelector).ToList();
+        TracksRandomizer.ArtistBalancedTrackRandomize(order, shuffleStartIndex: -1, random);
+
+        List<T> reordered = new(order.Count);
+
+        foreach (TrackDto dto in order)
+        {
+            reordered.Add(itemsById[dto.Id].Dequeue());
+        }
+
+        return reordered;
+    }
+}

--- a/tests/UnitTests/Rok.PresentationTests/ViewModels/Playlist/Services/PlaylistShuffleReordererTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/ViewModels/Playlist/Services/PlaylistShuffleReordererTests.cs
@@ -1,0 +1,113 @@
+using Rok.Application.Dto;
+using Rok.ViewModels.Playlist.Services;
+
+namespace Rok.PresentationTests.ViewModels.Playlist.Services;
+
+public class PlaylistShuffleReordererTests
+{
+    private static TrackDto Track(long id, string artist) =>
+        new() { Id = id, ArtistName = artist, Title = $"Track {id}" };
+
+    [Fact(DisplayName = "Reorder preserves the item count and the exact multiset of track ids")]
+    public void Reorder_ShouldPreserveMultiset()
+    {
+        // Arrange
+        List<TrackDto> items =
+        [
+            Track(1, "A"), Track(2, "B"), Track(3, "A"), Track(4, "C"), Track(5, "B"),
+        ];
+
+        // Act
+        List<TrackDto> result = PlaylistShuffleReorderer.Reorder(items, dto => dto, new Random(1));
+
+        // Assert
+        Assert.Equal(items.Count, result.Count);
+        Assert.Equal(items.Select(t => t.Id).OrderBy(id => id), result.Select(t => t.Id).OrderBy(id => id));
+    }
+
+    [Fact(DisplayName = "Reorder keeps the head track in place")]
+    public void Reorder_ShouldKeepHeadTrack()
+    {
+        // Arrange
+        List<TrackDto> items =
+        [
+            Track(1, "A"), Track(2, "B"), Track(3, "C"), Track(4, "A"), Track(5, "B"), Track(6, "C"),
+        ];
+
+        // Act
+        List<TrackDto> result = PlaylistShuffleReorderer.Reorder(items, dto => dto, new Random(1));
+
+        // Assert
+        Assert.Equal(items[0].Id, result[0].Id);
+    }
+
+    [Fact(DisplayName = "Reorder keeps both tracks when two share the same id")]
+    public void Reorder_ShouldPreserveDuplicateIds()
+    {
+        // Arrange
+        List<TrackDto> items =
+        [
+            Track(1, "A"), Track(7, "B"), Track(7, "C"), Track(4, "A"),
+        ];
+
+        // Act
+        List<TrackDto> result = PlaylistShuffleReorderer.Reorder(items, dto => dto, new Random(1));
+
+        // Assert
+        Assert.Equal(4, result.Count);
+        Assert.Equal(2, result.Count(t => t.Id == 7));
+    }
+
+    [Fact(DisplayName = "Reorder returns the single item unchanged for a one-element list")]
+    public void Reorder_ShouldReturnSingleItemUnchanged()
+    {
+        // Arrange
+        List<TrackDto> items = [Track(1, "A")];
+
+        // Act
+        List<TrackDto> result = PlaylistShuffleReorderer.Reorder(items, dto => dto);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+    }
+
+    [Fact(DisplayName = "Reorder returns an empty list for an empty input without throwing")]
+    public void Reorder_ShouldReturnEmptyForEmptyInput()
+    {
+        // Arrange
+        List<TrackDto> items = [];
+
+        // Act
+        List<TrackDto> result = PlaylistShuffleReorderer.Reorder(items, dto => dto);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact(DisplayName = "Reorder eventually reorders the tail while keeping the head fixed")]
+    public void Reorder_ShouldVaryTailOrderWhileKeepingHead()
+    {
+        // Arrange
+        List<TrackDto> items =
+        [
+            Track(1, "A"), Track(2, "B"), Track(3, "C"), Track(4, "A"),
+            Track(5, "B"), Track(6, "C"), Track(7, "A"), Track(8, "B"),
+        ];
+        List<long> originalTail = items.Skip(1).Select(t => t.Id).ToList();
+
+        // Act
+        bool tailReordered = false;
+
+        for (int attempt = 0; attempt < 50 && !tailReordered; attempt++)
+        {
+            List<TrackDto> result = PlaylistShuffleReorderer.Reorder(items, dto => dto);
+
+            Assert.Equal(items[0].Id, result[0].Id);
+            tailReordered = !result.Skip(1).Select(t => t.Id).SequenceEqual(originalTail);
+        }
+
+        // Assert
+        Assert.True(tailReordered, "Expected the tail to be reordered in at least one run.");
+    }
+}


### PR DESCRIPTION
## Objectif

Faire pointer le bouton **ShufflePlaylist** manuel de la page playlist sur le random « artist-balanced » existant, au lieu du mélange uniforme (Fisher-Yates). Expérience d'écoute homogène avec l'option « Lecture random » par playlist (suite de #355).

## Approche

- Nouveau helper pur générique `PlaylistShuffleReorderer.Reorder<T>(items, dtoSelector, random?)` (`src/Presentation/ViewModels/Playlist/Services/`) : appelle `TracksRandomizer.ArtistBalancedTrackRandomize(order, shuffleStartIndex: -1)` — **conserve le titre de tête**, rebrasse le reste avec balance artiste — puis remap DTO→item par file par Id (`Dictionary<long, Queue<T>>`), robuste aux Id dupliqués. La généricité permet de tester avec `T = TrackDto` sans construire de `TrackViewModel`.
- `PlaylistViewModel.ShufflePlaylist()` : `Tracks.Shuffle()` remplacé par `Reorder(...)` + `Tracks.InitWithAddRange(reordered)`. Nom de commande et binding XAML inchangés.

## Décisions

- **Titre de tête conservé** (`shuffleStartIndex: -1`), choix distinct de « Lecture random » qui tire aussi un premier titre au hasard.
- **Réordonnancement visuel non persisté** (parité avec le comportement actuel, aucun Save*).
- `ListExtensions.Shuffle` **conservé** (encore utilisé par `BackdropPicture` et `ListeningDataLoader`).

## Tests

- 6 nouveaux tests `PlaylistShuffleReordererTests` : multiensemble/Count préservés, tête inchangée, Id dupliqués préservés, no-op 1 élément / liste vide, rebrassage effectif de la queue (statistique, 50 essais, non-flaky).
- Suite `Rok.PresentationTests` verte : 363/363. Propriété artist-balance déjà couverte par `TracksRandomizerTests` (couche Application), pas de doublon.

## Gates legion

`architect` accept · `lint` accept · `reviewer` accept_with_opportunity · `test-engineer` accept. Build sans warning (TreatWarningsAsErrors).

Reste en opportunité (non bloquant) : simplifications cosmétiques mineures relevées par la revue (Reset superflu sur playlist à 1 titre, using redondant).

Closes #356
