### PR TITLE
feat(web-api): serve now-playing album cover and artist image

### DIFF
--- a/src/Presentation/DependencyInjection.cs
+++ b/src/Presentation/DependencyInjection.cs
@@ -65,6 +65,11 @@ public static class DependencyInjection
         services.AddSingleton<IPlayerCommandService, PlayerCommandService>();
         services.AddSingleton<IPlayerCommandHandler, PlayerCommandHandler>();
         services.AddSingleton<IWebApiRouteHandler, ListenPlaylistRouteHandler>();
+        services.AddSingleton<IWebApiRouteHandler, ListenAlbumRouteHandler>();
+        services.AddSingleton<IWebApiRouteHandler, ListenArtistRouteHandler>();
+        services.AddSingleton<IWebApiRouteHandler, ListenGenreRouteHandler>();
+        services.AddSingleton<IWebApiRouteHandler, CurrentAlbumCoverRouteHandler>();
+        services.AddSingleton<IWebApiRouteHandler, CurrentArtistImageRouteHandler>();
 
         services.AddSingleton<TagsProvider>();
 

--- a/src/Presentation/Pages/OptionsPage.xaml
+++ b/src/Presentation/Pages/OptionsPage.xaml
@@ -179,6 +179,34 @@
                                             <Button Grid.Column="3" Tag="/current" Click="TestEndpoint_Click" Content="▶ Test" FontSize="11" Padding="8,3" HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         </Grid>
 
+                                        <!-- /api/current/album-cover -->
+                                        <Grid Margin="0,4">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="56" />
+                                                <ColumnDefinition Width="210" />
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="120" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Text="GET" FontFamily="Consolas" FontSize="12" FontWeight="SemiBold" Foreground="{ThemeResource AccentFillColorDefaultBrush}" VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="1" Text="/current/album-cover" FontFamily="Consolas" FontSize="12" VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="2" x:Uid="ApiEndpointAlbumCoverDesc" Text="Returns the album cover image of the current track" FontSize="12" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                            <Button Grid.Column="3" Tag="/current/album-cover" Click="TestEndpoint_Click" Content="▶ Test" FontSize="11" Padding="8,3" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Grid>
+
+                                        <!-- /api/current/artist-image -->
+                                        <Grid Margin="0,4">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="56" />
+                                                <ColumnDefinition Width="210" />
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="120" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Text="GET" FontFamily="Consolas" FontSize="12" FontWeight="SemiBold" Foreground="{ThemeResource AccentFillColorDefaultBrush}" VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="1" Text="/current/artist-image" FontFamily="Consolas" FontSize="12" VerticalAlignment="Center" />
+                                            <TextBlock Grid.Column="2" x:Uid="ApiEndpointArtistImageDesc" Text="Returns the artist image of the current track" FontSize="12" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                            <Button Grid.Column="3" Tag="/current/artist-image" Click="TestEndpoint_Click" Content="▶ Test" FontSize="11" Padding="8,3" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Grid>
+
                                         <!-- /api/queue -->
                                         <Grid Margin="0,4">
                                             <Grid.ColumnDefinitions>

--- a/src/Presentation/Services/PlayerCommand/Api/CurrentAlbumCoverRouteHandler.cs
+++ b/src/Presentation/Services/PlayerCommand/Api/CurrentAlbumCoverRouteHandler.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using Rok.Application.Interfaces.Pictures;
+using Rok.Application.Player;
+
+namespace Rok.Services.PlayerCommand.Api;
+
+/// <summary>
+/// Serves the raw album cover bytes of the track currently playing at <c>GET /current/album-cover</c>.
+/// Returns 404 when nothing is playing (including radio) or when no cover file exists on disk.
+/// </summary>
+public sealed class CurrentAlbumCoverRouteHandler(
+    IPlayerService playerService,
+    IAlbumPicture albumPicture,
+    IFileSystem fileSystem,
+    Action<Action> dispatch,
+    ILogger<CurrentAlbumCoverRouteHandler> logger) : IWebApiRouteHandler
+{
+    private const string Route = "/current/album-cover";
+
+    public bool CanHandle(string method, string path) =>
+        method == "GET" && path == Route;
+
+    public async Task<WebApiResult> HandleAsync(string path)
+    {
+        TrackDto? track = await ReadCurrentTrackAsync();
+
+        if (track is null || string.IsNullOrEmpty(track.MusicFile))
+            return WebApiResult.NotFound();
+
+        string? albumDirectory = Path.GetDirectoryName(track.MusicFile);
+
+        if (string.IsNullOrEmpty(albumDirectory) || !albumPicture.PictureFileExists(albumDirectory))
+            return WebApiResult.NotFound();
+
+        string pictureFile = albumPicture.GetPictureFile(albumDirectory);
+
+        try
+        {
+            byte[] bytes = await fileSystem.ReadAllBytesAsync(pictureFile);
+            return WebApiResult.Binary(bytes, ImageContentType.FromPath(pictureFile));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to read album cover {File}", pictureFile);
+            return WebApiResult.NotFound();
+        }
+    }
+
+    private Task<TrackDto?> ReadCurrentTrackAsync()
+    {
+        TaskCompletionSource<TrackDto?> tcs = new();
+
+        dispatch(() =>
+        {
+            try
+            {
+                tcs.SetResult(playerService.CurrentTrack);
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+
+        return tcs.Task;
+    }
+}

--- a/src/Presentation/Services/PlayerCommand/Api/CurrentArtistImageRouteHandler.cs
+++ b/src/Presentation/Services/PlayerCommand/Api/CurrentArtistImageRouteHandler.cs
@@ -1,0 +1,64 @@
+using Rok.Application.Interfaces.Pictures;
+using Rok.Application.Player;
+
+namespace Rok.Services.PlayerCommand.Api;
+
+/// <summary>
+/// Serves the raw artist image bytes of the track currently playing at <c>GET /current/artist-image</c>.
+/// Returns 404 when nothing is playing (including radio) or when no artist image exists on disk.
+/// </summary>
+public sealed class CurrentArtistImageRouteHandler(
+    IPlayerService playerService,
+    IArtistPicture artistPicture,
+    IFileSystem fileSystem,
+    Action<Action> dispatch,
+    ILogger<CurrentArtistImageRouteHandler> logger) : IWebApiRouteHandler
+{
+    private const string Route = "/current/artist-image";
+
+    public bool CanHandle(string method, string path) =>
+        method == "GET" && path == Route;
+
+    public async Task<WebApiResult> HandleAsync(string path)
+    {
+        TrackDto? track = await ReadCurrentTrackAsync();
+
+        if (track is null || string.IsNullOrEmpty(track.ArtistName))
+            return WebApiResult.NotFound();
+
+        if (!artistPicture.PictureFileExists(track.ArtistName))
+            return WebApiResult.NotFound();
+
+        string pictureFile = artistPicture.GetPictureFile(track.ArtistName);
+
+        try
+        {
+            byte[] bytes = await fileSystem.ReadAllBytesAsync(pictureFile);
+            return WebApiResult.Binary(bytes, ImageContentType.FromPath(pictureFile));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to read artist image {File}", pictureFile);
+            return WebApiResult.NotFound();
+        }
+    }
+
+    private Task<TrackDto?> ReadCurrentTrackAsync()
+    {
+        TaskCompletionSource<TrackDto?> tcs = new();
+
+        dispatch(() =>
+        {
+            try
+            {
+                tcs.SetResult(playerService.CurrentTrack);
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+
+        return tcs.Task;
+    }
+}

--- a/src/Presentation/Services/PlayerCommand/Api/ImageContentType.cs
+++ b/src/Presentation/Services/PlayerCommand/Api/ImageContentType.cs
@@ -1,0 +1,27 @@
+using System.IO;
+
+namespace Rok.Services.PlayerCommand.Api;
+
+/// <summary>
+/// Maps an image file path to its HTTP <c>Content-Type</c> based on the file extension.
+/// </summary>
+public static class ImageContentType
+{
+    /// <summary>
+    /// Returns the MIME content type for the given image file path, or <c>application/octet-stream</c>
+    /// when the extension is not a recognized image format.
+    /// </summary>
+    /// <param name="path">The image file path whose extension determines the content type.</param>
+    public static string FromPath(string path)
+    {
+        string extension = Path.GetExtension(path).ToLowerInvariant();
+
+        return extension switch
+        {
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".png" => "image/png",
+            ".webp" => "image/webp",
+            _ => "application/octet-stream"
+        };
+    }
+}

--- a/src/Presentation/Services/PlayerCommand/Api/PlayerWebApiService.cs
+++ b/src/Presentation/Services/PlayerCommand/Api/PlayerWebApiService.cs
@@ -143,14 +143,24 @@ public sealed partial class PlayerWebApiService(
 
             WebApiResult result = await ResolveAsync(method, path);
 
-            response.ContentType = "application/json";
             response.StatusCode = result.StatusCode;
 
-            if (!string.IsNullOrEmpty(result.Body))
+            if (result.BinaryBody is { } binaryBody)
             {
-                byte[] buffer = Encoding.UTF8.GetBytes(result.Body);
-                response.ContentLength64 = buffer.Length;
-                await response.OutputStream.WriteAsync(buffer);
+                response.ContentType = result.ContentType ?? "application/octet-stream";
+                response.ContentLength64 = binaryBody.Length;
+                await response.OutputStream.WriteAsync(binaryBody);
+            }
+            else
+            {
+                response.ContentType = "application/json";
+
+                if (!string.IsNullOrEmpty(result.Body))
+                {
+                    byte[] buffer = Encoding.UTF8.GetBytes(result.Body);
+                    response.ContentLength64 = buffer.Length;
+                    await response.OutputStream.WriteAsync(buffer);
+                }
             }
         }
         catch (Exception ex)

--- a/src/Presentation/Services/PlayerCommand/Api/WebApiResult.cs
+++ b/src/Presentation/Services/PlayerCommand/Api/WebApiResult.cs
@@ -1,7 +1,17 @@
-﻿namespace Rok.Services.PlayerCommand.Api;
+namespace Rok.Services.PlayerCommand.Api;
 
 public readonly record struct WebApiResult(int StatusCode, string Body)
 {
+    /// <summary>
+    /// Raw binary payload to write to the response, or <c>null</c> for a text/JSON response.
+    /// </summary>
+    public byte[]? BinaryBody { get; init; }
+
+    /// <summary>
+    /// The <c>Content-Type</c> to send with a binary payload; ignored for text/JSON responses.
+    /// </summary>
+    public string? ContentType { get; init; }
+
     public static WebApiResult Ok(string body = "") => new(200, body);
 
     public static WebApiResult NotFound() => new(404, string.Empty);
@@ -9,4 +19,12 @@ public readonly record struct WebApiResult(int StatusCode, string Body)
     public static WebApiResult NotFound(string body) => new(404, body);
 
     public static WebApiResult BadRequest() => new(400, string.Empty);
+
+    /// <summary>
+    /// Creates a 200 response carrying raw bytes with the given content type (e.g. an image).
+    /// </summary>
+    /// <param name="content">The raw bytes to write to the response body.</param>
+    /// <param name="contentType">The MIME content type to advertise (e.g. <c>image/jpeg</c>).</param>
+    public static WebApiResult Binary(byte[] content, string contentType) =>
+        new(200, string.Empty) { BinaryBody = content, ContentType = contentType };
 }

--- a/src/Presentation/Strings/en-US/Resources.resw
+++ b/src/Presentation/Strings/en-US/Resources.resw
@@ -1327,6 +1327,12 @@
   <data name="ApiEndpointCurrentDesc.Text" xml:space="preserve">
     <value>Returns information about the current track (title, artist, album, duration)</value>
   </data>
+  <data name="ApiEndpointAlbumCoverDesc.Text" xml:space="preserve">
+    <value>Returns the album cover image of the current track</value>
+  </data>
+  <data name="ApiEndpointArtistImageDesc.Text" xml:space="preserve">
+    <value>Returns the artist image of the current track</value>
+  </data>
   <data name="ApiEndpointQueueDesc.Text" xml:space="preserve">
     <value>Returns the current playback queue</value>
   </data>

--- a/src/Presentation/Strings/es-ES/Resources.resw
+++ b/src/Presentation/Strings/es-ES/Resources.resw
@@ -1210,6 +1210,12 @@
   <data name="ApiEndpointCurrentDesc.Text" xml:space="preserve">
     <value>Devuelve información sobre la pista actual (título, artista, álbum, duración)</value>
   </data>
+  <data name="ApiEndpointAlbumCoverDesc.Text" xml:space="preserve">
+    <value>Devuelve la carátula del álbum de la pista actual</value>
+  </data>
+  <data name="ApiEndpointArtistImageDesc.Text" xml:space="preserve">
+    <value>Devuelve la imagen del artista de la pista actual</value>
+  </data>
   <data name="ApiEndpointQueueDesc.Text" xml:space="preserve">
     <value>Devuelve la cola de reproducción actual</value>
   </data>

--- a/src/Presentation/Strings/fr-FR/Resources.resw
+++ b/src/Presentation/Strings/fr-FR/Resources.resw
@@ -1326,6 +1326,12 @@
   <data name="ApiEndpointCurrentDesc.Text" xml:space="preserve">
     <value>Renvoie les informations relatives au morceau en cours (titre, artiste, album, durée)</value>
   </data>
+  <data name="ApiEndpointAlbumCoverDesc.Text" xml:space="preserve">
+    <value>Renvoie la pochette de l'album du morceau en cours</value>
+  </data>
+  <data name="ApiEndpointArtistImageDesc.Text" xml:space="preserve">
+    <value>Renvoie l'image de l'artiste du morceau en cours</value>
+  </data>
   <data name="ApiEndpointQueueDesc.Text" xml:space="preserve">
     <value>Renvoie la file d'attente de lecture actuelle</value>
   </data>

--- a/src/Presentation/Strings/uk-UA/Resources.resw
+++ b/src/Presentation/Strings/uk-UA/Resources.resw
@@ -1268,6 +1268,12 @@
   <data name="ApiEndpointCurrentDesc.Text" xml:space="preserve">
     <value>Повертає інформацію про поточну композицію (назву, виконавця, альбом, тривалість)</value>
   </data>
+  <data name="ApiEndpointAlbumCoverDesc.Text" xml:space="preserve">
+    <value>Повертає обкладинку альбому поточної композиції</value>
+  </data>
+  <data name="ApiEndpointArtistImageDesc.Text" xml:space="preserve">
+    <value>Повертає зображення виконавця поточної композиції</value>
+  </data>
   <data name="ApiEndpointQueueDesc.Text" xml:space="preserve">
     <value>Повертає поточну чергу відтворення</value>
   </data>

--- a/tests/UnitTests/Rok.PresentationTests/Services/PlayerCommand/Api/CurrentAlbumCoverRouteHandlerTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/Services/PlayerCommand/Api/CurrentAlbumCoverRouteHandlerTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Rok.Application.Dto;
+using Rok.Application.Interfaces;
+using Rok.Application.Interfaces.Pictures;
+using Rok.Application.Player;
+using Rok.Services.PlayerCommand.Api;
+
+namespace Rok.PresentationTests.Services.PlayerCommand.Api;
+
+public class CurrentAlbumCoverRouteHandlerTests
+{
+    private readonly Mock<IPlayerService> _playerService = new();
+    private readonly Mock<IAlbumPicture> _albumPicture = new();
+    private readonly Mock<IFileSystem> _fileSystem = new();
+
+    private CurrentAlbumCoverRouteHandler BuildHandler() =>
+        new(_playerService.Object, _albumPicture.Object, _fileSystem.Object, action => action(),
+            NullLogger<CurrentAlbumCoverRouteHandler>.Instance);
+
+    private static TrackDto TrackWithFile(string musicFile) =>
+        new() { Id = 1, MusicFile = musicFile, ArtistName = "Artist", AlbumName = "Album" };
+
+    [Theory(DisplayName = "CanHandle should accept only GET on the album cover route")]
+    [InlineData("GET", "/current/album-cover", true)]
+    [InlineData("POST", "/current/album-cover", false)]
+    [InlineData("GET", "/current/artist-image", false)]
+    [InlineData("GET", "/current", false)]
+    public void CanHandle_ShouldAcceptOnlyMatchingMethodAndRoute(string method, string path, bool expected)
+    {
+        // Arrange
+        CurrentAlbumCoverRouteHandler sut = BuildHandler();
+
+        // Act
+        bool result = sut.CanHandle(method, path);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact(DisplayName = "HandleAsync should return NotFound when nothing is playing")]
+    public async Task HandleAsync_ShouldReturnNotFound_WhenNoTrack()
+    {
+        // Arrange
+        _playerService.Setup(p => p.CurrentTrack).Returns((TrackDto?)null);
+        CurrentAlbumCoverRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/album-cover");
+
+        // Assert
+        Assert.Equal(404, result.StatusCode);
+        _fileSystem.Verify(f => f.ReadAllBytesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "HandleAsync should return NotFound when the current track has no music file")]
+    public async Task HandleAsync_ShouldReturnNotFound_WhenMusicFileEmpty()
+    {
+        // Arrange
+        _playerService.Setup(p => p.CurrentTrack).Returns(TrackWithFile(string.Empty));
+        CurrentAlbumCoverRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/album-cover");
+
+        // Assert
+        Assert.Equal(404, result.StatusCode);
+    }
+
+    [Fact(DisplayName = "HandleAsync should return NotFound when no cover file exists")]
+    public async Task HandleAsync_ShouldReturnNotFound_WhenCoverMissing()
+    {
+        // Arrange
+        _playerService.Setup(p => p.CurrentTrack).Returns(TrackWithFile(@"C:\Music\Album\track.mp3"));
+        _albumPicture.Setup(a => a.PictureFileExists(It.IsAny<string>())).Returns(false);
+        CurrentAlbumCoverRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/album-cover");
+
+        // Assert
+        Assert.Equal(404, result.StatusCode);
+        _fileSystem.Verify(f => f.ReadAllBytesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "HandleAsync should return the cover bytes when a local track has a cover")]
+    public async Task HandleAsync_ShouldReturnBytes_WhenCoverExists()
+    {
+        // Arrange
+        byte[] bytes = [1, 2, 3, 4];
+        _playerService.Setup(p => p.CurrentTrack).Returns(TrackWithFile(@"C:\Music\Album\track.mp3"));
+        _albumPicture.Setup(a => a.PictureFileExists(@"C:\Music\Album")).Returns(true);
+        _albumPicture.Setup(a => a.GetPictureFile(@"C:\Music\Album")).Returns(@"C:\Music\Album\cover.png");
+        _fileSystem.Setup(f => f.ReadAllBytesAsync(@"C:\Music\Album\cover.png", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(bytes);
+        CurrentAlbumCoverRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/album-cover");
+
+        // Assert
+        Assert.Equal(200, result.StatusCode);
+        Assert.Equal(bytes, result.BinaryBody);
+        Assert.Equal("image/png", result.ContentType);
+    }
+
+    [Theory(DisplayName = "HandleAsync should derive the content type from the cover extension")]
+    [InlineData("cover.jpg", "image/jpeg")]
+    [InlineData("cover.png", "image/png")]
+    [InlineData("cover.webp", "image/webp")]
+    public async Task HandleAsync_ShouldDeriveContentType(string coverFile, string expectedContentType)
+    {
+        // Arrange
+        string coverPath = @"C:\Music\Album\" + coverFile;
+        _playerService.Setup(p => p.CurrentTrack).Returns(TrackWithFile(@"C:\Music\Album\track.mp3"));
+        _albumPicture.Setup(a => a.PictureFileExists(It.IsAny<string>())).Returns(true);
+        _albumPicture.Setup(a => a.GetPictureFile(It.IsAny<string>())).Returns(coverPath);
+        _fileSystem.Setup(f => f.ReadAllBytesAsync(coverPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([9]);
+        CurrentAlbumCoverRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/album-cover");
+
+        // Assert
+        Assert.Equal(200, result.StatusCode);
+        Assert.Equal(expectedContentType, result.ContentType);
+    }
+}

--- a/tests/UnitTests/Rok.PresentationTests/Services/PlayerCommand/Api/CurrentArtistImageRouteHandlerTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/Services/PlayerCommand/Api/CurrentArtistImageRouteHandlerTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Rok.Application.Dto;
+using Rok.Application.Interfaces;
+using Rok.Application.Interfaces.Pictures;
+using Rok.Application.Player;
+using Rok.Services.PlayerCommand.Api;
+
+namespace Rok.PresentationTests.Services.PlayerCommand.Api;
+
+public class CurrentArtistImageRouteHandlerTests
+{
+    private readonly Mock<IPlayerService> _playerService = new();
+    private readonly Mock<IArtistPicture> _artistPicture = new();
+    private readonly Mock<IFileSystem> _fileSystem = new();
+
+    private CurrentArtistImageRouteHandler BuildHandler() =>
+        new(_playerService.Object, _artistPicture.Object, _fileSystem.Object, action => action(),
+            NullLogger<CurrentArtistImageRouteHandler>.Instance);
+
+    private static TrackDto TrackWithArtist(string artistName) =>
+        new() { Id = 1, ArtistName = artistName, MusicFile = @"C:\Music\Album\track.mp3" };
+
+    [Theory(DisplayName = "CanHandle should accept only GET on the artist image route")]
+    [InlineData("GET", "/current/artist-image", true)]
+    [InlineData("POST", "/current/artist-image", false)]
+    [InlineData("GET", "/current/album-cover", false)]
+    [InlineData("GET", "/current", false)]
+    public void CanHandle_ShouldAcceptOnlyMatchingMethodAndRoute(string method, string path, bool expected)
+    {
+        // Arrange
+        CurrentArtistImageRouteHandler sut = BuildHandler();
+
+        // Act
+        bool result = sut.CanHandle(method, path);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact(DisplayName = "HandleAsync should return NotFound when nothing is playing")]
+    public async Task HandleAsync_ShouldReturnNotFound_WhenNoTrack()
+    {
+        // Arrange
+        _playerService.Setup(p => p.CurrentTrack).Returns((TrackDto?)null);
+        CurrentArtistImageRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/artist-image");
+
+        // Assert
+        Assert.Equal(404, result.StatusCode);
+        _fileSystem.Verify(f => f.ReadAllBytesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "HandleAsync should return NotFound when the current track has no artist name")]
+    public async Task HandleAsync_ShouldReturnNotFound_WhenArtistEmpty()
+    {
+        // Arrange
+        _playerService.Setup(p => p.CurrentTrack).Returns(TrackWithArtist(string.Empty));
+        CurrentArtistImageRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/artist-image");
+
+        // Assert
+        Assert.Equal(404, result.StatusCode);
+    }
+
+    [Fact(DisplayName = "HandleAsync should return NotFound when no artist image exists")]
+    public async Task HandleAsync_ShouldReturnNotFound_WhenImageMissing()
+    {
+        // Arrange
+        _playerService.Setup(p => p.CurrentTrack).Returns(TrackWithArtist("Madonna"));
+        _artistPicture.Setup(a => a.PictureFileExists("Madonna")).Returns(false);
+        CurrentArtistImageRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/artist-image");
+
+        // Assert
+        Assert.Equal(404, result.StatusCode);
+        _fileSystem.Verify(f => f.ReadAllBytesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "HandleAsync should return the artist image bytes when it exists in cache")]
+    public async Task HandleAsync_ShouldReturnBytes_WhenImageExists()
+    {
+        // Arrange
+        byte[] bytes = [5, 6, 7];
+        _playerService.Setup(p => p.CurrentTrack).Returns(TrackWithArtist("Madonna"));
+        _artistPicture.Setup(a => a.PictureFileExists("Madonna")).Returns(true);
+        _artistPicture.Setup(a => a.GetPictureFile("Madonna")).Returns(@"C:\Cache\@Artists\madonna\artist.jpg");
+        _fileSystem.Setup(f => f.ReadAllBytesAsync(@"C:\Cache\@Artists\madonna\artist.jpg", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(bytes);
+        CurrentArtistImageRouteHandler sut = BuildHandler();
+
+        // Act
+        WebApiResult result = await sut.HandleAsync("/current/artist-image");
+
+        // Assert
+        Assert.Equal(200, result.StatusCode);
+        Assert.Equal(bytes, result.BinaryBody);
+        Assert.Equal("image/jpeg", result.ContentType);
+    }
+}

--- a/tests/UnitTests/Rok.PresentationTests/Services/PlayerCommand/Api/ImageContentTypeTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/Services/PlayerCommand/Api/ImageContentTypeTests.cs
@@ -1,0 +1,23 @@
+using Rok.Services.PlayerCommand.Api;
+
+namespace Rok.PresentationTests.Services.PlayerCommand.Api;
+
+public class ImageContentTypeTests
+{
+    [Theory(DisplayName = "FromPath should map known image extensions and fall back for the rest")]
+    [InlineData(@"C:\a\cover.jpg", "image/jpeg")]
+    [InlineData(@"C:\a\cover.jpeg", "image/jpeg")]
+    [InlineData(@"C:\a\cover.png", "image/png")]
+    [InlineData(@"C:\a\cover.webp", "image/webp")]
+    [InlineData(@"C:\a\COVER.JPG", "image/jpeg")]
+    [InlineData(@"C:\a\cover.gif", "application/octet-stream")]
+    [InlineData(@"C:\a\cover", "application/octet-stream")]
+    public void FromPath_ShouldMapExtension(string path, string expected)
+    {
+        // Act
+        string result = ImageContentType.FromPath(path);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+}

--- a/tests/UnitTests/Rok.PresentationTests/Services/PlayerCommand/Api/WebApiResultTests.cs
+++ b/tests/UnitTests/Rok.PresentationTests/Services/PlayerCommand/Api/WebApiResultTests.cs
@@ -58,4 +58,29 @@ public class WebApiResultTests
         Assert.Equal(400, result.StatusCode);
         Assert.Equal("", result.Body);
     }
+
+    [Fact(DisplayName = "Binary should produce a 200 result carrying the bytes and content type")]
+    public void Binary_ShouldCarryBytesAndContentType()
+    {
+        // Arrange
+        byte[] bytes = [1, 2, 3];
+
+        // Act
+        WebApiResult result = WebApiResult.Binary(bytes, "image/png");
+
+        // Assert
+        Assert.Equal(200, result.StatusCode);
+        Assert.Equal(bytes, result.BinaryBody);
+        Assert.Equal("image/png", result.ContentType);
+        Assert.Equal("", result.Body);
+    }
+
+    [Fact(DisplayName = "JSON factories should leave the binary payload null")]
+    public void JsonFactories_ShouldLeaveBinaryBodyNull()
+    {
+        // Assert
+        Assert.Null(WebApiResult.Ok("x").BinaryBody);
+        Assert.Null(WebApiResult.NotFound().BinaryBody);
+        Assert.Null(WebApiResult.BadRequest().BinaryBody);
+    }
 }


### PR DESCRIPTION
## Objectif

Exposer deux endpoints GET sur la Web API locale (`PlayerWebApiService`, `HttpListener` loopback) qui renvoient les octets bruts de la pochette d'album et de l'image d'artiste du titre **en cours d'écoute**, pour qu'un consommateur externe (overlay, widget, Stream Deck, navigateur) affiche l'artwork « now playing ».

## Approche

- **Pipeline binaire additif.** `WebApiResult` gagne deux propriétés `init` (`BinaryBody`, `ContentType`) et une fabrique `Binary(...)` ; la forme positionnelle et les fabriques JSON restent identiques. `HandleRequestAsync` branche sur `BinaryBody` : écrit les octets + le content-type, sinon le chemin JSON existant **recopié à l'identique** (zéro régression).
- **2 handlers dédiés** `IWebApiRouteHandler` : `CurrentAlbumCoverRouteHandler` (`GET /current/album-cover`) et `CurrentArtistImageRouteHandler` (`GET /current/artist-image`). Lecture de `CurrentTrack` sur le thread UI, résolution via `IAlbumPicture`/`IArtistPicture`, octets via `IFileSystem`. `Content-Type` déduit de l'extension (`ImageContentType.FromPath`).
- **404** si rien en lecture (radio incluse, `CurrentTrack == null`), `MusicFile`/`ArtistName` vide, ou image absente.

## Correctifs & décisions

- **Fix bug DI** : `ListenAlbumRouteHandler`, `ListenArtistRouteHandler`, `ListenGenreRouteHandler` existaient et étaient testés mais **n'étaient pas enregistrés** dans `DependencyInjection.cs` → 404 en prod. Désormais injectés (avec les 2 nouveaux handlers artwork).
- **OptionsPage** : 2 boutons « ▶ Test », descriptions localisées (`x:Uid`) dans les 4 locales (en-US, fr-FR, es-ES, uk-UA).

## Sécurité

Endpoints **sans paramètre** : le chemin fichier dérive uniquement de `CurrentTrack` (BDD interne) et des dossiers résolus depuis `CachePath`. Aucune entrée utilisateur n'atteint le système de fichiers → **pas de path-traversal**. Exceptions → 404/500 opaques. Écoute loopback inchangée. Aucun package ajouté.

## Tests

- 22 nouveaux tests API : `Binary` porte octets+content-type / fabriques JSON laissent `BinaryBody` null ; `ImageContentType` (jpg/jpeg/png/webp/casse/inconnu) ; les 2 handlers (CanHandle, 200 avec octets + content-type par extension, tous les 404, `ReadAllBytesAsync` non appelé sur 404) ; les 4 ListenX désormais couverts et injectés.
- Suite `Rok.PresentationTests` verte : 391/391. Build sans warning (TreatWarningsAsErrors).

## Gates legion

`architect` accept_with_opportunity · `lint` accept · `reviewer` accept_with_opportunity · `test-engineer` accept_with_opportunity · `security` accept.

Opportunités non bloquantes : duplication de `ReadCurrentTrackAsync` entre les 2 handlers ; cas « lecture de fichier échouée → 404 » couvert par le code (try/catch) mais pas par un test unitaire.

À vérifier en smoke (hors tests unitaires) : round-trip HTTP réel (image rendue par le navigateur) et endpoints `/listen/*` ne renvoyant plus 404.

Closes #357
